### PR TITLE
add batch download api

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -105,6 +105,8 @@ object MangaAPI {
             get("start", DownloadController.start)
             get("stop", DownloadController.stop)
             get("clear", DownloadController.stop)
+
+            post("", DownloadController.queueChapters)
         }
 
         path("download") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -105,13 +105,12 @@ object MangaAPI {
             get("start", DownloadController.start)
             get("stop", DownloadController.stop)
             get("clear", DownloadController.stop)
-
-            post("batch", DownloadController.queueChapters)
         }
 
         path("download") {
             get("{mangaId}/chapter/{chapterIndex}", DownloadController.queueChapter)
             delete("{mangaId}/chapter/{chapterIndex}", DownloadController.unqueueChapter)
+            post("batch", DownloadController.queueChapters)
         }
 
         path("update") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -106,7 +106,7 @@ object MangaAPI {
             get("stop", DownloadController.stop)
             get("clear", DownloadController.stop)
 
-            post("", DownloadController.queueChapters)
+            post("batch", DownloadController.queueChapters)
         }
 
         path("download") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
@@ -121,10 +121,10 @@ object DownloadController {
                 summary("Downloader add multiple chapters")
                 description("Queue multiple chapters for download")
             }
-            body<Array<EnqueueInput>>()
+            body<EnqueueInput>()
         },
         behaviorOf = { ctx ->
-            val inputs = json.decodeFromString<List<EnqueueInput>>(ctx.body())
+            val inputs = json.decodeFromString<EnqueueInput>(ctx.body())
             ctx.future(
                 future {
                     DownloadManager.enqueue(inputs)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
@@ -105,7 +105,7 @@ object DownloadController {
         behaviorOf = { ctx, chapterIndex, mangaId ->
             ctx.future(
                 future {
-                    DownloadManager.enqueue(listOf(EnqueueInput(mangaId, chapterIndex)))
+                    DownloadManager.enqueueWithChapterIndex(mangaId, chapterIndex)
                 }
             )
         },

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
@@ -105,7 +105,7 @@ object DownloadController {
         behaviorOf = { ctx, chapterIndex, mangaId ->
             ctx.future(
                 future {
-                    DownloadManager.enqueueMultiple(listOf(EnqueueInput(mangaId, chapterIndex)))
+                    DownloadManager.enqueue(listOf(EnqueueInput(mangaId, chapterIndex)))
                 }
             )
         },
@@ -121,15 +121,15 @@ object DownloadController {
                 summary("Downloader add multiple chapters")
                 description("Queue multiple chapters for download")
             }
+            body<Array<EnqueueInput>>()
         },
         behaviorOf = { ctx ->
             val inputs = json.decodeFromString<List<EnqueueInput>>(ctx.body())
             ctx.future(
                 future {
-                    DownloadManager.enqueueMultiple(inputs)
+                    DownloadManager.enqueue(inputs)
                 }
             )
-            ctx.status(200)
         },
         withResults = {
             httpCode(HttpCode.OK)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
@@ -9,13 +9,21 @@ package suwayomi.tachidesk.manga.controller
 
 import io.javalin.http.HttpCode
 import io.javalin.websocket.WsConfig
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.kodein.di.DI
+import org.kodein.di.conf.global
+import org.kodein.di.instance
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
+import suwayomi.tachidesk.manga.impl.download.DownloadManager.EnqueueInput
 import suwayomi.tachidesk.server.JavalinSetup.future
 import suwayomi.tachidesk.server.util.handler
 import suwayomi.tachidesk.server.util.pathParam
 import suwayomi.tachidesk.server.util.withOperation
 
 object DownloadController {
+    private val json by DI.global.instance<Json>()
+
     /** Download queue stats */
     fun downloadsWS(ws: WsConfig) {
         ws.onConnect { ctx ->
@@ -84,26 +92,47 @@ object DownloadController {
         }
     )
 
-    /** Queue chapter for download */
+    /** Queue single chapter for download */
     val queueChapter = handler(
         pathParam<Int>("chapterIndex"),
         pathParam<Int>("mangaId"),
         documentWith = {
             withOperation {
-                summary("Downloader add chapter")
-                description("Queue chapter for download")
+                summary("Downloader add single chapter")
+                description("Queue single chapter for download")
             }
         },
         behaviorOf = { ctx, chapterIndex, mangaId ->
             ctx.future(
                 future {
-                    DownloadManager.enqueue(chapterIndex, mangaId)
+                    DownloadManager.enqueueMultiple(listOf(EnqueueInput(mangaId, chapterIndex)))
                 }
             )
         },
         withResults = {
             httpCode(HttpCode.OK)
             httpCode(HttpCode.NOT_FOUND)
+        }
+    )
+
+    val queueChapters = handler(
+        documentWith = {
+            withOperation {
+                summary("Downloader add multiple chapters")
+                description("Queue multiple chapters for download")
+            }
+        },
+        behaviorOf = { ctx ->
+            val inputs = json.decodeFromString<List<EnqueueInput>>(ctx.body())
+            ctx.future(
+                future {
+                    DownloadManager.enqueueMultiple(inputs)
+                }
+            )
+            ctx.status(200)
+        },
+        withResults = {
+            httpCode(HttpCode.OK)
         }
     )
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -140,6 +140,7 @@ object Chapter {
             val dbChapter = dbChapterMap.getValue(it.url)
 
             ChapterDataClass(
+                dbChapter[ChapterTable.id].value,
                 it.url,
                 it.name,
                 it.date_upload,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -88,19 +88,22 @@ object DownloadManager {
                 .select { ChapterTable.manga.eq(mangaId) and ChapterTable.sourceOrder.eq(chapterIndex) }
                 .first()
         }
-        enqueue(listOf(EnqueueInput(chapter[ChapterTable.id].value)))
+        enqueue(EnqueueInput(chapterIds = listOf(chapter[ChapterTable.id].value)))
     }
 
     @Serializable
+    // Input might have additional formats in the future, such as "All for mangaID" or "Unread for categoryID"
+    // Having this input format is just future-proofing
     data class EnqueueInput(
-        val chapterId: Int
+        val chapterIds: List<Int>?
     )
 
-    fun enqueue(inputs: List<EnqueueInput>) {
+    fun enqueue(input: EnqueueInput) {
+        if (input.chapterIds == null) return
+
         val chapters = transaction {
-            val chapterIds = inputs.map { it.chapterId }.distinct()
             (ChapterTable innerJoin MangaTable)
-                .select { ChapterTable.id inList chapterIds }
+                .select { ChapterTable.id inList input.chapterIds }
                 .toList()
         }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -9,17 +9,22 @@ package suwayomi.tachidesk.manga.impl.download
 
 import io.javalin.websocket.WsContext
 import io.javalin.websocket.WsMessageContext
-import org.jetbrains.exposed.sql.and
+import kotlinx.serialization.Serializable
+import mu.KotlinLogging
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
-import suwayomi.tachidesk.manga.impl.Manga.getManga
 import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import suwayomi.tachidesk.manga.impl.download.model.DownloadState.Downloading
 import suwayomi.tachidesk.manga.impl.download.model.DownloadStatus
+import suwayomi.tachidesk.manga.model.dataclass.ChapterDataClass
+import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 import suwayomi.tachidesk.manga.model.table.ChapterTable
+import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+
+private val logger = KotlinLogging.logger {}
 
 object DownloadManager {
     private val clients = ConcurrentHashMap<String, WsContext>()
@@ -75,24 +80,77 @@ object DownloadManager {
         )
     }
 
-    suspend fun enqueue(chapterIndex: Int, mangaId: Int) {
-        if (downloadQueue.none { it.mangaId == mangaId && it.chapterIndex == chapterIndex }) {
-            downloadQueue.add(
-                DownloadChapter(
-                    chapterIndex,
-                    mangaId,
-                    chapter = ChapterTable.toDataClass(
-                        transaction {
-                            ChapterTable.select { (ChapterTable.manga eq mangaId) and (ChapterTable.sourceOrder eq chapterIndex) }
-                                .first()
-                        }
-                    ),
-                    manga = getManga(mangaId)
-                )
-            )
-            start()
+    @Serializable
+    data class EnqueueInput(
+        val mangaId: Int,
+        val chapterIndex: Int
+    )
+
+    fun enqueueMultiple(inputs: List<EnqueueInput>) {
+        val mangas = transaction {
+            val mangaIds = inputs.map { it.mangaId }.distinct()
+            MangaTable.select { MangaTable.id inList mangaIds }
+                .map { MangaTable.toDataClass(it) }
         }
-        notifyAllClients()
+
+        // This list will have unwanted chapters from other manga but there is no simple way
+        // to select only wanted ones. It will be mapped to input later so it should not be problem
+        val chapters = transaction {
+            val chapterIndexes = inputs.map { it.chapterIndex }.distinct()
+            ChapterTable.select { ChapterTable.sourceOrder inList chapterIndexes }.toList()
+        }
+
+        val mappedInputs = transaction {
+            inputs.map {
+                Pair(
+                    mangas.first { manga -> manga.id == it.mangaId },
+                    ChapterTable.toDataClass(
+                        chapters.first { chapter ->
+                            inputs.find { input ->
+                                it.chapterIndex == chapter[ChapterTable.sourceOrder] &&
+                                    input.mangaId == chapter[ChapterTable.manga].value
+                            } != null
+                        }
+                    )
+                )
+            }
+        }
+
+        addMultipleToQueue(mappedInputs)
+    }
+
+    /**
+     * Tries to add multiple inputs to queue
+     * If any of inputs was actually added to queue, starts the queue
+     */
+    private fun addMultipleToQueue(inputs: List<Pair<MangaDataClass, ChapterDataClass>>) {
+        val addedChapters = inputs.map { addToQueue(it.first, it.second) }
+        val anyAdded = addedChapters.any { it != null }
+
+        if (anyAdded) {
+            start()
+            notifyAllClients()
+        }
+    }
+
+    /**
+     * Tries to add chapter to queue.
+     * If chapter is added, returns the created DownloadChapter, otherwise returns null
+     */
+    private fun addToQueue(manga: MangaDataClass, chapter: ChapterDataClass): DownloadChapter? {
+        if (downloadQueue.none { it.mangaId == manga.id && it.chapterIndex == chapter.index }) {
+            val dc = DownloadChapter(
+                chapter.index,
+                manga.id,
+                chapter,
+                manga
+            )
+            downloadQueue.add(dc)
+            logger.debug("Added to download queue: ${manga.title} | ${chapter.index}")
+            return dc
+        }
+        logger.debug("Chapter already present in queue: ${manga.title} | ${chapter.index}")
+        return null
     }
 
     fun unqueue(chapterIndex: Int, mangaId: Int) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/ChapterDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/ChapterDataClass.kt
@@ -8,6 +8,7 @@ package suwayomi.tachidesk.manga.model.dataclass
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 data class ChapterDataClass(
+    val id: Int,
     val url: String,
     val name: String,
     val uploadDate: Long,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/ChapterTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/ChapterTable.kt
@@ -38,6 +38,7 @@ object ChapterTable : IntIdTable() {
 
 fun ChapterTable.toDataClass(chapterEntry: ResultRow) =
     ChapterDataClass(
+        chapterEntry[id].value,
         chapterEntry[url],
         chapterEntry[name],
         chapterEntry[date_upload],


### PR DESCRIPTION
This PR adds `POST /downloads` endpoint for creating chapter downloads.

The path is `POST /downloads` since it best matches REST scheme, since the call is creating Downloads.

For identification of chapters is used combination of `mangaId` and `chapterIndex`. I don't think it is ideal, but chapter ids are not available to client, so this combination needs to be used.

For optimizations manga and chapters are loaded upfront. I don't know how to load only the chapters required for query as there does not seem to be any apparent way to do custom `WHERE` query. Instead all chapters with `sourceIndex` present in input are loaded and then only those actually wanted are used.

If non-existing combination is sent, request does not add anything and returns 404. There is error message in server console, I'm not sure if it is handled enough.

If all chapters are already present in queue, the queue is not started / restarted. Clients are notified thorugh websockets only once after all the chapters are added.

I have also updated existing `GET /download/{mangaId}/chapter/{chapterIndex}` to use the same code.