### PR TITLE
[Feature] Ability to change default WebUi in server.conf

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -29,6 +29,7 @@ class ServerConfig(config: Config, moduleName: String = MODULE_NAME) : SystemPro
 
     // webUI
     val webUIEnabled: Boolean by overridableConfig
+    val webUIPath: String? by overridableConfig
     val initialOpenInBrowserEnabled: Boolean by overridableConfig
     val webUIInterface: String by overridableConfig
     val electronPath: String by overridableConfig

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -40,7 +40,20 @@ class ApplicationDirs(
     val thumbnailsRoot = "$dataRoot/thumbnails"
     val mangaDownloadsRoot = "$dataRoot/downloads"
     val localMangaRoot = "$dataRoot/local"
-    val webUIRoot = "$dataRoot/webUI"
+    val webUIRoot: String
+        get() {
+            if (!serverConfig.webUIPath.isNullOrEmpty()) {
+                if (serverConfig.webUIPath!!.isNotBlank()) {
+                    val file = File(serverConfig.webUIPath)
+                    return if (file.isAbsolute) {
+                        serverConfig.webUIPath!!
+                    } else {
+                        "$dataRoot/${serverConfig.webUIPath}"
+                    }
+                }
+            }
+            return "$dataRoot/webUI"
+        }
 }
 
 val serverConfig: ServerConfig by lazy { GlobalConfigManager.module() }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -44,8 +44,8 @@ class ApplicationDirs(
         get() {
             if (!serverConfig.webUIPath.isNullOrEmpty()) {
                 if (serverConfig.webUIPath!!.isNotBlank()) {
-                    val file = File(serverConfig.webUIPath)
-                    return if (file.isAbsolute) {
+                    val path = File(serverConfig.webUIPath)
+                    return if (path.isAbsolute) {
                         serverConfig.webUIPath!!
                     } else {
                         "$dataRoot/${serverConfig.webUIPath}"

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -45,8 +45,8 @@ class ApplicationDirs(
             val path =
                 if (serverConfig.webUIPath.isNullOrEmpty()) "$dataRoot/webUI"
                 else serverConfig.webUIPath!!
-            return if (File(serverConfig.webUIPath).isAbsolute) serverConfig.webUIPath!!
-            else "$dataRoot/${serverConfig.webUIPath}"
+            return if (File(path).isAbsolute) path
+            else "$dataRoot/$path"
         }
 }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -42,17 +42,11 @@ class ApplicationDirs(
     val localMangaRoot = "$dataRoot/local"
     val webUIRoot: String
         get() {
-            if (!serverConfig.webUIPath.isNullOrEmpty()) {
-                if (serverConfig.webUIPath!!.isNotBlank()) {
-                    val path = File(serverConfig.webUIPath)
-                    return if (path.isAbsolute) {
-                        serverConfig.webUIPath!!
-                    } else {
-                        "$dataRoot/${serverConfig.webUIPath}"
-                    }
-                }
-            }
-            return "$dataRoot/webUI"
+            val path =
+                if (serverConfig.webUIPath.isNullOrEmpty()) "$dataRoot/webUI"
+                else serverConfig.webUIPath!!
+            return if (File(serverConfig.webUIPath).isAbsolute) serverConfig.webUIPath!!
+            else "$dataRoot/${serverConfig.webUIPath}"
         }
 }
 

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -9,6 +9,7 @@ server.socksProxyPort = ""
 
 # webUI
 server.webUIEnabled = true
+server.webUIPath = "webUI" # absolute or relative path
 server.initialOpenInBrowserEnabled = true
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -13,6 +13,7 @@ server.systemTrayEnabled = false
 
 # webUI
 server.webUIEnabled = true
+server.webUIPath = "webUI" # absolute or relative path
 server.initialOpenInBrowserEnabled = true
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""


### PR DESCRIPTION
closes #325

- add `server.webUIPath` to `server.conf`
- revert to default webUI if no `server.webUIPath` option is provided.
- revert to default webUI if `server.webUIPath = ""`
- relative and absolute path are both valid values.
