### PR TITLE
Exclude "default" category from reordering

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -65,7 +65,7 @@ object Category {
     fun reorderCategory(from: Int, to: Int) {
         if (from == 0 || to == 0) return
         transaction {
-            val categories = CategoryTable.selectAll().orderBy(CategoryTable.order to SortOrder.ASC).toMutableList()
+            val categories = CategoryTable.select { CategoryTable.id neq DEFAULT_CATEGORY_ID }.orderBy(CategoryTable.order to SortOrder.ASC).toMutableList()
             categories.add(to - 1, categories.removeAt(from - 1))
             categories.forEachIndexed { index, cat ->
                 CategoryTable.update({ CategoryTable.id eq cat[CategoryTable.id].value }) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -72,6 +72,7 @@ object Category {
                     it[CategoryTable.order] = index + 1
                 }
             }
+            normalizeCategories()
         }
     }
 


### PR DESCRIPTION
Due to the "default" category having been added to the database, the index based approach to reorder the categories didn't work anymore. In case one tried to move a category to or from pos 1, the default category was selected due to being at index 0