### PR TITLE
Send last read chapter in Mangas in Category API

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
@@ -81,6 +81,14 @@ object CategoryManga {
 
         val transform: (ResultRow) -> MangaDataClass = {
             val dataClass = MangaTable.toDataClass(it)
+            dataClass.lastChapterRead = ChapterTable.toDataClass(
+                transaction {
+                    ChapterTable
+                        .select { (ChapterTable.manga eq it[MangaTable.id].value) }
+                        .orderBy(ChapterTable.lastReadAt, SortOrder.DESC)
+                        .first()
+                }
+            )
             dataClass.unreadCount = it[unreadExpression]
             dataClass.downloadCount = it[downloadExpression]
             dataClass.chapterCount = it[chapterCountExpression]

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/ArchiveProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/ArchiveProvider.kt
@@ -33,7 +33,6 @@ class ArchiveProvider(mangaId: Int, chapterId: Int) : DownloadedFilesProvider(ma
         val chapterFolder = File(chapterDir)
         if (outputFile.exists()) handleExistingCbzFile(outputFile, chapterFolder)
 
-
         FolderProvider(mangaId, chapterId).download(download, scope, step)
 
         withContext(Dispatchers.IO) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/MangaDataClass.kt
@@ -45,6 +45,7 @@ data class MangaDataClass(
     var unreadCount: Long? = null,
     var downloadCount: Long? = null,
     var chapterCount: Long? = null,
+    var lastReadAt: Long? = null,
     var lastChapterRead: ChapterDataClass? = null,
 
     val age: Long? = if (lastFetchedAt == null) 0 else Instant.now().epochSecond.minus(lastFetchedAt),


### PR DESCRIPTION
# What
This PR starts sending last read chapter details in the manga object. The provision to send this was already there but was not utilized for some reason(perhaps performance reasons, but that's just speculation)

# Why
This will enable us to implement the sort by last read manga feature

# Performance report for API `api/v1/category/{categoryId}`
JS code used for benchmarking:
```javascript
var url = "http://127.0.0.1:4567/api/v1/category/0"
const numRequests = 10
let totalFetchTime = 0;

for (let i = 0; i < numRequests; i++) {
    const startTime = performance.now();
    fetch(url)
        .then(response => {
            const endTime = performance.now();
            const fetchTime = endTime - startTime;
            console.log(`Request ${i+1}: ${fetchTime} ms`);
            totalFetchTime += fetchTime;
        })
        .catch(error => console.error(error));
}

const averageFetchTime = totalFetchTime / numRequests;
console.log(`Average fetch time: ${averageFetchTime} ms`);
```
Total Number of Rows in Manga table: `909`

Total Number of Manga in Library: `93`

Total Number of Rows in Chapter table: `18760`

Total Number of Chapters for Mangas in Library: `18345`

## TIMINGS
### Optimized Query after Last Read Chapter change
Average Request time over 10 requests ran 3 times: `392.173333333 ms`
### Non Optimized query after Last Read Chapter change
Average Request time over 10 requests ran 3 times: `430.143333333 ms`
### Optimized Query without Last Read Chapter change
Average Request time over 10 requests ran 3 times: `286.22 ms`
### Optimized Query with new column instead of Chapter object
Average Request time over 10 requests ran 3 times: `304.553333333 ms`
### Baseline(master branch)
Average Request time over 10 requests ran 3 times: `315.47 ms`

Server Hardware details:
```
CPU: AMD Ryzen 9 5900X 12-Core Processor
RAM: 32GB DDR4 3200 MT/s
STORAGE: Samsung SSD 970 EVO Plus 500GB
```
