### PR TITLE
Stop Javalin properly on shutdown

### DIFF
--- a/server/src/main/kotlin/ir/armor/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/ir/armor/tachidesk/server/JavalinSetup.kt
@@ -44,6 +44,7 @@ import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.concurrent.CompletableFuture
+import kotlin.concurrent.thread
 
 /*
  * Copyright (C) Contributors to the Suwayomi project
@@ -75,6 +76,13 @@ object JavalinSetup {
             }
             config.enableCorsForAllOrigins()
         }.start(serverConfig.ip, serverConfig.port)
+
+        Runtime.getRuntime().addShutdownHook(
+            thread(start = false) {
+                app.stop()
+            }
+        )
+
         if (hasWebUiBundled && serverConfig.initialOpenInBrowserEnabled) {
             openInBrowser()
         }


### PR DESCRIPTION
Add a shutdown hook to the JVM that calls the Javalin stop function when the JVM closes, allowing for a graceful shutdown