### PR TITLE
Update/Fix logging and update System Tray

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,13 +28,9 @@ serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-jso
 serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
 
 # Logging
-# Stuck on old versions since
-# 1. Logback 1.3.0+ requires Java 9
-# 2. Slf4j 2.0.0+ doesn't register older versions of Logback
-# 3. Kotlin-logging 3.0.2+ requires Java 11, but this is probably a bug
-slf4japi = "org.slf4j:slf4j-api:1.7.32"
-logback = "ch.qos.logback:logback-classic:1.2.6"
-kotlinlogging = "io.github.microutils:kotlin-logging:2.1.21"
+slf4japi = "org.slf4j:slf4j-api:2.0.6"
+logback = "ch.qos.logback:logback-classic:1.3.5"
+kotlinlogging = "io.github.microutils:kotlin-logging:3.0.5"
 
 # OkHttp
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
@@ -63,8 +59,8 @@ exposed-migrations = "com.github.Suwayomi:exposed-migrations:3.2.0"
 kodein = "org.kodein.di:kodein-di-conf-jvm:7.15.0"
 
 # tray icon
-systemtray-core = "com.dorkbox:SystemTray:4.1"
-systemtray-utils = "com.dorkbox:Utilities:1.9" # version locked by SystemTray
+systemtray-core = "com.dorkbox:SystemTray:4.2.1"
+systemtray-utils = "com.dorkbox:Utilities:1.39" # version locked by SystemTray
 systemtray-desktop = "com.dorkbox:Desktop:1.0"
 
 # dependencies of Tachiyomi extensions

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
@@ -51,8 +51,6 @@ object SystemTray {
                 }
             )
 
-            systemTray.installShutdownHook()
-
             return systemTray
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
Dorkbox SystemTray now automatically adds its shutdown hook, and removed the manual function
