### PR TITLE
Override getDefaultValueType with values based on the preference

### DIFF
--- a/AndroidCompat/src/main/java/androidx/preference/EditTextPreference.java
+++ b/AndroidCompat/src/main/java/androidx/preference/EditTextPreference.java
@@ -44,4 +44,9 @@ public class EditTextPreference extends DialogPreference {
     public interface OnBindEditTextListener {
         void onBindEditText(@NonNull EditText editText);
     }
+
+    @Override
+    public String getDefaultValueType() {
+        return "String";
+    }
 }

--- a/AndroidCompat/src/main/java/androidx/preference/ListPreference.java
+++ b/AndroidCompat/src/main/java/androidx/preference/ListPreference.java
@@ -42,4 +42,9 @@ public class ListPreference extends Preference {
     public String getValue() { throw new RuntimeException("Stub!"); }
 
     public void setValue(String value) { throw new RuntimeException("Stub!"); }
+
+    @Override
+    public String getDefaultValueType() {
+        return "String";
+    }
 }

--- a/AndroidCompat/src/main/java/androidx/preference/MultiSelectListPreference.java
+++ b/AndroidCompat/src/main/java/androidx/preference/MultiSelectListPreference.java
@@ -29,4 +29,9 @@ public class MultiSelectListPreference extends DialogPreference {
     public Set<String> getValues() { throw new RuntimeException("Stub!"); }
 
     public int findIndexOfValue(String value) { throw new RuntimeException("Stub!"); }
+
+    @Override
+    public String getDefaultValueType() {
+        return "Set";
+    }
 }

--- a/AndroidCompat/src/main/java/androidx/preference/SwitchPreferenceCompat.java
+++ b/AndroidCompat/src/main/java/androidx/preference/SwitchPreferenceCompat.java
@@ -9,7 +9,7 @@ package androidx.preference;
 
 import android.content.Context;
 
-public class SwitchPreferenceCompat extends Preference {
+public class SwitchPreferenceCompat extends TwoStatePreference {
     // reference: https://android.googlesource.com/platform/frameworks/support/+/996971f962fcd554339a7cb2859cef9ca89dbcb7/preference/preference/src/main/java/androidx/preference/CheckBoxPreference.java
 
     public SwitchPreferenceCompat(Context context) {

--- a/AndroidCompat/src/main/java/androidx/preference/TwoStatePreference.java
+++ b/AndroidCompat/src/main/java/androidx/preference/TwoStatePreference.java
@@ -29,4 +29,8 @@ public class TwoStatePreference extends Preference {
 
     public void setDisableDependentsState(boolean disableDependentsState) { throw new RuntimeException("Stub!"); }
 
+    @Override
+    public String getDefaultValueType() {
+        return "Boolean";
+    }
 }


### PR DESCRIPTION
Fixes NullPointerException errors

Also make SwitchPreferenceCompat inherit TwoStatePreference