### PR TITLE
Add cache control header to manga page response

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -315,6 +315,8 @@ object MangaController {
                 future { Page.getPageImage(mangaId, chapterIndex, index, useCache) }
                     .thenApply {
                         ctx.header("content-type", it.second)
+                        val httpCacheSeconds = 1.days.inWholeSeconds
+                        ctx.header("cache-control", "max-age=$httpCacheSeconds")
                         it.first
                     }
             )


### PR DESCRIPTION
This enables browser to cache chapter images for 1 day and makes navigating through chapters faster and less expensive on server.

The code is copied over from thumbnail endpoint.