### PR TITLE
Change type of Manga.genre to a List<String>

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/anime/model/table/AnimeTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/anime/model/table/AnimeTable.kt
@@ -11,8 +11,8 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ResultRow
 import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
-import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
+import suwayomi.tachidesk.manga.model.dataclass.toGenreList
 import suwayomi.tachidesk.manga.model.table.MangaStatus.Companion
 
 object AnimeTable : IntIdTable() {
@@ -49,7 +49,7 @@ fun AnimeTable.toDataClass(mangaEntry: ResultRow) =
         mangaEntry[artist],
         mangaEntry[author],
         mangaEntry[description],
-        mangaEntry[genre]?.split(",")?.trimAll().orEmpty(),
+        mangaEntry[genre].toGenreList(),
         Companion.valueOf(mangaEntry[status]).name,
         mangaEntry[inLibrary]
     )

--- a/server/src/main/kotlin/suwayomi/tachidesk/anime/model/table/AnimeTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/anime/model/table/AnimeTable.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.animesource.model.SAnime
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ResultRow
 import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
+import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 import suwayomi.tachidesk.manga.model.table.MangaStatus.Companion
 
@@ -48,7 +49,7 @@ fun AnimeTable.toDataClass(mangaEntry: ResultRow) =
         mangaEntry[artist],
         mangaEntry[author],
         mangaEntry[description],
-        mangaEntry[genre],
+        mangaEntry[genre]?.split(",")?.trimAll().orEmpty(),
         Companion.valueOf(mangaEntry[status]).name,
         mangaEntry[inLibrary]
     )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -21,6 +21,7 @@ import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
 import suwayomi.tachidesk.manga.impl.Source.getSource
 import suwayomi.tachidesk.manga.impl.util.GetHttpSource.getHttpSource
 import suwayomi.tachidesk.manga.impl.util.lang.awaitSingle
+import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.impl.util.network.await
 import suwayomi.tachidesk.manga.impl.util.storage.CachedImageResponse.clearCachedImage
 import suwayomi.tachidesk.manga.impl.util.storage.CachedImageResponse.getCachedImageResponse
@@ -56,7 +57,7 @@ object Manga {
                 mangaEntry[MangaTable.artist],
                 mangaEntry[MangaTable.author],
                 mangaEntry[MangaTable.description],
-                mangaEntry[MangaTable.genre],
+                mangaEntry[MangaTable.genre]?.split(",")?.trimAll().orEmpty(),
                 MangaStatus.valueOf(mangaEntry[MangaTable.status]).name,
                 mangaEntry[MangaTable.inLibrary],
                 getSource(mangaEntry[MangaTable.sourceReference]),
@@ -106,7 +107,7 @@ object Manga {
                 fetchedManga.artist,
                 fetchedManga.author,
                 fetchedManga.description,
-                fetchedManga.genre,
+                fetchedManga.genre?.split(",")?.trimAll().orEmpty(),
                 MangaStatus.valueOf(fetchedManga.status).name,
                 mangaEntry[MangaTable.inLibrary],
                 getSource(mangaEntry[MangaTable.sourceReference]),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -21,11 +21,11 @@ import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
 import suwayomi.tachidesk.manga.impl.Source.getSource
 import suwayomi.tachidesk.manga.impl.util.GetHttpSource.getHttpSource
 import suwayomi.tachidesk.manga.impl.util.lang.awaitSingle
-import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.impl.util.network.await
 import suwayomi.tachidesk.manga.impl.util.storage.CachedImageResponse.clearCachedImage
 import suwayomi.tachidesk.manga.impl.util.storage.CachedImageResponse.getCachedImageResponse
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
+import suwayomi.tachidesk.manga.model.dataclass.toGenreList
 import suwayomi.tachidesk.manga.model.table.MangaMetaTable
 import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.manga.model.table.MangaTable
@@ -57,7 +57,7 @@ object Manga {
                 mangaEntry[MangaTable.artist],
                 mangaEntry[MangaTable.author],
                 mangaEntry[MangaTable.description],
-                mangaEntry[MangaTable.genre]?.split(",")?.trimAll().orEmpty(),
+                mangaEntry[MangaTable.genre].toGenreList(),
                 MangaStatus.valueOf(mangaEntry[MangaTable.status]).name,
                 mangaEntry[MangaTable.inLibrary],
                 getSource(mangaEntry[MangaTable.sourceReference]),
@@ -107,7 +107,7 @@ object Manga {
                 fetchedManga.artist,
                 fetchedManga.author,
                 fetchedManga.description,
-                fetchedManga.genre?.split(",")?.trimAll().orEmpty(),
+                fetchedManga.genre.toGenreList(),
                 MangaStatus.valueOf(fetchedManga.status).name,
                 mangaEntry[MangaTable.inLibrary],
                 getSource(mangaEntry[MangaTable.sourceReference]),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
@@ -14,6 +14,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.manga.impl.Manga.getMangaMetaMap
 import suwayomi.tachidesk.manga.impl.util.GetHttpSource.getHttpSource
 import suwayomi.tachidesk.manga.impl.util.lang.awaitSingle
+import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 import suwayomi.tachidesk.manga.model.dataclass.PagedMangaListDataClass
 import suwayomi.tachidesk.manga.model.table.MangaStatus
@@ -72,7 +73,7 @@ object MangaList {
                         manga.artist,
                         manga.author,
                         manga.description,
-                        manga.genre,
+                        manga.genre?.split(",")?.trimAll().orEmpty(),
                         MangaStatus.valueOf(manga.status).name,
                         false, // It's a new manga entry
                         meta = getMangaMetaMap(mangaId),
@@ -94,7 +95,7 @@ object MangaList {
                         mangaEntry[MangaTable.artist],
                         mangaEntry[MangaTable.author],
                         mangaEntry[MangaTable.description],
-                        mangaEntry[MangaTable.genre],
+                        mangaEntry[MangaTable.genre]?.split(",")?.trimAll().orEmpty(),
                         MangaStatus.valueOf(mangaEntry[MangaTable.status]).name,
                         mangaEntry[MangaTable.inLibrary],
                         meta = getMangaMetaMap(mangaId),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
@@ -14,9 +14,9 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.manga.impl.Manga.getMangaMetaMap
 import suwayomi.tachidesk.manga.impl.util.GetHttpSource.getHttpSource
 import suwayomi.tachidesk.manga.impl.util.lang.awaitSingle
-import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 import suwayomi.tachidesk.manga.model.dataclass.PagedMangaListDataClass
+import suwayomi.tachidesk.manga.model.dataclass.toGenreList
 import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.manga.model.table.MangaTable
 
@@ -73,7 +73,7 @@ object MangaList {
                         manga.artist,
                         manga.author,
                         manga.description,
-                        manga.genre?.split(",")?.trimAll().orEmpty(),
+                        manga.genre.toGenreList(),
                         MangaStatus.valueOf(manga.status).name,
                         false, // It's a new manga entry
                         meta = getMangaMetaMap(mangaId),
@@ -95,7 +95,7 @@ object MangaList {
                         mangaEntry[MangaTable.artist],
                         mangaEntry[MangaTable.author],
                         mangaEntry[MangaTable.description],
-                        mangaEntry[MangaTable.genre]?.split(",")?.trimAll().orEmpty(),
+                        mangaEntry[MangaTable.genre].toGenreList(),
                         MangaStatus.valueOf(mangaEntry[MangaTable.status]).name,
                         mangaEntry[MangaTable.inLibrary],
                         meta = getMangaMetaMap(mangaId),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/lang/List.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/lang/List.kt
@@ -1,0 +1,3 @@
+package suwayomi.tachidesk.manga.impl.util.lang
+
+fun List<String>.trimAll() = map { it.trim() }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
@@ -7,6 +7,7 @@ package suwayomi.tachidesk.manga.model.dataclass
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.table.MangaStatus
 
 data class MangaDataClass(
@@ -39,3 +40,5 @@ data class PagedMangaListDataClass(
     val mangaList: List<MangaDataClass>,
     val hasNextPage: Boolean
 )
+
+internal inline fun String?.toGenreList() = this?.split(",")?.trimAll().orEmpty()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
@@ -22,7 +22,7 @@ data class MangaDataClass(
     val artist: String? = null,
     val author: String? = null,
     val description: String? = null,
-    val genre: String? = null,
+    val genre: List<String> = emptyList(),
     val status: String = MangaStatus.UNKNOWN.name,
     val inLibrary: Boolean = false,
     val source: SourceDataClass? = null,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
@@ -12,8 +12,8 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ResultRow
 import suwayomi.tachidesk.manga.impl.Manga.getMangaMetaMap
 import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
-import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
+import suwayomi.tachidesk.manga.model.dataclass.toGenreList
 import suwayomi.tachidesk.manga.model.table.MangaStatus.Companion
 
 object MangaTable : IntIdTable() {
@@ -53,7 +53,7 @@ fun MangaTable.toDataClass(mangaEntry: ResultRow) =
         mangaEntry[artist],
         mangaEntry[author],
         mangaEntry[description],
-        mangaEntry[genre]?.split(",")?.trimAll().orEmpty(),
+        mangaEntry[genre].toGenreList(),
         Companion.valueOf(mangaEntry[status]).name,
         mangaEntry[inLibrary],
         meta = getMangaMetaMap(mangaEntry[id].value),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ResultRow
 import suwayomi.tachidesk.manga.impl.Manga.getMangaMetaMap
 import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
+import suwayomi.tachidesk.manga.impl.util.lang.trimAll
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 import suwayomi.tachidesk.manga.model.table.MangaStatus.Companion
 
@@ -52,7 +53,7 @@ fun MangaTable.toDataClass(mangaEntry: ResultRow) =
         mangaEntry[artist],
         mangaEntry[author],
         mangaEntry[description],
-        mangaEntry[genre],
+        mangaEntry[genre]?.split(",")?.trimAll().orEmpty(),
         Companion.valueOf(mangaEntry[status]).name,
         mangaEntry[inLibrary],
         meta = getMangaMetaMap(mangaEntry[id].value),


### PR DESCRIPTION
Since it makes more sense for it to be a list of genre instead of a comma delimited string in the API I changed it. I did not change the DB since there isn't a better way to store it in a column.
Extensions have the freedom to add a space after a comma so I added a utility function that trims all strings in the list.