### PR TITLE
Fixes Page index issues for some providers

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.local.LocalSource
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.coroutines.flow.StateFlow
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -49,8 +50,11 @@ object Page {
         val chapterId = chapterEntry[ChapterTable.id].value
 
         val pageEntry =
-            transaction { PageTable.select { (PageTable.chapter eq chapterId) and (PageTable.index eq index) }.first() }
-
+            transaction {
+                PageTable.select { (PageTable.chapter eq chapterId) }
+                    .orderBy(PageTable.index to SortOrder.ASC)
+                    .limit(1, index.toLong()).first()
+            }
         val tachiyomiPage = Page(
             pageEntry[PageTable.index],
             pageEntry[PageTable.url],


### PR DESCRIPTION
Fixes Page starting index issues for certain providers.

**Background**
Tachiyomi does not standardize the starting indexes for it's extensions. This has led to some extensions starting the Page indexs from 0 and others from 1. This causes the reader in Tachidesk to crash since the first api to get Page with index 0 fails
