### PR TITLE
Feature/library update from source grouped by source

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -33,6 +33,9 @@ class ServerConfig(config: Config, moduleName: String = MODULE_NAME) : SystemPro
     val downloadAsCbz: Boolean by overridableConfig
     val downloadsPath: String by overridableConfig
 
+    // updater
+    val maxParallelUpdateRequests: Int by overridableConfig
+
     // Authentication
     val basicAuthEnabled: Boolean by overridableConfig
     val basicAuthUsername: String by overridableConfig

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -18,6 +18,9 @@ server.electronPath = ""
 server.downloadAsCbz = false
 server.downloadsPath = ""
 
+# updater
+server.maxParallelUpdateRequests = 10 # sets how many sources can be updated in parallel. updates are grouped by source and all mangas of a source are updated synchronously
+
 # Authentication
 server.basicAuthEnabled = false
 server.basicAuthUsername = ""

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -10,6 +10,9 @@ server.socksProxyPort = ""
 # downloader
 server.downloadAsCbz = false
 
+# updater
+server.maxParallelUpdateRequests = 10
+
 # misc
 server.debugLogsEnabled = true
 server.systemTrayEnabled = false


### PR DESCRIPTION
Update is currently done synchronously which can take a while.

With this change it's now done in parallel per source.
In case a library consists of mangas from many different sources, the max. parallel update requests are limited.

should fix #383 or at least improve it