### PR TITLE
Update Android Jar to Android API 30

### DIFF
--- a/AndroidCompat/getAndroid.ps1
+++ b/AndroidCompat/getAndroid.ps1
@@ -15,7 +15,7 @@ Write-Output "Getting required Android.jar..."
 Remove-Item -Recurse -Force "tmp" -ErrorAction SilentlyContinue | Out-Null
 New-Item -ItemType Directory -Force -Path "tmp" | Out-Null
 
-$androidEncoded = (Invoke-WebRequest -Uri "https://android.googlesource.com/platform/prebuilts/sdk/+/3b8a524d25fa6c3d795afb1eece3f24870c60988/27/public/android.jar?format=TEXT" -UseBasicParsing).content
+$androidEncoded = (Invoke-WebRequest -Uri "https://android.googlesource.com/platform/prebuilts/sdk/+/6cd31be5e4e25901aadf838120d71a79b46d9add/30/public/android.jar?format=TEXT" -UseBasicParsing).content
 
 $android_jar = (Get-Location).Path + "\tmp\android.jar"
 

--- a/AndroidCompat/getAndroid.sh
+++ b/AndroidCompat/getAndroid.sh
@@ -30,7 +30,7 @@ rm -rf "tmp"
 mkdir -p "tmp"
 pushd "tmp"
 
-curl "https://android.googlesource.com/platform/prebuilts/sdk/+/3b8a524d25fa6c3d795afb1eece3f24870c60988/27/public/android.jar?format=TEXT" | base64 --decode > android.jar
+curl "https://android.googlesource.com/platform/prebuilts/sdk/+/6cd31be5e4e25901aadf838120d71a79b46d9add/30/public/android.jar?format=TEXT" | base64 --decode > android.jar
 
 # We need to remove any stub classes that we have implementations for
 echo "Patching JAR..."


### PR DESCRIPTION
This updates the Android Library that AndroidCompat uses to Android API 30, which includes a bunch of fixes and improvements.