### PR TITLE
Fix white screen if the manga doesn't have genre.

### DIFF
--- a/webUI/react/src/components/MangaDetails.tsx
+++ b/webUI/react/src/components/MangaDetails.tsx
@@ -135,6 +135,9 @@ export default function MangaDetails(props: IProps) {
     const { setAction } = useContext(NavbarContext);
 
     const { manga } = props;
+    if (manga.genre == null) {
+        manga.genre = '';
+    }
     const [inLibrary, setInLibrary] = useState<string>(
         manga.inLibrary ? 'In Library' : 'Add To Library',
     );


### PR DESCRIPTION
The genre is display correctly if manga has a genre :
![Screenshot 2021-04-10 at 19-41-03 Tachidesk](https://user-images.githubusercontent.com/24809312/114279411-db1cb280-9a34-11eb-80be-e6d9a9795e22.png)
And he doesn't displays anything if he doesn't have one :
![image](https://user-images.githubusercontent.com/24809312/114279441-fe476200-9a34-11eb-971b-00fc8435fb10.png)
