### PR TITLE
Add libc++-dev to fix QuickJS

### DIFF
--- a/scripts/resources/deb/control
+++ b/scripts/resources/deb/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/Suwayomi/Tachidesk-Server
 
 Package: tachidesk-server
 Architecture: all
-Depends: ${misc:Depends}, default-jre-headless (>= 8)
+Depends: ${misc:Depends}, java8-runtime-headless, libc++-dev
 Description: Manga Reader
  A free and open source manga reader server that runs extensions built for Tachiyomi.
  Tachidesk is an independent Tachiyomi compatible software and is not a Fork of Tachiyomi.


### PR DESCRIPTION
Thanks @Syer10 for solving the issue.

- Fixes extensions which depend on QuickJS. for example ReadComicOnline [(source)](https://github.com/tachiyomiorg/tachiyomi-extensions/blob/50221eb16f45ec948962fb1a55fa5ed7ba311210/src/en/readcomiconline/src/eu/kanade/tachiyomi/extension/en/readcomiconline/Readcomiconline.kt). 
- Uses `java8-runtime-headless` instead of `default-jre-headless (>= 8)` which is a virtual package of different jre and jdk packages

test: https://github.com/mahor1221/Tachidesk-Server/actions/runs/3122174144
![2022-09-25_14-03-10](https://user-images.githubusercontent.com/73415437/192147827-7f6ca32f-6035-4f46-a589-3c698a5decef.jpg)
