### PR TITLE
Download queue missing update fix

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -94,7 +94,9 @@ object DownloadManager {
 
     private fun notifyAllClients(immediate: Boolean = false) {
         if (immediate) {
-            sendStatusToAllClients()
+            scope.launch {
+                sendStatusToAllClients()
+            }
         } else {
             scope.launch {
                 notifyFlow.emit(Unit)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -94,9 +94,7 @@ object DownloadManager {
 
     private fun notifyAllClients(immediate: Boolean = false) {
         if (immediate) {
-            scope.launch {
-                sendStatusToAllClients()
-            }
+            sendStatusToAllClients()
         } else {
             scope.launch {
                 notifyFlow.emit(Unit)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -235,7 +235,7 @@ object DownloadManager {
 
     fun unqueue(chapterIndex: Int, mangaId: Int) {
         downloadQueue.removeIf { it.mangaId == mangaId && it.chapterIndex == chapterIndex }
-        notifyAllClients(true)
+        notifyAllClients()
     }
 
     fun reorder(chapterIndex: Int, mangaId: Int, to: Int) {
@@ -260,13 +260,13 @@ object DownloadManager {
                 }
             }.awaitAll()
         }
-        notifyAllClients(true)
+        notifyAllClients()
     }
 
     suspend fun clear() {
         stop()
         downloadQueue.clear()
-        notifyAllClients(true)
+        notifyAllClients()
     }
 }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -74,7 +74,7 @@ class Downloader(
             }
         }
 
-        notifier(true)
+        notifier(false)
     }
 
     suspend fun stop() {
@@ -93,7 +93,7 @@ class Downloader(
                 step(download, true)
 
                 download.chapter = getChapterDownloadReady(download.chapterIndex, download.mangaId)
-                step(download, true)
+                step(download, false)
 
                 val pageCount = download.chapter.pageCount
                 for (pageNum in 0 until pageCount) {
@@ -131,7 +131,7 @@ class Downloader(
                 step(download, true)
 
                 downloadQueue.removeIf { it.mangaId == download.mangaId && it.chapterIndex == download.chapterIndex }
-                step(null, true)
+                step(null, false)
             } catch (e: CancellationException) {
                 logger.debug("Downloader was stopped")
                 downloadQueue.filter { it.state == Downloading }.forEach { it.state = Queued }
@@ -142,7 +142,7 @@ class Downloader(
                 download.tries++
                 download.state = Error
             } finally {
-                notifier(true)
+                notifier(false)
             }
         }
     }


### PR DESCRIPTION
This PR tries to fix #446

By moving websocket updates to periodically polled updater, some updates (last) might get lost since they are not polled before notifyFlow is cleared. I believe this is caused by behavior of [sample](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/sample.html) function.

@Syer10 I believe you did the downloader rework. Would something like this be correct way to fix it?