### PR TITLE
[WIP] token auth

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -56,14 +56,16 @@ object JavalinSetup {
             config.enableCorsForAllOrigins()
 
             config.accessManager { handler, ctx, _ ->
-                fun credentialsValid(): Boolean {
+                fun basicAuthCredentialsValid(): Boolean {
                     val (username, password) = ctx.basicAuthCredentials()
                     return username == serverConfig.basicAuthUsername && password == serverConfig.basicAuthPassword
                 }
 
-                if (serverConfig.basicAuthEnabled && !(ctx.basicAuthCredentialsExist() && credentialsValid())) {
-                    ctx.header("WWW-Authenticate", "Basic")
-                    ctx.status(401).json("Unauthorized")
+                if (serverConfig.authType != "none") {
+                    if (serverConfig.authType == "basicAuth" && !(ctx.basicAuthCredentialsExist() && basicAuthCredentialsValid())) {
+                        ctx.header("WWW-Authenticate", "Basic")
+                        ctx.status(401).json("Unauthorized")
+                    }
                 } else {
                     handler.handle(ctx)
                 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -11,6 +11,7 @@ import com.typesafe.config.Config
 import xyz.nulldev.ts.config.GlobalConfigManager
 import xyz.nulldev.ts.config.SystemPropertyOverridableConfigModule
 import xyz.nulldev.ts.config.debugLogsEnabled
+import kotlin.reflect.KProperty
 
 private const val MODULE_NAME = "server"
 class ServerConfig(config: Config, moduleName: String = MODULE_NAME) : SystemPropertyOverridableConfigModule(config, moduleName) {
@@ -34,6 +35,15 @@ class ServerConfig(config: Config, moduleName: String = MODULE_NAME) : SystemPro
     val electronPath: String by overridableConfig
 
     // Authentication
+    val authType: String by object {
+        operator fun <R> getValue(thisRef: R, property: KProperty<*>): String {
+            val propValue: String = overridableConfig.getValue(thisRef, property)
+            if (basicAuthEnabled) {
+                return "basicAuth"
+            }
+            return propValue
+        }
+    }
     val basicAuthEnabled: Boolean by overridableConfig
     val basicAuthUsername: String by overridableConfig
     val basicAuthPassword: String by overridableConfig

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -14,7 +14,8 @@ server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""
 
 # Authentication
-server.basicAuthEnabled = false
+server.authType = "none" # "none" or "basicAuth" or "token"
+server.basicAuthEnabled = false # This is deprecated, use server.authType
 server.basicAuthUsername = ""
 server.basicAuthPassword = ""
 


### PR DESCRIPTION
The implementation is partial, up for grabs if anyone wants to continue.

Goals of the current implementation:
- Only handle single user mode.
- Potentially receive username and password from the config file(not the best idea?)
- have a "acquire (new) token" endpoint
- Check auth header compatible with [the standard HTTP way](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication) sample `Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`
- Steal implementation details from [django rest framework's token auth](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication)