### PR TITLE
Fixes Dex2Jar and dorkbox dependency issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .gradle
 .idea
 gradle.properties
-
+.fleet
 # But we need these
 !.idea/runConfigurations
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ okhttp = "4.10.0" # Major version is locked by Tachiyomi extensions
 javalin = "4.6.6" # Javalin 5.0.0+ requires Java 11
 jackson = "2.13.3" # jackson version locked by javalin, ref: `io.javalin.core.util.OptionalDependency`
 exposed = "0.40.1"
-dex2jar = "v56"
+dex2jar = "v59"
 rhino = "1.7.14"
 settings = "1.0.0-RC"
 twelvemonkeys = "3.9.4"
@@ -63,8 +63,9 @@ exposed-migrations = "com.github.Suwayomi:exposed-migrations:3.2.0"
 kodein = "org.kodein.di:kodein-di-conf-jvm:7.15.0"
 
 # tray icon
-systemtray-core = "com.dorkbox:SystemTray:4.2"
-systemtray-utils = "com.dorkbox:Utilities:1.39" # version locked by SystemTray
+systemtray-core = "com.dorkbox:SystemTray:4.1"
+systemtray-utils = "com.dorkbox:Utilities:1.9" # version locked by SystemTray
+systemtray-desktop = "com.dorkbox:Desktop:1.0"
 
 # dependencies of Tachiyomi extensions
 injekt = "com.github.inorichi.injekt:injekt-core:65b0440"
@@ -198,6 +199,7 @@ exposed = [
 systemtray = [
     "systemtray-core",
     "systemtray-utils",
+    "systemtray-desktop"
 ]
 rhino = [
     "rhino-runtime",

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/Browser.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/Browser.kt
@@ -7,7 +7,7 @@ package suwayomi.tachidesk.server.util
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import dorkbox.util.Desktop
+import dorkbox.desktop.Desktop
 import suwayomi.tachidesk.server.serverConfig
 
 object Browser {


### PR DESCRIPTION
This PR does the following:
* Updates Dex2Jar dependency to v59 to fix JitPack issues for v56-v58
* Adds dorkbox's [Desktop](https://github.com/dorkbox/Desktop) as a dependency since it was separated from Utilities dependecy in a recent [commit](https://github.com/dorkbox/Utilities/commit/4f3f6444f33b7f36d2606b3edb962a7b1e7e7eea)
* Adds [Fleet](https://www.jetbrains.com/fleet/)'s configuration folder to .gitignore