### PR TITLE
Fix sources list of one source throws an exception

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Source.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Source.kt
@@ -24,6 +24,7 @@ import suwayomi.tachidesk.manga.impl.extension.Extension.getExtensionIconUrl
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSource
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.unregisterCatalogueSource
+import suwayomi.tachidesk.manga.impl.util.source.StubSource
 import suwayomi.tachidesk.manga.model.dataclass.SourceDataClass
 import suwayomi.tachidesk.manga.model.table.ExtensionTable
 import suwayomi.tachidesk.manga.model.table.SourceTable
@@ -36,8 +37,9 @@ object Source {
 
     fun getSourceList(): List<SourceDataClass> {
         return transaction {
-            SourceTable.selectAll().map {
+            SourceTable.selectAll().mapNotNull {
                 val catalogueSource = getCatalogueSourceOrStub(it[SourceTable.id].value)
+                if (catalogueSource is StubSource) return@mapNotNull null
                 val sourceExtension = ExtensionTable.select { ExtensionTable.id eq it[SourceTable.extension] }.first()
 
                 SourceDataClass(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/source/GetCatalogueSource.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/source/GetCatalogueSource.kt
@@ -57,7 +57,7 @@ object GetCatalogueSource {
     }
 
     fun getCatalogueSourceOrStub(sourceId: Long): CatalogueSource {
-        return getCatalogueSource(sourceId) ?: StubSource(sourceId)
+        return runCatching { getCatalogueSource(sourceId) }.getOrNull() ?: StubSource(sourceId)
     }
 
     fun registerCatalogueSource(sourcePair: Pair<Long, CatalogueSource>) {


### PR DESCRIPTION
getCatalogueSource can throw exceptions if it fails to load a source, such as if a source jar was deleted when the server was down, or it failed to load the source class because GSON dissapeared with an outdated extension.

This PR fixes that by catching errors and using a StubSource when necessary.