### PR TITLE
Add batch chapter update endpoint

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -66,6 +66,7 @@ object MangaAPI {
             patch("{mangaId}/meta", MangaController.meta)
 
             get("{mangaId}/chapters", MangaController.chapterList)
+            post("{mangaId}/chapter/batch", MangaController.chapterBatch)
             get("{mangaId}/chapter/{chapterIndex}", MangaController.chapterRetrieve)
             patch("{mangaId}/chapter/{chapterIndex}", MangaController.chapterModify)
             delete("{mangaId}/chapter/{chapterIndex}", MangaController.chapterDelete)


### PR DESCRIPTION
This PR adds endpoint for batch updating chapters on `POST /manga/{mangaId}/chapter/batch`.

This allows client to batch update `isRead` or `isBookmarked`. For completion sake, `lastPageRead` can also be changed, although I don't see how that would be useful.

The endpoint expects JSON body with chapter selection and change. For example:

```
POST /api/v1/manga/100/chapter/batch
{
    "chapterIndexes": [
        170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185
    ],
    "change": {
        "isRead": false,
        "isBookmarked": false
    }
}
```

Chapter ids can also be used:

```
POST /api/v1/manga/100/chapter/batch
{
    "chapterIds": [
        1,2,3,4,5
    ],
    "change": {
        "isRead": true,
        "isBookmarked": false
    }
}
```

If both `chapterIds` and `chapterIndexes` are present, ids will be used.