### PR TITLE
Attempt to fix #237

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/BytecodeEditor.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/BytecodeEditor.kt
@@ -18,6 +18,7 @@ import org.objectweb.asm.Opcodes
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import kotlin.streams.asSequence
 
 object BytecodeEditor {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/BytecodeEditor.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/BytecodeEditor.kt
@@ -251,6 +251,11 @@ object BytecodeEditor {
     }
 
     private fun write(pair: Pair<Path, ByteArray>) {
-        Files.write(pair.first, pair.second)
+        Files.write(
+            pair.first,
+            pair.second,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING
+        )
     }
 }


### PR DESCRIPTION
This PR attempts to fix #237 by explicitly setting the standard open options that Files.write is supposed to set by default. I cannot reproduce the issue locally so I cannot test to see if this actually helps.