### PR TITLE
POST variant for `/{sourceId}/search` endpoint

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -48,7 +48,7 @@ object MangaAPI {
             post("{sourceId}/filters", SourceController.setFilters)
 
             get("{sourceId}/search", SourceController.searchSingle)
-            post("{sourceId}/filter", SourceController.filterSingle)
+            post("{sourceId}/quick-search", SourceController.quickSearchSingle)
 //            get("all/search", SourceController.searchGlobal) // TODO
         }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -48,7 +48,7 @@ object MangaAPI {
             post("{sourceId}/filters", SourceController.setFilters)
 
             get("{sourceId}/search", SourceController.searchSingle)
-            post("{sourceId}/search", SourceController.searchSingle)
+            post("{sourceId}/filter", SourceController.filterSingle)
 //            get("all/search", SourceController.searchGlobal) // TODO
         }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -48,6 +48,7 @@ object MangaAPI {
             post("{sourceId}/filters", SourceController.setFilters)
 
             get("{sourceId}/search", SourceController.searchSingle)
+            post("{sourceId}/search", SourceController.searchSingle)
 //            get("all/search", SourceController.searchGlobal) // TODO
         }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
@@ -195,7 +195,15 @@ object SourceController {
             }
         },
         behaviorOf = { ctx, sourceId, searchTerm, pageNum ->
-            ctx.future(future { Search.sourceSearch(sourceId, searchTerm, pageNum) })
+            var filterChange: List<FilterChange>? = null
+            if (ctx.method() == "POST") {
+                filterChange = try {
+                    json.decodeFromString<List<FilterChange>>(ctx.body())
+                } catch (e: Exception) {
+                    listOf(json.decodeFromString<FilterChange>(ctx.body()))
+                }
+            }
+            ctx.future(future { Search.sourceSearch(sourceId, searchTerm, pageNum, filterChange) })
         },
         withResults = {
             json<PagedMangaListDataClass>(HttpCode.OK)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
@@ -209,8 +209,8 @@ object SourceController {
         queryParam("pageNum", 1),
         documentWith = {
             withOperation {
-                summary("Source search")
-                description("Single source search")
+                summary("Source manga filter")
+                description("Returns list of manga from source matching posted searchTerm and filter")
             }
         },
         behaviorOf = { ctx, sourceId, pageNum ->

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
@@ -203,13 +203,13 @@ object SourceController {
         }
     )
 
-    /** single source filter */
-    val filterSingle = handler(
+    /** quick search single source filter */
+    val quickSearchSingle = handler(
         pathParam<Long>("sourceId"),
         queryParam("pageNum", 1),
         documentWith = {
             withOperation {
-                summary("Source manga filter")
+                summary("Source manga quick search")
                 description("Returns list of manga from source matching posted searchTerm and filter")
             }
         },


### PR DESCRIPTION
This change allows client to call search endpoint with filter values in request body.

Client will be able to simply load source filters and query the source directly, without needing to update filters on server before calling search. This should allow for easier state management and filtering on client.

The filters in body are merged with original source `FilterList` to prevent unexpected values from `filterListCache`. Also they are not stored to server cache, so using them have no effect on `filterListCache`.