### PR TITLE
Remove IE Requirement in ps1 script

### DIFF
--- a/AndroidCompat/getAndroid.ps1
+++ b/AndroidCompat/getAndroid.ps1
@@ -15,7 +15,7 @@ Write-Output "Getting required Android.jar..."
 Remove-Item -Recurse -Force "tmp" -ErrorAction SilentlyContinue | Out-Null
 New-Item -ItemType Directory -Force -Path "tmp" | Out-Null
 
-$androidEncoded = (Invoke-WebRequest -Uri "https://android.googlesource.com/platform/prebuilts/sdk/+/3b8a524d25fa6c3d795afb1eece3f24870c60988/27/public/android.jar?format=TEXT").content
+$androidEncoded = (Invoke-WebRequest -Uri "https://android.googlesource.com/platform/prebuilts/sdk/+/3b8a524d25fa6c3d795afb1eece3f24870c60988/27/public/android.jar?format=TEXT" -UseBasicParsing).content
 
 $android_jar = (Get-Location).Path + "\tmp\android.jar"
 


### PR DESCRIPTION
If Invoke-WebRequest doesn't have the -UseBasicParsing tag it will use IE which not everyone has installed anymore on Windows 10. This PR allows anyone to use the script in essence.