### PR TITLE
Remove depreciated arbuilder’s docker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ yay -S tachidesk
 ```
 
 ### Docker
-Check our Offical Docker release [Tachidesk Container](https://github.com/orgs/Suwayomi/packages/container/package/tachidesk) or use [arbuilder's](https://github.com/arbuilder/Tachidesk-docker) tachidesk docker repo for installation. Source code for our container is available at [docker-tachidesk](https://github.com/Suwayomi/docker-tachidesk). By default the server will be running on http://localhost:4567 open this url in your browser.
+Check our Official Docker release [Tachidesk Container](https://github.com/orgs/Suwayomi/packages/container/package/tachidesk) for running Tachidesk Server in a docker container. Source code for our container is available at [docker-tachidesk](https://github.com/Suwayomi/docker-tachidesk). By default the server will be running on http://localhost:4567 open this url in your browser.
 
 Install from the command line:
 ```


### PR DESCRIPTION
Remove depreciated arbuilder’s docker link