### PR TITLE
Standardize Line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,27 @@
-#
-# https://help.github.com/articles/dealing-with-line-endings/
-#
-# These are explicitly windows files and should use crlf
-*.bat           text eol=crlf
+* text=auto
+* text eol=lf
 
+# Windows forced line-endings
+/.idea/* text eol=crlf
+*.bat    text eol=crlf
+*.ps1    text eol=crlf
+
+# Gradle wrapper
+*.jar binary
+
+# Images
+*.webp binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.swp binary
+*.pdf binary


### PR DESCRIPTION
Standardize line endings
Fixes the issue where if you clone on windows you cannot use the getAndroid.sh in WSL.
Let git know what files are binary, so that git doesnt try to update the line endings for them