### PR TITLE
Batch editing and deleting any chapter

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -69,6 +69,7 @@ object MangaAPI {
 
             get("{mangaId}/chapters", MangaController.chapterList)
             post("{mangaId}/chapter/batch", MangaController.chapterBatch)
+            post("any/chapter/batch", MangaController.anyChapterBatch)
             get("{mangaId}/chapter/{chapterIndex}", MangaController.chapterRetrieve)
             patch("{mangaId}/chapter/{chapterIndex}", MangaController.chapterModify)
             put("{mangaId}/chapter/{chapterIndex}", MangaController.chapterModify)
@@ -77,8 +78,6 @@ object MangaAPI {
             patch("{mangaId}/chapter/{chapterIndex}/meta", MangaController.chapterMeta)
 
             get("{mangaId}/chapter/{chapterIndex}/page/{index}", MangaController.pageRetrieve)
-
-            post("any/chapters/batch", MangaController.anyChapterBatch)
         }
 
         path("category") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -77,6 +77,8 @@ object MangaAPI {
             patch("{mangaId}/chapter/{chapterIndex}/meta", MangaController.chapterMeta)
 
             get("{mangaId}/chapter/{chapterIndex}/page/{index}", MangaController.pageRetrieve)
+
+            post("any/chapters/batch", MangaController.anyChapterBatch)
         }
 
         path("category") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -69,7 +69,6 @@ object MangaAPI {
 
             get("{mangaId}/chapters", MangaController.chapterList)
             post("{mangaId}/chapter/batch", MangaController.chapterBatch)
-            post("any/chapter/batch", MangaController.anyChapterBatch)
             get("{mangaId}/chapter/{chapterIndex}", MangaController.chapterRetrieve)
             patch("{mangaId}/chapter/{chapterIndex}", MangaController.chapterModify)
             put("{mangaId}/chapter/{chapterIndex}", MangaController.chapterModify)
@@ -78,6 +77,10 @@ object MangaAPI {
             patch("{mangaId}/chapter/{chapterIndex}/meta", MangaController.chapterMeta)
 
             get("{mangaId}/chapter/{chapterIndex}/page/{index}", MangaController.pageRetrieve)
+        }
+
+        path("chapters") {
+            post("batch", MangaController.anyChapterBatch)
         }
 
         path("category") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -259,7 +259,7 @@ object MangaController {
         }
     )
 
-    /** batch edit chapters */
+    /** batch edit chapters from multiple manga */
     val anyChapterBatch = handler(
         documentWith = {
             withOperation {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -240,19 +240,43 @@ object MangaController {
         }
     )
 
-    /** batch edit chapters */
+    /** batch edit chapters of single manga */
     val chapterBatch = handler(
         pathParam<Int>("mangaId"),
         documentWith = {
             withOperation {
                 summary("Chapters update multiple")
-                description("Update multiple chapters. For batch marking as read, or bookmarking")
+                description("Update multiple chapters of single manga. For batch marking as read, or bookmarking")
+            }
+            body<Chapter.MangaChapterBatchEditInput>()
+        },
+        behaviorOf = { ctx, mangaId ->
+            val input = json.decodeFromString<Chapter.MangaChapterBatchEditInput>(ctx.body())
+            Chapter.modifyChapters(input, mangaId)
+        },
+        withResults = {
+            httpCode(HttpCode.OK)
+        }
+    )
+
+    /** batch edit chapters */
+    val anyChapterBatch = handler(
+        documentWith = {
+            withOperation {
+                summary("Chapters update multiple")
+                description("Update multiple chapters on any manga. For batch marking as read, or bookmarking")
             }
             body<Chapter.ChapterBatchEditInput>()
         },
-        behaviorOf = { ctx, mangaId ->
+        behaviorOf = { ctx ->
             val input = json.decodeFromString<Chapter.ChapterBatchEditInput>(ctx.body())
-            Chapter.modifyChapters(input, mangaId)
+            Chapter.modifyChapters(
+                Chapter.MangaChapterBatchEditInput(
+                    input.chapterIds,
+                    null,
+                    input.change
+                )
+            )
         },
         withResults = {
             httpCode(HttpCode.OK)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -223,10 +223,11 @@ object Chapter {
 
         // Handle deleting separately
         if (delete == true) {
-            return deleteChapters(input, mangaId)
+            deleteChapters(input, mangaId)
         }
 
-        if (isRead == null && isBookmarked == null) return
+        // return early if there are no other changes
+        if (listOfNotNull(isRead, isBookmarked, lastPageRead).isEmpty()) return
 
         // Make sure some filter is defined
         val condition = when {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -199,7 +199,7 @@ object Chapter {
     data class ChapterChange(
         val isRead: Boolean? = null,
         val isBookmarked: Boolean? = null,
-        val lastPageRead: Int? = null, // this probably won't be very useful, but for completion's sake
+        val lastPageRead: Int? = null,
         val delete: Boolean? = null
     )
 
@@ -322,7 +322,7 @@ object Chapter {
         }
     }
 
-    fun deleteChapters(input: MangaChapterBatchEditInput, mangaId: Int? = null) {
+    private fun deleteChapters(input: MangaChapterBatchEditInput, mangaId: Int? = null) {
         if (input.chapterIds != null) {
             val chapterIds = input.chapterIds
 


### PR DESCRIPTION
closes #448 

This PR adds new endpoint `/manga/any/chapter/batch` (notice singular `chapter`) for batch editing any chapters based on list of chapter ids.

I have also added new `change` option to batch edit input. If `delete = true` chapter contents are deleted instead.
This delete functionality is also available on `/manga/:id/chapter/batch` endpoint as it uses same controller.