### PR TITLE
Create getAndroid.ps1

### DIFF
--- a/AndroidCompat/getAndroid.ps1
+++ b/AndroidCompat/getAndroid.ps1
@@ -1,0 +1,90 @@
+if ($(Split-Path -Path (Get-Location) -Leaf) -eq "AndroidCompat" ) {
+    Set-Location ..
+}
+
+Write-Output "Getting required Android.jar..."
+Remove-Item -Recurse -Force "tmp" | Out-Null
+New-Item -ItemType Directory -Force -Path "tmp" | Out-Null
+
+$androidEncoded = (Invoke-WebRequest -Uri "https://android.googlesource.com/platform/prebuilts/sdk/+/3b8a524d25fa6c3d795afb1eece3f24870c60988/27/public/android.jar?format=TEXT").content
+
+$android_jar = (Get-Location).Path + "\tmp\android.jar"
+
+[IO.File]::WriteAllBytes($android_jar, [Convert]::FromBase64String($androidEncoded))
+
+# We need to remove any stub classes that we might use
+Write-Output "Patching JAR..."
+
+function Remove-Files-Zip($zipfile, $path)
+{
+    [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression') | Out-Null
+
+    $stream = New-Object IO.FileStream($zipfile, [IO.FileMode]::Open)
+    $mode   = [IO.Compression.ZipArchiveMode]::Update
+    $zip    = New-Object IO.Compression.ZipArchive($stream, $mode)
+
+    ($zip.Entries | Where-Object { $_.FullName -like $path }) | ForEach-Object { Write-Output "Deleting: $($_.FullName)"; $_.Delete() }
+
+    $zip.Dispose()
+    $stream.Close()
+    $stream.Dispose()
+}
+
+Write-Output "Removing org.json..."
+Remove-Files-Zip $android_jar 'org/json/*'
+
+Write-Output "Removing org.apache..."
+Remove-Files-Zip $android_jar 'org/apache/*'
+
+Write-Output "Removing org.w3c..."
+Remove-Files-Zip $android_jar 'org/w3c/*'
+
+Write-Output "Removing org.xml..."
+Remove-Files-Zip $android_jar 'org/xml/*'
+
+Write-Output "Removing org.xmlpull..."
+Remove-Files-Zip $android_jar 'org/xmlpull/*'
+
+Write-Output "Removing junit..."
+Remove-Files-Zip $android_jar 'junit/*'
+
+Write-Output "Removing javax..."
+Remove-Files-Zip $android_jar 'javax/*'
+
+Write-Output "Removing java..."
+Remove-Files-Zip $android_jar 'java/*'
+
+Write-Output "Removing overriden classes..."
+Remove-Files-Zip $android_jar 'android/app/Application.class'
+Remove-Files-Zip $android_jar 'android/app/Service.class'
+Remove-Files-Zip $android_jar 'android/net/Uri.class'
+Remove-Files-Zip $android_jar 'android/net/Uri$Builder.class'
+Remove-Files-Zip $android_jar 'android/os/Environment.class'
+Remove-Files-Zip $android_jar 'android/text/format/Formatter.class'
+Remove-Files-Zip $android_jar 'android/text/Html.class'
+
+function Dedupe($path)
+{
+    Push-Location $path
+    $classes = Get-ChildItem . *.* -Recurse | Where-Object { !$_.PSIsContainer }
+    $classes | ForEach-Object {
+        "Processing class: $($_.FullName)"
+        Remove-Files-Zip $android_jar "$($_.Name).class" | Out-Null
+        Remove-Files-Zip $android_jar "$($_.Name)$*.class" | Out-Null
+        Remove-Files-Zip $android_jar "$($_.Name)Kt.class" | Out-Null
+        Remove-Files-Zip $android_jar "$($_.Name)Kt$*.class" | Out-Null
+    }
+    Pop-Location
+}
+
+Dedupe "AndroidCompat/src/main/java"
+Dedupe "server/src/main/java"
+Dedupe "server/src/main/kotlin"
+
+Write-Output "Copying Android.jar to library folder..."
+Move-Item -Force $android_jar "AndroidCompat/lib/android.jar"
+
+Write-Output "Cleaning up..."
+Remove-Item -Recurse -Force "tmp"
+
+Write-Output "Done!"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This project has two components:
 #### Manual download
 Download [android.jar](https://raw.githubusercontent.com/Suwayomi/Tachidesk/android-jar/android.jar) and put it under `AndroidCompat/lib`.
 #### Automated download(needs `bash`, `curl`, `base64`, `zip` to work)
-Run `AndroidCompat/getAndroid.sh` from project's root directory to download and rebuild the jar file from Google's repository.
+Run `AndroidCompat/getAndroid.sh`(MacOS/Linux) or `AndroidCompat/getAndroid.ps1`(Windows) from project's root directory to download and rebuild the jar file from Google's repository.
 ### Prerequisite: Software dependencies
 You need this software packages installed in order to build this project:
 - Java Development Kit and Java Runtime Environment version 8 or newer(both Oracle JDK and OpenJDK works)


### PR DESCRIPTION
Create a version of getAndroid.sh to run in pure Windows workflows, this is planned to tie into the build process of TachideskJUI. It is noticeably slower than getAndroid.sh, which is why I still did the other PR.