### PR TITLE
Downloader Rewrite

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -116,13 +116,13 @@ fun Call.asObservableSuccess(): Observable<Response> {
 @Suppress("UNUSED_PARAMETER")
 fun OkHttpClient.newCallWithProgress(request: Request, listener: ProgressListener): Call {
     val progressClient = newBuilder()
-//        .cache(null)
-//        .addNetworkInterceptor { chain ->
-//            val originalResponse = chain.proceed(chain.request())
-//            originalResponse.newBuilder()
-//                .body(ProgressResponseBody(originalResponse.body!!, listener))
-//                .build()
-//        }
+        .cache(null)
+        .addNetworkInterceptor { chain ->
+            val originalResponse = chain.proceed(chain.request())
+            originalResponse.newBuilder()
+                .body(ProgressResponseBody(originalResponse.body!!, listener))
+                .build()
+        }
         .build()
 
     return progressClient.newCall(request)

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/ProgressResponseBody.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/ProgressResponseBody.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.network
+
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import okio.Buffer
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.Source
+import okio.buffer
+import java.io.IOException
+
+class ProgressResponseBody(private val responseBody: ResponseBody, private val progressListener: ProgressListener) : ResponseBody() {
+
+    private val bufferedSource: BufferedSource by lazy {
+        source(responseBody.source()).buffer()
+    }
+
+    override fun contentType(): MediaType? {
+        return responseBody.contentType()
+    }
+
+    override fun contentLength(): Long {
+        return responseBody.contentLength()
+    }
+
+    override fun source(): BufferedSource {
+        return bufferedSource
+    }
+
+    private fun source(source: Source): Source {
+        return object : ForwardingSource(source) {
+            var totalBytesRead = 0L
+
+            @Throws(IOException::class)
+            override fun read(sink: Buffer, byteCount: Long): Long {
+                val bytesRead = super.read(sink, byteCount)
+                // read() returns the number of bytes read, or -1 if this source is exhausted.
+                totalBytesRead += if (bytesRead != -1L) bytesRead else 0
+                progressListener.update(totalBytesRead, responseBody.contentLength(), bytesRead == -1L)
+                return bytesRead
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/loader/EpubPageLoader.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/loader/EpubPageLoader.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.source.local.loader
 
-import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.storage.EpubFile
 import java.io.File
 
@@ -24,7 +23,6 @@ class EpubPageLoader(file: File) : PageLoader {
                 val streamFn = { epub.getInputStream(epub.getEntry(path)!!) }
                 ReaderPage(i).apply {
                     stream = streamFn
-                    status = Page.READY
                 }
             }
     }

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/loader/RarPageLoader.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/loader/RarPageLoader.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.source.local.loader
 
 import com.github.junrar.Archive
 import com.github.junrar.rarfile.FileHeader
-import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil
 import java.io.ByteArrayInputStream
@@ -46,7 +45,6 @@ class RarPageLoader(file: File) : PageLoader {
 
                     ReaderPage(i).apply {
                         stream = streamFn
-                        status = Page.READY
                     }
                 }
         }
@@ -58,7 +56,6 @@ class RarPageLoader(file: File) : PageLoader {
 
                 ReaderPage(i).apply {
                     stream = streamFn
-                    status = Page.READY
                 }
             }
     }

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/loader/ZipPageLoader.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/loader/ZipPageLoader.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.source.local.loader
 
-import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil
 import java.io.File
@@ -24,7 +23,6 @@ class ZipPageLoader(file: File) : PageLoader {
                 val streamFn = { zip.getInputStream(entry) }
                 ReaderPage(i).apply {
                     stream = streamFn
-                    status = Page.READY
                 }
             }
     }

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/Page.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/Page.kt
@@ -2,7 +2,8 @@ package eu.kanade.tachiyomi.source.model
 
 import android.net.Uri
 import eu.kanade.tachiyomi.network.ProgressListener
-import rx.subjects.Subject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 open class Page(
     val index: Int,
@@ -11,46 +12,15 @@ open class Page(
     @Transient var uri: Uri? = null // Deprecated but can't be deleted due to extensions
 ) : ProgressListener {
 
-    val number: Int
-        get() = index + 1
-
-    @Transient
-    @Volatile
-    var status: Int = 0
-        set(value) {
-            field = value
-            statusSubject?.onNext(value)
-            statusCallback?.invoke(this)
-        }
-
-    @Transient
-    @Volatile
-    var progress: Int = 0
-        set(value) {
-            field = value
-            statusCallback?.invoke(this)
-        }
-
-    @Transient
-    private var statusSubject: Subject<Int, Int>? = null
-
-    @Transient
-    private var statusCallback: ((Page) -> Unit)? = null
+    private val _progress = MutableStateFlow(0)
+    val progress = _progress.asStateFlow()
 
     override fun update(bytesRead: Long, contentLength: Long, done: Boolean) {
-        progress = if (contentLength > 0) {
+        _progress.value = if (contentLength > 0) {
             (100 * bytesRead / contentLength).toInt()
         } else {
             -1
         }
-    }
-
-    fun setStatusSubject(subject: Subject<Int, Int>?) {
-        this.statusSubject = subject
-    }
-
-    fun setStatusCallback(f: ((Page) -> Unit)?) {
-        statusCallback = f
     }
 
     companion object {

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSourceFetcher.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSourceFetcher.kt
@@ -4,9 +4,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import rx.Observable
 
 fun HttpSource.getImageUrl(page: Page): Observable<Page> {
-    page.status = Page.LOAD_PAGE
     return fetchImageUrl(page)
-        .doOnError { page.status = Page.ERROR }
         .onErrorReturn { null }
         .doOnNext { page.imageUrl = it }
         .map { page }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -104,7 +104,7 @@ object MangaAPI {
 
             get("start", DownloadController.start)
             get("stop", DownloadController.stop)
-            get("clear", DownloadController.stop)
+            get("clear", DownloadController.clear)
         }
 
         path("download") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -110,6 +110,7 @@ object MangaAPI {
         path("download") {
             get("{mangaId}/chapter/{chapterIndex}", DownloadController.queueChapter)
             delete("{mangaId}/chapter/{chapterIndex}", DownloadController.unqueueChapter)
+            patch("{mangaId}/chapter/{chapterIndex}/reorder/{to}", DownloadController.reorderChapter)
             post("batch", DownloadController.queueChapters)
         }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
@@ -153,4 +153,23 @@ object DownloadController {
             httpCode(HttpCode.OK)
         }
     )
+
+    /** clear download queue */
+    val reorderChapter = handler(
+        pathParam<Int>("chapterIndex"),
+        pathParam<Int>("mangaId"),
+        pathParam<Int>("to"),
+        documentWith = {
+            withOperation {
+                summary("Downloader reorder chapter")
+                description("Reorder chapter in download queue")
+            }
+        },
+        behaviorOf = { _, chapterIndex, mangaId, to ->
+            DownloadManager.reorder(chapterIndex, mangaId, to)
+        },
+        withResults = {
+            httpCode(HttpCode.OK)
+        }
+    )
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/DownloadController.kt
@@ -46,10 +46,8 @@ object DownloadController {
                 description("Start the downloader")
             }
         },
-        behaviorOf = { ctx ->
+        behaviorOf = {
             DownloadManager.start()
-
-            ctx.status(200)
         },
         withResults = {
             httpCode(HttpCode.OK)
@@ -65,9 +63,9 @@ object DownloadController {
             }
         },
         behaviorOf = { ctx ->
-            DownloadManager.stop()
-
-            ctx.status(200)
+            ctx.future(
+                future { DownloadManager.stop() }
+            )
         },
         withResults = {
             httpCode(HttpCode.OK)
@@ -83,9 +81,9 @@ object DownloadController {
             }
         },
         behaviorOf = { ctx ->
-            DownloadManager.clear()
-
-            ctx.status(200)
+            ctx.future(
+                future { DownloadManager.clear() }
+            )
         },
         withResults = {
             httpCode(HttpCode.OK)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -186,6 +186,14 @@ object DownloadManager {
         notifyAllClients()
     }
 
+    fun reorder(chapterIndex: Int, mangaId: Int, to: Int) {
+        require(to >= 0) { "'to' must be over or equal to 0" }
+        val download = downloadQueue.find { it.mangaId == mangaId && it.chapterIndex == chapterIndex }
+            ?: return
+        downloadQueue -= download
+        downloadQueue.add(to, download)
+    }
+
     fun start() {
         if (downloaderJob?.isActive != true) {
             downloaderJob = GlobalScope.launch {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -69,7 +69,7 @@ class Downloader(private val downloadQueue: CopyOnWriteArrayList<DownloadChapter
                                     .distinctUntilChanged()
                                     .onEach {
                                         download.progress = (pageNum.toFloat() + (it.toFloat() * 0.01f)) / pageCount
-                                        step(download)
+                                        step(null) // don't throw on canceled download here since we can't do anything
                                     }
                                     .launchIn(GlobalScope)
                             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -44,7 +44,7 @@ class Downloader(
     private suspend fun step(download: DownloadChapter?) {
         notifier()
         currentCoroutineContext().ensureActive()
-        if (download != null && download != downloadQueue.firstOrNull()) {
+        if (download != null && download != downloadQueue.firstOrNull { it.state != Error }) {
             if (download in downloadQueue) {
                 throw PauseDownloadException()
             } else {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -119,7 +119,6 @@ class Downloader(
                         pageProgressJob?.cancel()
                     }
                     // TODO: retry on error with 2,4,8 seconds of wait
-                    // TODO: download multiple pages at once, possible solution: rx observer's strategy is used in Tachiyomi
                     download.progress = ((pageNum + 1).toFloat()) / pageCount
                     step(download)
                 }


### PR DESCRIPTION
- Rewrite downloader to use coroutines instead of a thread
- Remove unused Page functions
- Add page progress
- Add ProgressResponseBody
- Add support for canceling a download in the middle of downloading
- Fix clear download queue
- Reorder downloads
- Buffer the notify clients queue
- Download in parallel by source

closes #262 