### PR TITLE
Handlers must return a result

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/UpdateController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/UpdateController.kt
@@ -107,6 +107,7 @@ object UpdateController {
             )
         },
         withResults = {
+            httpCode(HttpCode.OK)
         }
     )
 }


### PR DESCRIPTION
Minor fix for the updates handler, a handler should always document a possible result.