### PR TITLE
Feature/global update exclude mangas with state

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -35,6 +35,9 @@ class ServerConfig(getConfig: () -> Config, moduleName: String = MODULE_NAME) : 
 
     // updater
     var maxParallelUpdateRequests: Int by overridableConfig
+    var excludeUnreadChapters: Boolean by overridableConfig
+    var excludeNotStarted: Boolean by overridableConfig
+    var excludeCompleted: Boolean by overridableConfig
 
     // Authentication
     var basicAuthEnabled: Boolean by overridableConfig

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -20,6 +20,9 @@ server.downloadsPath = ""
 
 # updater
 server.maxParallelUpdateRequests = 10 # sets how many sources can be updated in parallel. updates are grouped by source and all mangas of a source are updated synchronously
+server.excludeUnreadChapters = true
+server.excludeNotStarted = true
+server.excludeCompleted = true
 
 # Authentication
 server.basicAuthEnabled = false

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -12,6 +12,9 @@ server.downloadAsCbz = false
 
 # updater
 server.maxParallelUpdateRequests = 10
+server.excludeUnreadChapters = true
+server.excludeNotStarted = true
+server.excludeCompleted = true
 
 # misc
 server.debugLogsEnabled = true


### PR DESCRIPTION
why a specific endpoint for global update settings:
 - settings are known unlike metadata set by the client
 - documented in swagger, otherwise, they would be "hidden" unless code gets checked
 - easier to use on client side