### PR TITLE
Improve continuous horizontal reader

### DIFF
--- a/webUI/react/src/components/manga/reader/Page.tsx
+++ b/webUI/react/src/components/manga/reader/Page.tsx
@@ -17,7 +17,8 @@ function imageStyle(settings: IReaderSettings): CSSProperties {
     || settings.readerType === 'ContinuesHorizontalRTL') {
         return {
             display: 'block',
-            marginBottom: 0,
+            marginLeft: '7px',
+            marginRight: '7px',
             width: 'auto',
             minHeight: '99vh',
             height: 'auto',

--- a/webUI/react/src/components/manga/reader/Page.tsx
+++ b/webUI/react/src/components/manga/reader/Page.tsx
@@ -23,6 +23,7 @@ function imageStyle(settings: IReaderSettings): CSSProperties {
             height: 'auto',
             maxHeight: '99vh',
             objectFit: 'contain',
+            pointerEvents: 'none',
         };
     }
 
@@ -79,14 +80,8 @@ const Page = React.forwardRef((props: IProps, ref: any) => {
     const handleHorizontalScroll = () => {
         if (imgRef.current) {
             const rect = imgRef.current.getBoundingClientRect();
-            if (settings.readerType === 'ContinuesHorizontalLTR') {
-                if (rect.left <= window.innerWidth / 2 && rect.right > window.innerWidth / 2) {
-                    setCurPage(index);
-                }
-            } else if (settings.readerType === 'ContinuesHorizontalRTL') {
-                if (rect.right <= window.innerWidth / 2 && rect.left > window.innerWidth / 2) {
-                    setCurPage(index);
-                }
+            if (rect.left <= window.innerWidth / 2 && rect.right > window.innerWidth / 2) {
+                setCurPage(index);
             }
         }
     };

--- a/webUI/react/src/components/manga/reader/Page.tsx
+++ b/webUI/react/src/components/manga/reader/Page.tsx
@@ -82,11 +82,11 @@ const Page = React.forwardRef((props: IProps, ref: any) => {
         if (imgRef.current) {
             const rect = imgRef.current.getBoundingClientRect();
             if (settings.readerType === 'ContinuesHorizontalLTR') {
-                if (rect.left <= 0 && rect.left + rect.width > 0) {
+                if (rect.left <= window.innerWidth / 2 && rect.right > window.innerWidth / 2) {
                     setCurPage(index);
                 }
             } else {
-                if (rect.right - window.innerWidth <= 0 && rect.left - window.innerWidth > 0) {
+                if (rect.right <= window.innerWidth / 2 && rect.left > window.innerWidth / 2) {
                     setCurPage(index);
                 }
             }

--- a/webUI/react/src/components/manga/reader/Page.tsx
+++ b/webUI/react/src/components/manga/reader/Page.tsx
@@ -5,8 +5,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* eslint-disable no-lonely-if */
-
 import { makeStyles } from '@material-ui/core/styles';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import React, { useEffect, useRef } from 'react';
@@ -85,7 +83,7 @@ const Page = React.forwardRef((props: IProps, ref: any) => {
                 if (rect.left <= window.innerWidth / 2 && rect.right > window.innerWidth / 2) {
                     setCurPage(index);
                 }
-            } else {
+            } else if (settings.readerType === 'ContinuesHorizontalRTL') {
                 if (rect.right <= window.innerWidth / 2 && rect.left > window.innerWidth / 2) {
                     setCurPage(index);
                 }

--- a/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
+++ b/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
@@ -51,11 +51,27 @@ export default function HorizontalPager(props: IReaderProps) {
         }
     }
 
-    function clickControl(e:MouseEvent) {
-        if (e.clientX > window.innerWidth / 2) {
+    function goLeft() {
+        if (settings.readerType === 'ContinuesHorizontalLTR') {
+            prevPage();
+        } else {
+            nextPage();
+        }
+    }
+
+    function goRight() {
+        if (settings.readerType === 'ContinuesHorizontalLTR') {
             nextPage();
         } else {
             prevPage();
+        }
+    }
+
+    function clickControl(e:MouseEvent) {
+        if (e.clientX > window.innerWidth / 2) {
+            goRight();
+        } else {
+            goLeft();
         }
     }
 

--- a/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
+++ b/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
@@ -5,8 +5,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* eslint-disable no-lonely-if */
-
 import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect, useRef } from 'react';
 import Page from '../Page';
@@ -80,7 +78,7 @@ export default function HorizontalPager(props: IReaderProps) {
             if (window.scrollX + window.innerWidth >= document.body.scrollWidth) {
                 nextChapter();
             }
-        } else {
+        } else if (settings.readerType === 'ContinuesHorizontalRTL') {
             if (window.scrollX <= window.innerWidth) {
                 nextChapter();
             }

--- a/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
+++ b/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
@@ -60,7 +60,6 @@ export default function HorizontalPager(props: IReaderProps) {
     }
 
     const handleLoadNextonEnding = () => {
-        console.log(window.scrollX + window.innerWidth, document.body.scrollWidth);
         if (settings.readerType === 'ContinuesHorizontalLTR') {
             if (window.scrollX + window.innerWidth >= document.body.scrollWidth) {
                 nextChapter();

--- a/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
+++ b/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
@@ -18,6 +18,7 @@ const useStyles = (settings: IReaderSettings) => makeStyles({
         width: 'auto',
         height: 'auto',
         overflowX: 'visible',
+        userSelect: 'none',
     },
 });
 
@@ -65,10 +66,25 @@ export default function HorizontalPager(props: IReaderProps) {
         }
     }
 
+    const mouseXPos = useRef<number>(0);
+
+    function dragScreen(e: MouseEvent) {
+        window.scrollBy(mouseXPos.current - e.pageX, 0);
+    }
+
+    function dragControl(e:MouseEvent) {
+        mouseXPos.current = e.pageX;
+        selfRef.current?.addEventListener('mousemove', dragScreen);
+    }
+
+    function removeDragControl() {
+        selfRef.current?.removeEventListener('mousemove', dragScreen);
+    }
+
     function clickControl(e:MouseEvent) {
-        if (e.clientX > window.innerWidth / 2) {
+        if (e.clientX >= window.innerWidth * 0.85) {
             goRight();
-        } else {
+        } else if (e.clientX <= window.innerWidth * 0.15) {
             goLeft();
         }
     }
@@ -90,14 +106,24 @@ export default function HorizontalPager(props: IReaderProps) {
     }, [settings.readerType]);
 
     useEffect(() => {
+        selfRef.current?.addEventListener('mousedown', dragControl);
+        selfRef.current?.addEventListener('mouseup', removeDragControl);
+
+        return () => {
+            selfRef.current?.removeEventListener('mousedown', dragControl);
+            selfRef.current?.removeEventListener('mouseup', removeDragControl);
+        };
+    }, [selfRef]);
+
+    useEffect(() => {
         if (settings.loadNextonEnding) {
             document.addEventListener('scroll', handleLoadNextonEnding);
         }
-        selfRef.current?.addEventListener('click', clickControl);
+        selfRef.current?.addEventListener('mousedown', clickControl);
 
         return () => {
             document.removeEventListener('scroll', handleLoadNextonEnding);
-            selfRef.current?.removeEventListener('click', clickControl);
+            selfRef.current?.removeEventListener('mousedown', clickControl);
         };
     }, [selfRef, curPage]);
 

--- a/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
+++ b/webUI/react/src/components/manga/reader/pager/HorizontalPager.tsx
@@ -6,34 +6,37 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { makeStyles } from '@material-ui/core/styles';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Page from '../Page';
 
-const useStyles = makeStyles({
+const useStyles = (settings: IReaderSettings) => makeStyles({
     reader: {
         display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'center',
+        flexDirection: (settings.readerType === 'ContinuesHorizontalLTR') ? 'row' : 'row-reverse',
+        justifyContent: (settings.readerType === 'ContinuesHorizontalLTR') ? 'flex-start' : 'flex-end',
         margin: '0 auto',
-        width: '100%',
-        height: '100vh',
-        overflowX: 'scroll',
+        width: 'auto',
+        height: 'auto',
+        overflowX: 'visible',
     },
 });
 
-interface IProps {
-    pages: Array<IReaderPage>
-    setCurPage: React.Dispatch<React.SetStateAction<number>>
-    settings: IReaderSettings
-}
+export default function HorizontalPager(props: IReaderProps) {
+    const {
+        pages, curPage, settings, setCurPage,
+    } = props;
 
-export default function HorizontalPager(props: IProps) {
-    const { pages, settings, setCurPage } = props;
+    const classes = useStyles(settings)();
 
-    const classes = useStyles();
+    const selfRef = useRef<HTMLDivElement>(null);
+    const pagesRef = useRef<HTMLDivElement[]>([]);
+
+    useEffect(() => {
+        pagesRef.current[curPage]?.scrollIntoView({ inline: 'center' });
+    }, [settings.readerType]);
 
     return (
-        <div className={classes.reader}>
+        <div ref={selfRef} className={classes.reader}>
             {
                 pages.map((page) => (
                     <Page
@@ -43,6 +46,7 @@ export default function HorizontalPager(props: IProps) {
                         onImageLoad={() => {}}
                         setCurPage={setCurPage}
                         settings={settings}
+                        ref={(e:HTMLDivElement) => { pagesRef.current[page.index] = e; }}
                     />
                 ))
             }

--- a/webUI/react/src/components/navbar/ReaderNavBar.tsx
+++ b/webUI/react/src/components/navbar/ReaderNavBar.tsx
@@ -313,8 +313,12 @@ export default function ReaderNavBar(props: IProps) {
                                         Continues Vertical
 
                                     </MenuItem>
-                                    <MenuItem value="ContinuesHorizontal">
-                                        Horizontal(WIP)
+                                    <MenuItem value="ContinuesHorizontalLTR">
+                                        Horizontal (LTR)
+
+                                    </MenuItem>
+                                    <MenuItem value="ContinuesHorizontalRTL">
+                                        Horizontal (RTL)
 
                                     </MenuItem>
                                 </Select>

--- a/webUI/react/src/screens/manga/Reader.tsx
+++ b/webUI/react/src/screens/manga/Reader.tsx
@@ -46,7 +46,8 @@ const getReaderComponent = (readerType: ReaderType) => {
         case 'DoubleLTR':
             return DoublePagedPager;
             break;
-        case 'ContinuesHorizontal':
+        case 'ContinuesHorizontalLTR':
+        case 'ContinuesHorizontalRTL':
             return HorizontalPager;
         default:
             return VerticalPager;

--- a/webUI/react/src/typings.d.ts
+++ b/webUI/react/src/typings.d.ts
@@ -117,7 +117,8 @@ type ReaderType =
 'DoubleVertical' |
 'DoubleRTL' |
 'DoubleLTR' |
-'ContinuesHorizontal';
+'ContinuesHorizontalLTR'|
+'ContinuesHorizontalRTL';
 
 interface IReaderSettings{
     staticNav: boolean


### PR DESCRIPTION
## Description
Added click events to navigate pages and also fix an issue with displaying pages in continuous horizontal viewing mode.

## Changes
- Replaced ReaderType `ContinuesHorizontal` with `ContinuesHorizontalLTR` and `ContinuesHorizontalRTL`.
- Changed some CSS properties in `HorizontalPager.tsx` to display images properly.
- Added click events to navigate pages in `HorizontalPager.tsx`
- Added ability to click to drag in `HorizontalPager.tsx`
- Added horizontal scrolling event to update curPage in `Page.tsx`.