### PR TITLE
Better thumbnail handling

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -87,8 +87,10 @@ object Manga {
                     it[MangaTable.description] = truncate(sManga.description, 4096)
                     it[MangaTable.genre] = sManga.genre
                     it[MangaTable.status] = sManga.status
-                    if (sManga.thumbnail_url != null && sManga.thumbnail_url.orEmpty().isNotEmpty()) {
+                    if (!sManga.thumbnail_url.isNullOrEmpty() && sManga.thumbnail_url != mangaEntry[MangaTable.thumbnail_url]) {
                         it[MangaTable.thumbnail_url] = sManga.thumbnail_url
+                        it[MangaTable.thumbnailUrlLastFetched] = Instant.now().epochSecond
+                        clearMangaThumbnail(mangaId)
                     }
 
                     it[MangaTable.realUrl] = runCatching {
@@ -99,8 +101,6 @@ object Manga {
                 }
             }
 
-            clearMangaThumbnail(mangaId)
-
             mangaEntry = transaction { MangaTable.select { MangaTable.id eq mangaId }.first() }
 
             MangaDataClass(
@@ -110,6 +110,7 @@ object Manga {
                 mangaEntry[MangaTable.url],
                 mangaEntry[MangaTable.title],
                 proxyThumbnailUrl(mangaId),
+                mangaEntry[MangaTable.thumbnailUrlLastFetched],
 
                 true,
 
@@ -171,6 +172,7 @@ object Manga {
         mangaEntry[MangaTable.url],
         mangaEntry[MangaTable.title],
         proxyThumbnailUrl(mangaId),
+        mangaEntry[MangaTable.thumbnailUrlLastFetched],
 
         true,
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
@@ -76,6 +76,7 @@ object MangaList {
                         manga.url,
                         manga.title,
                         proxyThumbnailUrl(mangaId),
+                        mangaEntry[MangaTable.thumbnailUrlLastFetched],
 
                         manga.initialized,
 
@@ -101,6 +102,7 @@ object MangaList {
                         manga.url,
                         manga.title,
                         proxyThumbnailUrl(mangaId),
+                        mangaEntry[MangaTable.thumbnailUrlLastFetched],
 
                         true,
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
@@ -18,6 +18,7 @@ data class MangaDataClass(
     val url: String,
     val title: String,
     val thumbnailUrl: String? = null,
+    val thumbnailUrlLastFetched: Long = 0,
 
     val initialized: Boolean = false,
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
@@ -28,6 +28,7 @@ object MangaTable : IntIdTable() {
 
     val status = integer("status").default(SManga.UNKNOWN)
     val thumbnail_url = varchar("thumbnail_url", 2048).nullable()
+    val thumbnailUrlLastFetched = long("thumbnail_url_last_fetched").default(0)
 
     val inLibrary = bool("in_library").default(false)
     val defaultCategory = bool("default_category").default(true)
@@ -51,6 +52,7 @@ fun MangaTable.toDataClass(mangaEntry: ResultRow) =
         mangaEntry[url],
         mangaEntry[title],
         proxyThumbnailUrl(mangaEntry[this.id].value),
+        mangaEntry[MangaTable.thumbnailUrlLastFetched],
 
         mangaEntry[initialized],
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0022_MangaThumbnailLastFetched.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0022_MangaThumbnailLastFetched.kt
@@ -1,0 +1,18 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.AddColumnMigration
+
+@Suppress("ClassName", "unused")
+class M0022_MangaThumbnailLastFetched : AddColumnMigration(
+    "Manga",
+    "thumbnail_url_last_fetched",
+    "BIGINT",
+    "0"
+)


### PR DESCRIPTION
- Add `thumbnail_url_last_fetched` column in the `Manga` table, allowing clients to know when the thumbnail was last modified
- Only clear thumbnail if the source returns a new link(similar to what tachiyomi does)