### PR TITLE
Decouples Cache and Download behaviour

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -15,7 +15,6 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SortOrder.ASC
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.manga.impl.Manga.getManga
 import suwayomi.tachidesk.manga.impl.util.getChapterDir
@@ -312,9 +311,7 @@ object Chapter {
                 ChapterTable.select { (ChapterTable.manga eq mangaId) and (ChapterTable.sourceOrder eq chapterIndex) }
                     .first()[ChapterTable.id].value
 
-            val chapterDir = getChapterDir(mangaId, chapterId)
-
-            File(chapterDir).deleteRecursively()
+            ChapterDownloadHelper.delete(mangaId, chapterId)
 
             ChapterTable.update({ (ChapterTable.manga eq mangaId) and (ChapterTable.sourceOrder eq chapterIndex) }) {
                 it[isDownloaded] = false

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -1,0 +1,24 @@
+package suwayomi.tachidesk.manga.impl
+
+import suwayomi.tachidesk.manga.impl.download.DownloadedFilesProvider
+import suwayomi.tachidesk.manga.impl.download.FolderProvider
+import java.io.InputStream
+
+object ChapterDownloadHelper {
+    fun getImage(mangaId: Int, chapterId: Int, index: Int): Pair<InputStream, String> {
+        return provider(mangaId, chapterId).getImage(index)
+    }
+
+    fun delete(mangaId: Int, chapterId: Int): Boolean {
+        return provider(mangaId, chapterId).delete()
+    }
+
+    fun putImage(mangaId: Int, chapterId: Int, index: Int, image: InputStream): Boolean {
+        return provider(mangaId, chapterId).putImage(index, image)
+    }
+
+    // return the appropriate provider based on how the download was saved. For the logic is simple but will evolve when new types of downloads are available
+    private fun provider(mangaId: Int, chapterId: Int): DownloadedFilesProvider {
+        return FolderProvider(mangaId, chapterId)
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -5,7 +5,6 @@ import suwayomi.tachidesk.manga.impl.download.DownloadedFilesProvider
 import suwayomi.tachidesk.manga.impl.download.FolderProvider
 import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import java.io.InputStream
-import kotlin.reflect.KSuspendFunction2
 
 object ChapterDownloadHelper {
     fun getImage(mangaId: Int, chapterId: Int, index: Int): Pair<InputStream, String> {
@@ -21,7 +20,7 @@ object ChapterDownloadHelper {
         chapterId: Int,
         download: DownloadChapter,
         scope: CoroutineScope,
-        step: KSuspendFunction2<DownloadChapter?, Boolean, Unit>
+        step: suspend (DownloadChapter?, Boolean) -> Unit
     ): Boolean {
         return provider(mangaId, chapterId).download(download, scope, step)
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -1,8 +1,11 @@
 package suwayomi.tachidesk.manga.impl
 
+import kotlinx.coroutines.CoroutineScope
 import suwayomi.tachidesk.manga.impl.download.DownloadedFilesProvider
 import suwayomi.tachidesk.manga.impl.download.FolderProvider
+import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import java.io.InputStream
+import kotlin.reflect.KSuspendFunction2
 
 object ChapterDownloadHelper {
     fun getImage(mangaId: Int, chapterId: Int, index: Int): Pair<InputStream, String> {
@@ -13,8 +16,14 @@ object ChapterDownloadHelper {
         return provider(mangaId, chapterId).delete()
     }
 
-    fun putImage(mangaId: Int, chapterId: Int, index: Int, image: InputStream): Boolean {
-        return provider(mangaId, chapterId).putImage(index, image)
+    suspend fun download(
+        mangaId: Int,
+        chapterId: Int,
+        download: DownloadChapter,
+        scope: CoroutineScope,
+        step: KSuspendFunction2<DownloadChapter?, Boolean, Unit>
+    ): Boolean {
+        return provider(mangaId, chapterId).download(download, scope, step)
     }
 
     // return the appropriate provider based on how the download was saved. For the logic is simple but will evolve when new types of downloads are available

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -15,7 +15,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
-import suwayomi.tachidesk.manga.impl.util.getChapterDir
 import suwayomi.tachidesk.manga.impl.util.lang.awaitSingle
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse.getImageResponse
@@ -82,9 +81,11 @@ object Page {
             }
         }
 
-        val chapterDir = getChapterDir(mangaId, chapterId)
-        File(chapterDir).mkdirs()
         val fileName = getPageName(index)
+
+        if (chapterEntry[ChapterTable.isDownloaded]) {
+            return ChapterDownloadHelper.getImage(mangaId, chapterId, index)
+        }
 
         return getImageResponse(mangaId, chapterId, fileName, useCache) {
             source.fetchImage(tachiyomiPage).awaitSingle()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -86,7 +86,7 @@ object Page {
         File(chapterDir).mkdirs()
         val fileName = getPageName(index)
 
-        return getImageResponse(chapterDir, fileName, useCache) {
+        return getImageResponse(mangaId, chapterId, fileName, useCache) {
             source.fetchImage(tachiyomiPage).awaitSingle()
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
@@ -11,8 +11,4 @@ abstract class DownloadedFilesProvider(val mangaId: Int, val chapterId: Int) {
     abstract fun putImage(index: Int, image: InputStream): Boolean
 
     abstract fun delete(): Boolean
-
-    private fun getPageName(index: Int): String {
-        return String.format("%03d", index + 1)
-    }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
@@ -3,7 +3,6 @@ package suwayomi.tachidesk.manga.impl.download
 import kotlinx.coroutines.CoroutineScope
 import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import java.io.InputStream
-import kotlin.reflect.KSuspendFunction2
 
 /*
 * Base class for downloaded chapter files provider, example: Folder, Archive
@@ -14,7 +13,7 @@ abstract class DownloadedFilesProvider(val mangaId: Int, val chapterId: Int) {
     abstract suspend fun download(
         download: DownloadChapter,
         scope: CoroutineScope,
-        step: KSuspendFunction2<DownloadChapter?, Boolean, Unit>
+        step: suspend (DownloadChapter?, Boolean) -> Unit
     ): Boolean
 
     abstract fun delete(): Boolean

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
@@ -1,0 +1,18 @@
+package suwayomi.tachidesk.manga.impl.download
+
+import java.io.InputStream
+
+/*
+* Base class for downloaded chapter files provider, example: Folder, Archive
+* */
+abstract class DownloadedFilesProvider(val mangaId: Int, val chapterId: Int) {
+    abstract fun getImage(index: Int): Pair<InputStream, String>
+
+    abstract fun putImage(index: Int, image: InputStream): Boolean
+
+    abstract fun delete(): Boolean
+
+    private fun getPageName(index: Int): String {
+        return String.format("%03d", index + 1)
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadedFilesProvider.kt
@@ -1,6 +1,9 @@
 package suwayomi.tachidesk.manga.impl.download
 
+import kotlinx.coroutines.CoroutineScope
+import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import java.io.InputStream
+import kotlin.reflect.KSuspendFunction2
 
 /*
 * Base class for downloaded chapter files provider, example: Folder, Archive
@@ -8,7 +11,11 @@ import java.io.InputStream
 abstract class DownloadedFilesProvider(val mangaId: Int, val chapterId: Int) {
     abstract fun getImage(index: Int): Pair<InputStream, String>
 
-    abstract fun putImage(index: Int, image: InputStream): Boolean
+    abstract suspend fun download(
+        download: DownloadChapter,
+        scope: CoroutineScope,
+        step: KSuspendFunction2<DownloadChapter?, Boolean, Unit>
+    ): Boolean
 
     abstract fun delete(): Boolean
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -13,10 +13,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
@@ -24,7 +20,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import suwayomi.tachidesk.manga.impl.ChapterDownloadHelper
-import suwayomi.tachidesk.manga.impl.Page.getPageImage
 import suwayomi.tachidesk.manga.impl.chapter.getChapterDownloadReady
 import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import suwayomi.tachidesk.manga.impl.download.model.DownloadState.Downloading
@@ -96,35 +91,7 @@ class Downloader(
                 download.chapter = getChapterDownloadReady(download.chapterIndex, download.mangaId)
                 step(download, false)
 
-                val pageCount = download.chapter.pageCount
-                for (pageNum in 0 until pageCount) {
-                    var pageProgressJob: Job? = null
-                    try {
-                        val image = getPageImage(
-                            mangaId = download.mangaId,
-                            chapterIndex = download.chapterIndex,
-                            index = pageNum,
-                            progressFlow = { flow ->
-                                pageProgressJob = flow
-                                    .sample(100)
-                                    .distinctUntilChanged()
-                                    .onEach {
-                                        download.progress = (pageNum.toFloat() + (it.toFloat() * 0.01f)) / pageCount
-                                        step(null, false) // don't throw on canceled download here since we can't do anything
-                                    }
-                                    .launchIn(scope)
-                            }
-                        ).first
-                        ChapterDownloadHelper.putImage(download.mangaId, download.chapter.id, pageNum, image)
-                        image.close()
-                    } finally {
-                        // always cancel the page progress job even if it throws an exception to avoid memory leaks
-                        pageProgressJob?.cancel()
-                    }
-                    // TODO: retry on error with 2,4,8 seconds of wait
-                    download.progress = ((pageNum + 1).toFloat()) / pageCount
-                    step(download, false)
-                }
+                ChapterDownloadHelper.download(download.mangaId, download.chapter.id, download, scope, this::step)
                 download.state = Finished
                 transaction {
                     ChapterTable.update({ (ChapterTable.manga eq download.mangaId) and (ChapterTable.sourceOrder eq download.chapterIndex) }) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/FolderProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/FolderProvider.kt
@@ -1,0 +1,37 @@
+package suwayomi.tachidesk.manga.impl.download
+
+import suwayomi.tachidesk.manga.impl.Page.getPageName
+import suwayomi.tachidesk.manga.impl.util.getChapterDir
+import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+
+/*
+* Provides downloaded files when pages were downloaded into folders
+* */
+class FolderProvider(mangaId: Int, chapterId: Int) : DownloadedFilesProvider(mangaId, chapterId) {
+    override fun getImage(index: Int): Pair<InputStream, String> {
+        val chapterDir = getChapterDir(mangaId, chapterId)
+        val folder = File(chapterDir)
+        folder.mkdirs()
+        val file = folder.listFiles()?.get(index)
+        val fileType = file!!.name.substringAfterLast(".")
+        return Pair(FileInputStream(file).buffered(), "image/$fileType")
+    }
+
+    override fun putImage(index: Int, image: InputStream): Boolean {
+        val chapterDir = getChapterDir(mangaId, chapterId)
+        val folder = File(chapterDir)
+        folder.mkdirs()
+        val fileName = getPageName(index)
+        val filePath = "$chapterDir/$fileName"
+        ImageResponse.saveImage(filePath, image)
+        return true
+    }
+
+    override fun delete(): Boolean {
+        val chapterDir = getChapterDir(mangaId, chapterId)
+        return File(chapterDir).deleteRecursively()
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/FolderProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/FolderProvider.kt
@@ -1,11 +1,23 @@
 package suwayomi.tachidesk.manga.impl.download
 
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import suwayomi.tachidesk.manga.impl.Page
 import suwayomi.tachidesk.manga.impl.Page.getPageName
+import suwayomi.tachidesk.manga.impl.download.model.DownloadChapter
 import suwayomi.tachidesk.manga.impl.util.getChapterDir
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
+import kotlin.reflect.KSuspendFunction2
 
 /*
 * Provides downloaded files when pages were downloaded into folders
@@ -20,13 +32,48 @@ class FolderProvider(mangaId: Int, chapterId: Int) : DownloadedFilesProvider(man
         return Pair(FileInputStream(file).buffered(), "image/$fileType")
     }
 
-    override fun putImage(index: Int, image: InputStream): Boolean {
-        val chapterDir = getChapterDir(mangaId, chapterId)
-        val folder = File(chapterDir)
-        folder.mkdirs()
-        val fileName = getPageName(index)
-        val filePath = "$chapterDir/$fileName"
-        ImageResponse.saveImage(filePath, image)
+    @OptIn(FlowPreview::class)
+    override suspend fun download(
+        download: DownloadChapter,
+        scope: CoroutineScope,
+        step: KSuspendFunction2<DownloadChapter?, Boolean, Unit>
+    ): Boolean {
+        val pageCount = download.chapter.pageCount
+        for (pageNum in 0 until pageCount) {
+            var pageProgressJob: Job? = null
+            try {
+                val image = Page.getPageImage(
+                    mangaId = download.mangaId,
+                    chapterIndex = download.chapterIndex,
+                    index = pageNum,
+                    progressFlow = { flow ->
+                        pageProgressJob = flow
+                            .sample(100)
+                            .distinctUntilChanged()
+                            .onEach {
+                                download.progress = (pageNum.toFloat() + (it.toFloat() * 0.01f)) / pageCount
+                                step(null, false) // don't throw on canceled download here since we can't do anything
+                            }
+                            .launchIn(scope)
+                    }
+                ).first
+                val chapterDir = getChapterDir(mangaId, chapterId)
+                val folder = File(chapterDir)
+                folder.mkdirs()
+                val fileName = getPageName(pageNum) // might have to change this to index stored in database
+                val filePath = "$chapterDir/$fileName"
+                ImageResponse.saveImage(filePath, image)
+                withContext(Dispatchers.IO) {
+                    image.close()
+                }
+            } finally {
+                // always cancel the page progress job even if it throws an exception to avoid memory leaks
+                pageProgressJob?.cancel()
+            }
+            // TODO: retry on error with 2,4,8 seconds of wait
+            download.progress = ((pageNum + 1).toFloat()) / pageCount
+            step(download, false)
+        }
         return true
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/DirName.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/DirName.kt
@@ -7,6 +7,7 @@ package suwayomi.tachidesk.manga.impl.util
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.kodein.di.DI
@@ -21,17 +22,16 @@ import java.io.File
 
 private val applicationDirs by DI.global.instance<ApplicationDirs>()
 
-fun getMangaDir(mangaId: Int): String {
-    val mangaEntry = transaction { MangaTable.select { MangaTable.id eq mangaId }.first() }
+fun getMangaDir(mangaId: Int, cache: Boolean = false): String {
+    val mangaEntry = getMangaEntry(mangaId)
     val source = GetCatalogueSource.getCatalogueSourceOrStub(mangaEntry[MangaTable.sourceReference])
 
     val sourceDir = source.toString()
     val mangaDir = SafePath.buildValidFilename(mangaEntry[MangaTable.title])
-
-    return "${applicationDirs.mangaDownloadsRoot}/$sourceDir/$mangaDir"
+    return (if (cache) applicationDirs.cacheRoot else applicationDirs.mangaDownloadsRoot) + "/$sourceDir/$mangaDir"
 }
 
-fun getChapterDir(mangaId: Int, chapterId: Int): String {
+fun getChapterDir(mangaId: Int, chapterId: Int, cache: Boolean = false): String {
     val chapterEntry = transaction { ChapterTable.select { ChapterTable.id eq chapterId }.first() }
 
     val chapterDir = SafePath.buildValidFilename(
@@ -41,12 +41,12 @@ fun getChapterDir(mangaId: Int, chapterId: Int): String {
         }
     )
 
-    return getMangaDir(mangaId) + "/$chapterDir"
+    return getMangaDir(mangaId, cache) + "/$chapterDir"
 }
 
 /** return value says if rename/move was successful */
 fun updateMangaDownloadDir(mangaId: Int, newTitle: String): Boolean {
-    val mangaEntry = transaction { MangaTable.select { MangaTable.id eq mangaId }.first() }
+    val mangaEntry = getMangaEntry(mangaId)
     val source = GetCatalogueSource.getCatalogueSourceOrStub(mangaEntry[MangaTable.sourceReference])
 
     val sourceDir = source.toString()
@@ -65,4 +65,8 @@ fun updateMangaDownloadDir(mangaId: Int, newTitle: String): Boolean {
     } else {
         true
     }
+}
+
+private fun getMangaEntry(mangaId: Int): ResultRow {
+    return transaction { MangaTable.select { MangaTable.id eq mangaId }.first() }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -38,6 +38,7 @@ private val logger = KotlinLogging.logger {}
 class ApplicationDirs(
     val dataRoot: String = ApplicationRootDir
 ) {
+    val cacheRoot = System.getProperty("java.io.tmpdir") + "/tachidesk"
     val extensionsRoot = "$dataRoot/extensions"
     val thumbnailsRoot = "$dataRoot/thumbnails"
     val mangaDownloadsRoot = serverConfig.downloadsPath.ifBlank { "$dataRoot/downloads" }


### PR DESCRIPTION
# Decoupling Cache and Download behaviour

## Separating cache directory from Download directory
Tachidesk's caching and download logic are tightly coupled. This includes the cache directory being the same as download directory. Ideally the directory for files meant to be temporarily stored as cache should be the operating system's temp directory. The first change deals with changing the cache directory to the OS' temp directory

## Implementing a new Downloader logic
Now that cached files are stored in another place, the downloader relying on cache logic to store the page(image) files no longer works. To fix this we need to make the downloader self-reliant which only asks the ImageRespone to be in image and then stores the file to the download folder on it's own

## Technicals
All of this introduces a few new changes in the server:
1. Introduced `DownloadedFilesProvider` as an abstract class which sets up the struture for a provider that is responsible for handling downloaded files i.e. getting, putting and deleting pages.
2. Introduced `FileProvider` as the default provider implementing `DownloadedFilesProvider` that implements the default behaviour of saving each page as a separate image in the chapter folder inside downloads directory.
3. Introduced `ChapterDownloadHelper` object that works as a `DownloadedFilesProvider` factory which generates the appropriate provider object. This abstracts the complexity that each provider must implement to store it's own logic for the above mentioned tasks.