### PR TITLE
Delete tmp files on request failure

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageResponse.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageResponse.kt
@@ -57,6 +57,7 @@ object ImageResponse {
             return pathToInputStream(actualSavePath) to imageType
         } else {
             response.closeQuietly()
+            clearCachedImage(saveDir, fileName)
             throw Exception("request error! ${response.code}")
         }
     }


### PR DESCRIPTION
In case the image request failed, the tmp file would still exist and would get returned as an "existing" image on the next request for the same image