### PR TITLE
Fix random page sent when book is downloaded

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/ArchiveProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/ArchiveProvider.kt
@@ -33,7 +33,6 @@ class ArchiveProvider(mangaId: Int, chapterId: Int) : DownloadedFilesProvider(ma
         val chapterFolder = File(chapterDir)
         if (outputFile.exists()) handleExistingCbzFile(outputFile, chapterFolder)
 
-
         FolderProvider(mangaId, chapterId).download(download, scope, step)
 
         withContext(Dispatchers.IO) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/FolderProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/FolderProvider.kt
@@ -24,7 +24,7 @@ class FolderProvider(mangaId: Int, chapterId: Int) : DownloadedFilesProvider(man
         val chapterDir = getChapterDownloadPath(mangaId, chapterId)
         val folder = File(chapterDir)
         folder.mkdirs()
-        val file = folder.listFiles()?.get(index)
+        val file = folder.listFiles()?.sortedBy { it.name }?.get(index)
         val fileType = file!!.name.substringAfterLast(".")
         return Pair(FileInputStream(file).buffered(), "image/$fileType")
     }


### PR DESCRIPTION
# Fixes random pages being sent when a chapter is downloaded

## Steps to reproduce
1. In the master branch or release, download any chapter from any book while keeping download as cbz disabled
2. Go to read that downloaded chapter

### Expected behaviour
The pages should render in correct order

### Current behaviour
The pages are getting rendered randomly

The problem was the files were not being sorted before being read and sent. Now that's fixed