### PR TITLE
Add displayValues json field for select filter

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/Filter.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/Filter.kt
@@ -5,7 +5,9 @@ package eu.kanade.tachiyomi.source.model
 open class Filter<T>(val name: String, var state: T) {
     open class Header(name: String) : Filter<Any>(name, 0)
     open class Separator(name: String = "") : Filter<Any>(name, 0)
-    abstract class Select<V>(name: String, val values: Array<V>, state: Int = 0) : Filter<Int>(name, state)
+    abstract class Select<V>(name: String, val values: Array<V>, state: Int = 0) : Filter<Int>(name, state) {
+        val displayValues get() = values.map { it.toString() }
+    }
     abstract class Text(name: String, state: String = "") : Filter<String>(name, state)
     abstract class CheckBox(name: String, state: Boolean = false) : Filter<Boolean>(name, state)
     abstract class TriState(name: String, state: Int = STATE_IGNORE) : Filter<Int>(name, state) {


### PR DESCRIPTION
Closes https://github.com/Suwayomi/Tachidesk-Server/issues/300

Adds a json-array of strings to the Select filter json so that Select.values doesnt break client filtering, they can use Select.displayValues for the Select filter options. I dont believe that Select.values needs to be exposed anymore, but that would probably be a breaking change.