### PR TITLE
Update gradle action

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.0
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -45,13 +45,9 @@ jobs:
           mkdir -p ~/.gradle
           cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
 
-
       - name: Build Jar
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: master
-          wrapper-directory: master
           arguments: :server:shadowJar --stacktrace
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
+

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -46,16 +46,12 @@ jobs:
           cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Build Jar
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         env:
           ProductBuildType: "Preview"
         with:
           build-root-directory: master
-          wrapper-directory: master
           arguments: :server:shadowJar --stacktrace
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
 
       - name: Upload Jar
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,16 +47,12 @@ jobs:
             ~/.gradle/gradle.properties
 
       - name: Build and copy webUI, Build Jar
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         env:
           ProductBuildType: "Stable"
         with:
           build-root-directory: master
-          wrapper-directory: master
           arguments: :server:downloadWebUI :server:shadowJar --stacktrace
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
 
       - name: Upload Jar
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://github.com/eskatos/gradle-command-action
redirects to 
https://github.com/gradle/gradle-build-action
It has better performance and removes deprecated warnings

Test run: https://github.com/mahor1221/Tachidesk-Server/actions/runs/2598294031