### PR TITLE
get default User Agent from WebView

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -128,6 +128,20 @@ object CFClearance {
             .build()
     }
 
+    fun getWebViewUserAgent(): String {
+        Playwright.create().use { playwright ->
+            val browser = playwright.chromium().launch(
+                LaunchOptions()
+                    .setHeadless(true)
+            )
+            browser.newPage().use { page ->
+                val userAgent = page.evaluate("() => {return navigator.userAgent}") as String
+                logger.debug { "WebView User-Agent is $userAgent" }
+                return userAgent
+            }
+        }
+    }
+
     private fun getCookies(page: Page, url: String): List<Cookie> {
         applyStealthInitScripts(page)
         page.navigate(url)

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -130,14 +130,15 @@ object CFClearance {
 
     fun getWebViewUserAgent(): String {
         Playwright.create().use { playwright ->
-            val browser = playwright.chromium().launch(
+            playwright.chromium().launch(
                 LaunchOptions()
                     .setHeadless(true)
-            )
-            browser.newPage().use { page ->
-                val userAgent = page.evaluate("() => {return navigator.userAgent}") as String
-                logger.debug { "WebView User-Agent is $userAgent" }
-                return userAgent
+            ).use { browser ->
+                browser.newPage().use { page ->
+                    val userAgent = page.evaluate("() => {return navigator.userAgent}") as String
+                    logger.debug { "WebView User-Agent is $userAgent" }
+                    return userAgent
+                }
             }
         }
     }

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.source.online
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.asObservableSuccess
+import eu.kanade.tachiyomi.network.interceptor.CFClearance.getWebViewUserAgent
 import eu.kanade.tachiyomi.network.newCallWithProgress
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -372,6 +373,6 @@ abstract class HttpSource : CatalogueSource {
     override fun getFilterList() = FilterList()
 
     companion object {
-        const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36 Edg/88.0.705.63"
+        val DEFAULT_USER_AGENT by lazy { getWebViewUserAgent() }
     }
 }


### PR DESCRIPTION
This approach potentially will cause a pause and memory spike on user's computer.

Also, PlayWright has to download a bunch of stuff on first execution, that will probably worsen the first user experience.