### PR TITLE
Do not count mangas as part of categories that aren't in the library

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -142,9 +142,8 @@ object Category {
                     .select { MangaTable.inLibrary eq true }
                     .andWhere { CategoryMangaTable.manga.isNull() }
             } else {
-                CategoryMangaTable.select {
-                    CategoryMangaTable.category eq categoryId
-                }
+                CategoryMangaTable.leftJoin(MangaTable).select { CategoryMangaTable.category eq categoryId }
+                    .andWhere { MangaTable.inLibrary eq true }
             }.count().toInt()
         }
     }


### PR DESCRIPTION
Otherwise, the "size" calculation of categories is wrong, since it includes mangas that aren't in the library anymore and won't be returned in the list of mangas of a category