### PR TITLE
[WIP] multi-user experiment

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -25,10 +25,10 @@ import org.kodein.di.conf.global
 import org.kodein.di.instance
 import suwayomi.tachidesk.global.GlobalAPI
 import suwayomi.tachidesk.manga.MangaAPI
+import suwayomi.tachidesk.server.database.DBManager.databaseForUser
 import suwayomi.tachidesk.server.util.Browser
 import suwayomi.tachidesk.server.util.setupWebInterface
 import java.io.IOException
-import java.lang.IllegalArgumentException
 import java.util.concurrent.CompletableFuture
 import kotlin.concurrent.thread
 
@@ -66,6 +66,8 @@ object JavalinSetup {
                     ctx.header("WWW-Authenticate", "Basic")
                     ctx.status(401).json("Unauthorized")
                 } else {
+                    val username = if (serverConfig.basicAuthEnabled) serverConfig.basicAuthUsername else "default-user"
+                    ctx.attribute("db", databaseForUser(username))
                     handler.handle(ctx)
                 }
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/DBManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/DBManager.kt
@@ -19,27 +19,50 @@ import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.ServerConfig
 
 object DBManager {
+    private val logger = KotlinLogging.logger {}
 
-    val db by lazy {
+    val masterDB by lazy {
         val applicationDirs by DI.global.instance<ApplicationDirs>()
+
         Database.connect(
-            "jdbc:h2:${applicationDirs.dataRoot}/database",
+            "jdbc:h2:${applicationDirs.dataRoot}/server",
             "org.h2.Driver",
             databaseConfig = DatabaseConfig {
                 useNestedTransactions = true
             }
         )
     }
-}
 
-private val logger = KotlinLogging.logger {}
-
-fun databaseUp(db: Database = DBManager.db) {
-    // call db to initialize the lazy object
-    logger.info {
-        "Using ${db.vendor} database version ${db.version}"
+    fun masterDbUp() {
+        val db = masterDB
+        logger.info { "Initialized masterDb: ${masterDB.url}" }
     }
 
-    val migrations = loadMigrationsFrom("suwayomi.tachidesk.server.database.migration", ServerConfig::class.java)
-    runMigrations(migrations)
+    private val usersDatabases = mutableMapOf<String, Database>()
+    fun databaseForUser(username: String) {
+        usersDatabases.getOrElse(username) {
+            val applicationDirs by DI.global.instance<ApplicationDirs>()
+
+            // call db to initialize the lazy object
+            logger.info {
+                "initializing database for user $username"
+            }
+
+            val database = Database.connect(
+                "jdbc:h2:${applicationDirs.dataRoot}/server",
+                "org.h2.Driver",
+                databaseConfig = DatabaseConfig {
+                    useNestedTransactions = true
+                }
+            )
+
+            val migrations =
+                loadMigrationsFrom("suwayomi.tachidesk.server.database.migration", ServerConfig::class.java)
+            runMigrations(migrations, database)
+
+            usersDatabases[username] = database
+
+            database
+        }
+    }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/model/table/User.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/model/table/User.kt
@@ -1,0 +1,10 @@
+package suwayomi.tachidesk.server.model.table
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+class User


### PR DESCRIPTION
This an experimental work, I leave it to whom that are interested if they want to continue where I got bored and left off

The idea is having a main "server" database that holds the core data which would be the same across all users, and a database file for each user which would contain their library (and possibly everything else like extensions, downloaded manga and thumbnails)

This would work in theory if we change the default transaction database on Exposed in javalin's accessManager, because javalin is running multi threaded between requests and Exposed is using `ThreadLocal` values for handling transaction database, so to sum it up it could be configured to use a different database for each thread/request.