### PR TITLE
Feature/update default category handling

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -52,7 +52,7 @@ object Category {
         transaction {
             CategoryTable.update({ CategoryTable.id eq categoryId }) {
                 if (categoryId != DEFAULT_CATEGORY_ID && name != null && !name.equals(DEFAULT_CATEGORY_NAME, ignoreCase = true)) it[CategoryTable.name] = name
-                if (categoryId != DEFAULT_CATEGORY_ID && isDefault != null) it[CategoryTable.isDefault] = isDefault
+                if (isDefault != null) it[CategoryTable.isDefault] = isDefault
                 if (includeInUpdate != null) it[CategoryTable.includeInUpdate] = includeInUpdate
             }
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -21,7 +21,6 @@ import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
 import suwayomi.tachidesk.manga.model.table.CategoryMangaTable
 import suwayomi.tachidesk.manga.model.table.CategoryMetaTable
 import suwayomi.tachidesk.manga.model.table.CategoryTable
-import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
 
 object Category {
@@ -118,15 +117,8 @@ object Category {
 
     fun getCategorySize(categoryId: Int): Int {
         return transaction {
-            if (categoryId == DEFAULT_CATEGORY_ID) {
-                MangaTable
-                    .leftJoin(CategoryMangaTable)
-                    .select { MangaTable.inLibrary eq true }
-                    .andWhere { CategoryMangaTable.manga.isNull() }
-            } else {
-                CategoryMangaTable.select {
-                    CategoryMangaTable.category eq categoryId
-                }
+            CategoryMangaTable.select {
+                CategoryMangaTable.category eq categoryId
             }.count().toInt()
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -10,7 +10,6 @@ package suwayomi.tachidesk.manga.impl
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
@@ -97,15 +96,6 @@ object Category {
         }
     }
 
-    private fun needsDefaultCategory() = transaction {
-        MangaTable
-            .leftJoin(CategoryMangaTable)
-            .select { MangaTable.inLibrary eq true }
-            .andWhere { CategoryMangaTable.manga.isNull() }
-            .empty()
-            .not()
-    }
-
     const val DEFAULT_CATEGORY_ID = 0
     const val DEFAULT_CATEGORY_NAME = "Default"
 
@@ -113,13 +103,6 @@ object Category {
         return transaction {
             CategoryTable.selectAll()
                 .orderBy(CategoryTable.order to SortOrder.ASC)
-                .let {
-                    if (needsDefaultCategory()) {
-                        it
-                    } else {
-                        it.andWhere { CategoryTable.id neq DEFAULT_CATEGORY_ID }
-                    }
-                }
                 .map {
                     CategoryTable.toDataClass(it)
                 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -62,7 +62,6 @@ object Category {
      * Move the category from order number `from` to `to`
      */
     fun reorderCategory(from: Int, to: Int) {
-        if (from == 0 || to == 0) return
         transaction {
             val categories = CategoryTable.selectAll().orderBy(CategoryTable.order to SortOrder.ASC).toMutableList()
             categories.add(to - 1, categories.removeAt(from - 1))

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -87,7 +87,7 @@ object Category {
         transaction {
             CategoryTable.selectAll()
                 .orderBy(CategoryTable.order to SortOrder.ASC)
-                .sortedWith(compareBy({ it[CategoryTable.id].value != 0 }, { it[CategoryTable.order] }))
+                .sortedWith(compareBy { it[CategoryTable.order] })
                 .forEachIndexed { index, cat ->
                     CategoryTable.update({ CategoryTable.id eq cat[CategoryTable.id].value }) {
                         it[CategoryTable.order] = index

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
@@ -32,8 +32,9 @@ import suwayomi.tachidesk.manga.model.table.toDataClass
 
 object CategoryManga {
     fun addMangaToCategory(mangaId: Int, categoryId: Int) {
-        if (categoryId == DEFAULT_CATEGORY_ID) return
-        fun notAlreadyInCategory() = CategoryMangaTable.select { (CategoryMangaTable.category eq categoryId) and (CategoryMangaTable.manga eq mangaId) }.isEmpty()
+        fun notAlreadyInCategory() =
+            CategoryMangaTable.select { (CategoryMangaTable.category eq categoryId) and (CategoryMangaTable.manga eq mangaId) }
+                .isEmpty()
 
         transaction {
             if (notAlreadyInCategory()) {
@@ -46,7 +47,6 @@ object CategoryManga {
     }
 
     fun removeMangaFromCategory(mangaId: Int, categoryId: Int) {
-        if (categoryId == DEFAULT_CATEGORY_ID) return
         transaction {
             CategoryMangaTable.deleteWhere { (CategoryMangaTable.category eq categoryId) and (CategoryMangaTable.manga eq mangaId) }
         }
@@ -80,19 +80,11 @@ object CategoryManga {
 
         return transaction {
             // Fetch data from the MangaTable and join with the CategoryMangaTable, if a category is specified
-            val query = if (categoryId == DEFAULT_CATEGORY_ID) {
-                MangaTable
-                    .leftJoin(ChapterTable, { MangaTable.id }, { ChapterTable.manga })
-                    .leftJoin(CategoryMangaTable)
-                    .slice(columns = selectedColumns)
-                    .select { (MangaTable.inLibrary eq true) and CategoryMangaTable.category.isNull() }
-            } else {
-                MangaTable
-                    .innerJoin(CategoryMangaTable)
-                    .leftJoin(ChapterTable, { MangaTable.id }, { ChapterTable.manga })
-                    .slice(columns = selectedColumns)
-                    .select { (MangaTable.inLibrary eq true) and (CategoryMangaTable.category eq categoryId) }
-            }
+            val query = MangaTable
+                .innerJoin(CategoryMangaTable)
+                .leftJoin(ChapterTable, { MangaTable.id }, { ChapterTable.manga })
+                .slice(columns = selectedColumns)
+                .select { (MangaTable.inLibrary eq true) and (CategoryMangaTable.category eq categoryId) }
 
             // Join with the ChapterTable to fetch the last read chapter for each manga
             query.groupBy(*MangaTable.columns.toTypedArray()).map(transform)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
@@ -47,8 +47,15 @@ object CategoryManga {
     }
 
     fun removeMangaFromCategory(mangaId: Int, categoryId: Int) {
+        val mangaCategories = getMangaCategories(mangaId)
+        val addToDefaultCategory = mangaCategories.size == 1
+
         transaction {
             CategoryMangaTable.deleteWhere { (CategoryMangaTable.category eq categoryId) and (CategoryMangaTable.manga eq mangaId) }
+        }
+
+        if (addToDefaultCategory) {
+            addMangaToCategory(mangaId, DEFAULT_CATEGORY_ID)
         }
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
@@ -48,13 +48,18 @@ object CategoryManga {
 
     fun removeMangaFromCategory(mangaId: Int, categoryId: Int) {
         val mangaCategories = getMangaCategories(mangaId)
-        val addToDefaultCategory = mangaCategories.size == 1
+        val willHaveNoCategoryAfterRemoval = mangaCategories.size == 1
+        val isOnlyInDefaultCategory = willHaveNoCategoryAfterRemoval && mangaCategories[0].id == DEFAULT_CATEGORY_ID
+
+        if (isOnlyInDefaultCategory) {
+            throw IllegalArgumentException("Default category can not be removed if it is the only category")
+        }
 
         transaction {
             CategoryMangaTable.deleteWhere { (CategoryMangaTable.category eq categoryId) and (CategoryMangaTable.manga eq mangaId) }
         }
 
-        if (addToDefaultCategory) {
+        if (willHaveNoCategoryAfterRemoval) {
             addMangaToCategory(mangaId, DEFAULT_CATEGORY_ID)
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Library.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Library.kt
@@ -7,7 +7,6 @@ package suwayomi.tachidesk.manga.impl
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -23,9 +22,8 @@ object Library {
         val manga = getManga(mangaId)
         if (!manga.inLibrary) {
             transaction {
-                val defaultCategories = CategoryTable.select {
-                    (CategoryTable.isDefault eq true) and (CategoryTable.id neq Category.DEFAULT_CATEGORY_ID)
-                }.toList()
+                val defaultCategory = CategoryTable.select { (CategoryTable.id eq Category.DEFAULT_CATEGORY_ID) }
+                val defaultCategories = CategoryTable.select { (CategoryTable.isDefault eq true) }.toList().ifEmpty { defaultCategory }
                 val existingCategories = CategoryMangaTable.select { CategoryMangaTable.manga eq mangaId }.toList()
 
                 MangaTable.update({ MangaTable.id eq manga.id }) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0030_IncludeDefaultCategoryMangaMappingInCategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0030_IncludeDefaultCategoryMangaMappingInCategoryManga.kt
@@ -1,0 +1,10 @@
+package suwayomi.tachidesk.server.database.migration
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+
+@Suppress("ClassName", "unused")
+class M0030_IncludeDefaultCategoryMangaMappingInCategoryManga : SQLMigration() {
+    override val sql: String = """
+       INSERT INTO CATEGORYMANGA (CATEGORY, MANGA) SELECT 0, ID FROM MANGA WHERE IN_LIBRARY AND ID NOT IN (SELECT MANGA FROM CATEGORYMANGA) 
+    """.trimIndent()
+}


### PR DESCRIPTION
**should be merged after #574 and has to be updated before merge due to database migration with the same ID**

 - always return the "default" category
   - to be able to change the order
   - to be able to change settings (without additional logic needed on UI side)
     - "isDefault" flag
     - "includeInUpdate" flag
 - handle "default" category mapping in "CategoryManga" table
   - simplifies "default" category handling
   - makes it possible to have mangas in "default" and other categories simultaneously
