### PR TITLE
OpenApi Documentation

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 
+    // javalin openapi
+    implementation("io.javalin:javalin-openapi:4.1.1")
+
     // Exposed ORM
     val exposedVersion = "0.34.1"
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -54,7 +54,7 @@ object MangaAPI {
 
         path("manga") {
             get("{mangaId}", MangaController::retrieve)
-            get("{mangaId}/thumbnail", documented(MangaController.getThumbnailDocumented, MangaController::thumbnail))
+            get("{mangaId}/thumbnail", MangaController::thumbnail)
 
             get("{mangaId}/category", MangaController::categoryList)
             get("{mangaId}/category/{categoryId}", MangaController::addToCategory)
@@ -113,9 +113,9 @@ object MangaAPI {
         }
 
         path("update") {
-            get("recentChapters/{pageNum}", UpdateController::recentChapters)
+            get("recentChapters/{pageNum}", documented(UpdateController.recentChaptersDocumentation, UpdateController::recentChapters))
             post("fetch", documented(UpdateController.categoryUpdateDocumentation, UpdateController::categoryUpdate))
-            get("summary", UpdateController::updateSummary)
+            get("summary", documented(UpdateController.updateSummaryDocumentation, UpdateController::updateSummary))
             ws("", UpdateController::categoryUpdateWS)
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -13,6 +13,7 @@ import io.javalin.apibuilder.ApiBuilder.patch
 import io.javalin.apibuilder.ApiBuilder.path
 import io.javalin.apibuilder.ApiBuilder.post
 import io.javalin.apibuilder.ApiBuilder.ws
+import io.javalin.plugin.openapi.dsl.documented
 import suwayomi.tachidesk.manga.controller.BackupController
 import suwayomi.tachidesk.manga.controller.CategoryController
 import suwayomi.tachidesk.manga.controller.DownloadController
@@ -53,7 +54,7 @@ object MangaAPI {
 
         path("manga") {
             get("{mangaId}", MangaController::retrieve)
-            get("{mangaId}/thumbnail", MangaController::thumbnail)
+            get("{mangaId}/thumbnail", documented(MangaController.getThumbnailDocumented, MangaController::thumbnail))
 
             get("{mangaId}/category", MangaController::categoryList)
             get("{mangaId}/category/{categoryId}", MangaController::addToCategory)
@@ -113,7 +114,7 @@ object MangaAPI {
 
         path("update") {
             get("recentChapters/{pageNum}", UpdateController::recentChapters)
-            post("fetch", UpdateController::categoryUpdate)
+            post("fetch", documented(UpdateController.categoryUpdateDocumentation, UpdateController::categoryUpdate))
             get("summary", UpdateController::updateSummary)
             ws("", UpdateController::categoryUpdateWS)
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -113,9 +113,9 @@ object MangaAPI {
         }
 
         path("update") {
-            get("recentChapters/{pageNum}", documented(UpdateController.recentChaptersDocumentation, UpdateController::recentChapters))
-            post("fetch", documented(UpdateController.categoryUpdateDocumentation, UpdateController::categoryUpdate))
-            get("summary", documented(UpdateController.updateSummaryDocumentation, UpdateController::updateSummary))
+            get("recentChapters/{pageNum}", UpdateController.recentChapters)
+            post("fetch",  UpdateController.categoryUpdate)
+            get("summary", UpdateController.updateSummary)
             ws("", UpdateController::categoryUpdateWS)
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -8,8 +8,6 @@ package suwayomi.tachidesk.manga.controller
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import io.javalin.http.Context
-import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
-import io.javalin.plugin.openapi.dsl.document
 import suwayomi.tachidesk.manga.impl.CategoryManga
 import suwayomi.tachidesk.manga.impl.Chapter
 import suwayomi.tachidesk.manga.impl.Library
@@ -30,20 +28,6 @@ object MangaController {
         )
     }
 
-    val getThumbnailDocumented: OpenApiDocumentation = document()
-        .operation {
-            it.summary("Get Manga thumbnail")
-            it.description("Get the thumbnail for a manga")
-        }
-        .pathParam<Int>("mangaId") {
-            it.description("The id of the manga")
-        }
-        .queryParam<Boolean>("onlineFetch") {
-            it.description("Whether to fetch the manga from the online source")
-        }
-        .result<ByteArray>("200", "binary image") {
-            it.description("The thumbnail image")
-        }
     /** manga thumbnail */
     fun thumbnail(ctx: Context) {
         val mangaId = ctx.pathParam("mangaId").toInt()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -8,6 +8,8 @@ package suwayomi.tachidesk.manga.controller
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import io.javalin.http.Context
+import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
+import io.javalin.plugin.openapi.dsl.document
 import suwayomi.tachidesk.manga.impl.CategoryManga
 import suwayomi.tachidesk.manga.impl.Chapter
 import suwayomi.tachidesk.manga.impl.Library
@@ -28,6 +30,20 @@ object MangaController {
         )
     }
 
+    val getThumbnailDocumented: OpenApiDocumentation = document()
+        .operation {
+            it.summary("Get Manga thumbnail")
+            it.description("Get the thumbnail for a manga")
+        }
+        .pathParam<Int>("mangaId") {
+            it.description("The id of the manga")
+        }
+        .queryParam<Boolean>("onlineFetch") {
+            it.description("Whether to fetch the manga from the online source")
+        }
+        .result<ByteArray>("200", "binary image") {
+            it.description("The thumbnail image")
+        }
     /** manga thumbnail */
     fun thumbnail(ctx: Context) {
         val mangaId = ctx.pathParam("mangaId").toInt()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/UpdateController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/UpdateController.kt
@@ -2,6 +2,8 @@ package suwayomi.tachidesk.manga.controller
 
 import io.javalin.http.Context
 import io.javalin.http.HttpCode
+import io.javalin.plugin.openapi.dsl.OpenApiDocumentation
+import io.javalin.plugin.openapi.dsl.document
 import io.javalin.websocket.WsConfig
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
@@ -37,6 +39,20 @@ object UpdateController {
         )
     }
 
+    val categoryUpdateDocumentation: OpenApiDocumentation = document()
+        .operation {
+            it.summary("Start fetching all mangas in a category")
+            it.description(
+                """
+                Will start fetching all mangas in a category based on the category id.
+                If the category id is not valid, a Bad Request will be returned.
+                If the category id is null, all categories will be fetched.
+                """.trimIndent()
+            )
+        }
+        .formParam<Int>("category", false)
+        .result<String>("OK", "text/plain")
+        .result<String>("BAD_REQUEST", "text/plain")
     fun categoryUpdate(ctx: Context) {
         val categoryId = ctx.formParam("category")?.toIntOrNull()
         val categoriesForUpdate = ArrayList<CategoryDataClass>()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateStatus.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateStatus.kt
@@ -1,6 +1,10 @@
 package suwayomi.tachidesk.manga.impl.update
 
+import io.javalin.plugin.json.JsonMapper
 import mu.KotlinLogging
+import org.kodein.di.DI
+import org.kodein.di.conf.global
+import org.kodein.di.instance
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 
 var logger = KotlinLogging.logger {}
@@ -26,8 +30,20 @@ class UpdateStatus(
         return "UpdateStatus(statusMap=${statusMap.map { "${it.key} : ${it.value.size}" }.joinToString("; ")}, running=$running)"
     }
 
+    fun getSummary(): UpdateStatusSummary {
+        val summaryMap = mutableMapOf<JobStatus, Int>()
+        statusMap.forEach {
+            summaryMap[it.key] = it.value.size
+        }
+        return UpdateStatusSummary(
+            running,
+            summaryMap
+        )
+    }
+
     // serialize to summary json
     fun getJsonSummary(): String {
-        return """{"statusMap":{${statusMap.map { "\"${it.key}\" : ${it.value.size}" }.joinToString(",")}}, "running":$running}"""
+        val jsonMapper by DI.global.instance<JsonMapper>()
+        return jsonMapper.toJsonString(getSummary())
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateStatusSummary.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateStatusSummary.kt
@@ -1,0 +1,6 @@
+package suwayomi.tachidesk.manga.impl.update
+
+data class UpdateStatusSummary(
+    val running: Boolean,
+    val statusMap: Map<JobStatus, Int>
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -11,6 +11,10 @@ import io.javalin.Javalin
 import io.javalin.apibuilder.ApiBuilder.path
 import io.javalin.core.security.RouteRole
 import io.javalin.http.staticfiles.Location
+import io.javalin.plugin.openapi.OpenApiOptions
+import io.javalin.plugin.openapi.OpenApiPlugin
+import io.javalin.plugin.openapi.ui.SwaggerOptions
+import io.swagger.v3.oas.models.info.Info
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -49,6 +53,7 @@ object JavalinSetup {
             }
 
             config.enableCorsForAllOrigins()
+            config.registerPlugin(OpenApiPlugin(getOpenApiOptions()))
         }.events { event ->
             event.serverStarted {
                 if (serverConfig.initialOpenInBrowserEnabled) {
@@ -100,5 +105,18 @@ object JavalinSetup {
 
     object Auth {
         enum class Role : RouteRole { ANYONE, USER_READ, USER_WRITE }
+    }
+
+    private fun getOpenApiOptions(): OpenApiOptions {
+        val applicationInfo: Info = Info()
+            .version("1.0")
+            .description("Tachidesk Api")
+
+        return OpenApiOptions(applicationInfo)
+            .path("/api/openapi.json")
+            .swagger(
+                SwaggerOptions("/api/swagger-ui")
+                    .title("Tachidesk Swagger Documentation")
+            )
     }
 }


### PR DESCRIPTION
Added https://javalin.io/plugins/openapi to Tachidesk.
There are now two new paths available:
1. /api/openapi.json - OpenApi Document in JSON Representation
2. /api/swagger-ui - Swagger Frontend to view API Documentation and use the API

OpenApi isn't able to document WebSockets as of now.
I fully documented the UpdateController using the dsl API. Which provides flexibility in the placement of the documentation.
