### PR TITLE
Thumbnail Caching Header

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -37,6 +37,8 @@ object MangaController {
             future { Manga.getMangaThumbnail(mangaId, useCache) }
                 .thenApply {
                     ctx.header("content-type", it.second)
+                    val httpCacheSeconds = 60 * 60 * 24
+                    ctx.header("cache-control", "max-age=$httpCacheSeconds")
                     it.first
                 }
         )


### PR DESCRIPTION
Added Cache Header to Thumbnail Response for improved library performance
Set it to 24 Hours.
This way the thumbnails aren't loaded each time.