### PR TITLE
Emit update to clients after adding all mangas to the queue

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/UpdateController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/UpdateController.kt
@@ -93,14 +93,13 @@ object UpdateController {
         if (clear) {
             updater.reset()
         }
-        categories
-            .flatMap { CategoryManga.getCategoryMangaList(it.id) }
-            .distinctBy { it.id }
-            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, MangaDataClass::title))
-            .filter { it.updateStrategy == UpdateStrategy.ALWAYS_UPDATE }
-            .forEach { manga ->
-                updater.addMangaToQueue(manga)
-            }
+        updater.addMangasToQueue(
+            categories
+                .flatMap { CategoryManga.getCategoryMangaList(it.id) }
+                .distinctBy { it.id }
+                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, MangaDataClass::title))
+                .filter { it.updateStrategy == UpdateStrategy.ALWAYS_UPDATE }
+        )
     }
 
     fun categoryUpdateWS(ws: WsConfig) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/IUpdater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/IUpdater.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.StateFlow
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 
 interface IUpdater {
-    fun addMangaToQueue(manga: MangaDataClass)
+    fun addMangasToQueue(mangas: List<MangaDataClass>)
     val status: StateFlow<UpdateStatus>
     fun reset()
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -74,13 +74,17 @@ class Updater : IUpdater {
         return tracker.values.toList()
     }
 
-    override fun addMangaToQueue(manga: MangaDataClass) {
+    override fun addMangasToQueue(mangas: List<MangaDataClass>) {
+        mangas.forEach { tracker[it.id] = UpdateJob(it) }
+        _status.update { UpdateStatus(tracker.values.toList(), true) }
+        mangas.forEach { addMangaToQueue(it) }
+    }
+
+    private fun addMangaToQueue(manga: MangaDataClass) {
         val updateChannel = getOrCreateUpdateChannelFor(manga.sourceId)
         scope.launch {
             updateChannel.send(UpdateJob(manga))
         }
-        tracker[manga.id] = UpdateJob(manga)
-        _status.update { UpdateStatus(tracker.values.toList(), true) }
     }
 
     override fun reset() {

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/update/TestUpdater.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/update/TestUpdater.kt
@@ -13,8 +13,8 @@ class TestUpdater : IUpdater {
     private val _status = MutableStateFlow(UpdateStatus())
     override val status: StateFlow<UpdateStatus> = _status.asStateFlow()
 
-    override fun addMangaToQueue(manga: MangaDataClass) {
-        updateQueue.add(UpdateJob(manga))
+    override fun addMangasToQueue(mangas: List<MangaDataClass>) {
+        mangas.forEach { updateQueue.add(UpdateJob(it)) }
         isRunning = true
         updateStatus()
     }


### PR DESCRIPTION
Emitting updates before all the mangas were added to the queue could lead to e.g. wrong progress calculation.