### PR TITLE
Feature/move server frontend mapping to the frontend

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -105,12 +105,7 @@ buildConfig {
     buildConfigField("String", "BUILD_TYPE", quoteWrap(if (System.getenv("ProductBuildType") == "Stable") "Stable" else "Preview"))
     buildConfigField("long", "BUILD_TIME", Instant.now().epochSecond.toString())
 
-
-    buildConfigField("String", "WEBUI_REPO", quoteWrap("https://github.com/Suwayomi/Tachidesk-WebUI-preview"))
     buildConfigField("String", "WEBUI_TAG", quoteWrap(webUIRevisionTag))
-    buildConfigField("String", "WEBUI_VERSION_MAPPING_URL", quoteWrap("https://raw.githubusercontent.com/Suwayomi/Tachidesk-WebUI/master/src/versionToServerVersionMapping.json"))
-    buildConfigField("String", "WEBUI_LATEST_RELEASE_INFO_URL", quoteWrap("https://api.github.com/repos/Suwayomi/Tachidesk-WebUI-preview/releases/latest"))
-
 
     buildConfigField("String", "GITHUB", quoteWrap("https://github.com/Suwayomi/Tachidesk-Server"))
     buildConfigField("String", "DISCORD", quoteWrap("https://discord.gg/DDZdqZWaHA"))

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -108,6 +108,8 @@ buildConfig {
 
     buildConfigField("String", "WEBUI_REPO", quoteWrap("https://github.com/Suwayomi/Tachidesk-WebUI-preview"))
     buildConfigField("String", "WEBUI_TAG", quoteWrap(webUIRevisionTag))
+    buildConfigField("String", "WEBUI_VERSION_MAPPING_URL", quoteWrap("https://raw.githubusercontent.com/Suwayomi/Tachidesk-WebUI/master/src/versionToServerVersionMapping.json"))
+    buildConfigField("String", "WEBUI_LATEST_RELEASE_INFO_URL", quoteWrap("https://api.github.com/repos/Suwayomi/Tachidesk-WebUI-preview/releases/latest"))
 
 
     buildConfigField("String", "GITHUB", quoteWrap("https://github.com/Suwayomi/Tachidesk-Server"))

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -47,7 +47,7 @@ object JavalinSetup {
     fun javalinSetup() {
         val app = Javalin.create { config ->
             if (serverConfig.webUIEnabled) {
-                WebInterfaceManager.setupWebInterface()
+                WebInterfaceManager.setupWebUI()
 
                 logger.info { "Serving web static files for ${serverConfig.webUIFlavor}" }
                 config.addStaticFiles(applicationDirs.webUIRoot, Location.EXTERNAL)

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -27,7 +27,7 @@ import suwayomi.tachidesk.global.GlobalAPI
 import suwayomi.tachidesk.graphql.GraphQL
 import suwayomi.tachidesk.manga.MangaAPI
 import suwayomi.tachidesk.server.util.Browser
-import suwayomi.tachidesk.server.util.setupWebInterface
+import suwayomi.tachidesk.server.util.WebInterfaceManager
 import java.io.IOException
 import java.lang.IllegalArgumentException
 import java.util.concurrent.CompletableFuture
@@ -47,7 +47,7 @@ object JavalinSetup {
     fun javalinSetup() {
         val app = Javalin.create { config ->
             if (serverConfig.webUIEnabled) {
-                setupWebInterface()
+                WebInterfaceManager.setupWebInterface()
 
                 logger.info { "Serving web static files for ${serverConfig.webUIFlavor}" }
                 config.addStaticFiles(applicationDirs.webUIRoot, Location.EXTERNAL)

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -29,7 +29,7 @@ class ServerConfig(getConfig: () -> Config, moduleName: String = MODULE_NAME) : 
     var webUIInterface: String by overridableConfig
     var electronPath: String by overridableConfig
     var webUIChannel: String by overridableConfig
-    var webUIAutoUpdate: Boolean by overridableConfig
+    var webUIUpdateCheckInterval: Double by overridableConfig
 
     // downloader
     var downloadAsCbz: Boolean by overridableConfig

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -28,6 +28,8 @@ class ServerConfig(getConfig: () -> Config, moduleName: String = MODULE_NAME) : 
     var initialOpenInBrowserEnabled: Boolean by overridableConfig
     var webUIInterface: String by overridableConfig
     var electronPath: String by overridableConfig
+    var webUIChannel: String by overridableConfig
+    var webUIAutoUpdate: Boolean by overridableConfig
 
     // downloader
     var downloadAsCbz: Boolean by overridableConfig

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -380,7 +380,7 @@ object WebInterfaceManager {
 
     private fun extractDownload(zipFilePath: String, targetPath: String) {
         File(targetPath).mkdirs()
-        ZipFile(zipFilePath).extractAll(targetPath)
+        ZipFile(zipFilePath).use { it.extractAll(targetPath) }
     }
 
     fun isUpdateAvailable(currentVersion: String): Boolean {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -7,32 +7,92 @@ package suwayomi.tachidesk.server.util
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
 import net.lingala.zip4j.ZipFile
+import org.json.JSONArray
 import org.kodein.di.DI
 import org.kodein.di.conf.global
 import org.kodein.di.instance
 import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.BuildConfig
 import suwayomi.tachidesk.server.serverConfig
-import uy.kohesive.injekt.injectLazy
 import java.io.File
-import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
-private val logger = KotlinLogging.logger {}
 private val applicationDirs by DI.global.instance<ApplicationDirs>()
-private val json: Json by injectLazy()
 private val tmpDir = System.getProperty("java.io.tmpdir")
 
 private fun ByteArray.toHex(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
 
+enum class WebUIChannel {
+    BUNDLED, // the version bundled with the server release
+    STABLE,
+    PREVIEW;
+
+    companion object {
+        fun doesConfigChannelEqual(channel: WebUIChannel): Boolean {
+            return serverConfig.webUIChannel.equals(channel.toString(), true)
+        }
+    }
+}
+
 object WebInterfaceManager {
-    private fun directoryMD5(fileDir: String): String {
+    private val logger = KotlinLogging.logger {}
+    private const val webUIPreviewVersion = "PREVIEW"
+    private const val baseReleasesUrl = "${BuildConfig.WEBUI_REPO}/releases"
+    private const val downloadSpecificVersionBaseUrl = "$baseReleasesUrl/download"
+    private const val downloadLatestVersionBaseUrl = "$baseReleasesUrl/latest/download"
+
+    fun setupWebUI() {
+        if (serverConfig.webUIFlavor == "Custom") {
+            return
+        }
+
+        // check if we have webUI installed and is correct version
+        val webUIRevisionFile = File(applicationDirs.webUIRoot + "/revision")
+        val webUIExists = webUIRevisionFile.exists()
+
+        if (webUIExists) {
+            val currentVersion = webUIRevisionFile.readText().trim()
+
+            logger.info { "WebUI Static files exists, version= $currentVersion" }
+            logger.info { "Verifying WebUI Static files..." }
+
+            val localMD5Sum = getLocalMD5Sum(applicationDirs.webUIRoot)
+            val currentVersionMD5Sum = fetchMD5SumFor(currentVersion)
+            val validationFailed = currentVersionMD5Sum != localMD5Sum
+
+            logger.info { "Validation ${if (validationFailed) "failed" else "succeeded"} - md5: local= $localMD5Sum; expected= $currentVersionMD5Sum" }
+
+            if (validationFailed) {
+                downloadLatestCompatibleVersion()
+                return
+            }
+
+            if (serverConfig.webUIAutoUpdate && isUpdateAvailable(currentVersion)) {
+                logger.info { "An update is available, starting download..." }
+                downloadLatestCompatibleVersion()
+            }
+
+            return
+        }
+
+        logger.info { "No WebUI Static files found, starting download..." }
+        downloadLatestCompatibleVersion()
+    }
+
+    private fun getDownloadUrlFor(version: String): String {
+        return if (version == webUIPreviewVersion) downloadLatestVersionBaseUrl else "$downloadSpecificVersionBaseUrl/$version"
+    }
+
+    private fun getLocalMD5Sum(fileDir: String): String {
         var sum = ""
         File(fileDir).walk().toList().sortedBy { it.path }.forEach { file ->
             if (file.isFile) {
@@ -49,90 +109,123 @@ object WebInterfaceManager {
         return digest.toHex()
     }
 
-    /** Make sure a valid web interface installation is available */
-    fun setupWebInterface() {
-        when (serverConfig.webUIFlavor) {
-            "WebUI" -> setupWebUI()
-            "Custom" -> {
-                /* do nothing */
-            }
-            else -> setupWebUI()
+    private fun fetchMD5SumFor(version: String): String {
+        return try {
+            val url = "${getDownloadUrlFor(version)}/md5sum"
+            URL(url).readText().trim()
+        } catch (e: Exception) {
+            ""
         }
     }
 
-    /** Make sure a valid copy of WebUI is available */
-    fun setupWebUI() {
-        // check if we have webUI installed and is correct version
-        val webUIRevisionFile = File(applicationDirs.webUIRoot + "/revision")
-        if (webUIRevisionFile.exists() && webUIRevisionFile.readText().trim() == BuildConfig.WEBUI_TAG) {
-            logger.info { "WebUI Static files exists and is the correct revision" }
-            logger.info { "Verifying WebUI Static files..." }
-            logger.info { "md5: " + directoryMD5(applicationDirs.webUIRoot) }
-        } else {
-            File(applicationDirs.webUIRoot).deleteRecursively()
+    private fun extractVersion(versionString: String): Int {
+        // version string is of format "r<number>"
+        return versionString.substring(1).toInt()
+    }
 
-            val webUIZip = "Tachidesk-WebUI-${BuildConfig.WEBUI_TAG}.zip"
-            val webUIZipPath = "$tmpDir/$webUIZip"
-            val webUIZipFile = File(webUIZipPath)
+    private fun fetchPreviewVersion(): String {
+        val releaseInfoJson = URL(BuildConfig.WEBUI_LATEST_RELEASE_INFO_URL).readText()
+        return Json.decodeFromString<JsonObject>(releaseInfoJson)["tag_name"]?.jsonPrimitive?.content ?: ""
+    }
 
-            // try with resources first
-            val resourceWebUI: InputStream? = try {
-                BuildConfig::class.java.getResourceAsStream("/WebUI.zip")
-            } catch (e: NullPointerException) {
-                logger.info { "No bundled WebUI.zip found!" }
-                null
+    private fun getLatestCompatibleVersion(): String {
+        if (WebUIChannel.doesConfigChannelEqual(WebUIChannel.BUNDLED)) {
+            return BuildConfig.WEBUI_TAG
+        }
+
+        val currentServerVersionNumber = extractVersion(BuildConfig.REVISION)
+        val webUIToServerVersionMappings = JSONArray(URL(BuildConfig.WEBUI_VERSION_MAPPING_URL).readText())
+
+        logger.debug { "webUIChannel= ${serverConfig.webUIChannel} currentServerVersion= ${BuildConfig.REVISION}, mappingFile= $webUIToServerVersionMappings" }
+
+        for (i in 0 until webUIToServerVersionMappings.length()) {
+            val webUIToServerVersionEntry = webUIToServerVersionMappings.getJSONObject(i)
+            val webUIVersion = webUIToServerVersionEntry.getString("uiVersion")
+            val minServerVersionString = webUIToServerVersionEntry.getString("serverVersion")
+            val minServerVersionNumber = extractVersion(minServerVersionString)
+
+            val ignorePreviewVersion = !WebUIChannel.doesConfigChannelEqual(WebUIChannel.PREVIEW) && webUIVersion == webUIPreviewVersion
+            if (ignorePreviewVersion) {
+                continue
             }
 
-            if (resourceWebUI == null) { // is not bundled
-                // download webUI zip
-                val webUIZipURL = "${BuildConfig.WEBUI_REPO}/releases/download/${BuildConfig.WEBUI_TAG}/$webUIZip"
-                webUIZipFile.delete()
+            val isCompatibleVersion = minServerVersionNumber <= currentServerVersionNumber
+            if (isCompatibleVersion) {
+                return webUIVersion
+            }
+        }
 
-                logger.info { "Downloading WebUI zip from the Internet..." }
-                val data = ByteArray(1024)
+        throw Exception("No compatible webUI version found")
+    }
 
-                webUIZipFile.outputStream().use { webUIZipFileOut ->
+    fun downloadLatestCompatibleVersion() {
+        val latestCompatibleVersion = try {
+            val version = getLatestCompatibleVersion()
 
-                    val connection = URL(webUIZipURL).openConnection() as HttpURLConnection
-                    connection.connect()
-                    val contentLength = connection.contentLength
-
-                    connection.inputStream.buffered().use { inp ->
-                        var totalCount = 0
-
-                        print("Download progress: % 00")
-                        while (true) {
-                            val count = inp.read(data, 0, 1024)
-
-                            if (count == -1) {
-                                break
-                            }
-
-                            totalCount += count
-                            val percentage = (totalCount.toFloat() / contentLength * 100).toInt().toString().padStart(2, '0')
-                            print("\b\b$percentage")
-
-                            webUIZipFileOut.write(data, 0, count)
-                        }
-                        println()
-                        logger.info { "Downloading WebUI Done." }
-                    }
-                }
+            if (version == webUIPreviewVersion) {
+                fetchPreviewVersion()
             } else {
-                logger.info { "Using the bundled WebUI zip..." }
-
-                resourceWebUI.use { input ->
-                    webUIZipFile.outputStream().use { output ->
-                        input.copyTo(output)
-                    }
-                }
+                version
             }
+        } catch (e: Exception) {
+            BuildConfig.WEBUI_TAG
+        }
 
-            // extract webUI zip
-            logger.info { "Extracting WebUI zip..." }
-            File(applicationDirs.webUIRoot).mkdirs()
-            ZipFile(webUIZipPath).extractAll(applicationDirs.webUIRoot)
-            logger.info { "Extracting WebUI zip Done." }
+        File(applicationDirs.webUIRoot).deleteRecursively()
+
+        val webUIZip = "Tachidesk-WebUI-$latestCompatibleVersion.zip"
+        val webUIZipPath = "$tmpDir/$webUIZip"
+        val webUIZipFile = File(webUIZipPath)
+
+        // download webUI zip
+        val webUIZipURL = "${getDownloadUrlFor(latestCompatibleVersion)}/$webUIZip"
+        webUIZipFile.delete()
+
+        logger.info { "Downloading WebUI (version \"$latestCompatibleVersion\") zip from the Internet..." }
+        val data = ByteArray(1024)
+
+        webUIZipFile.outputStream().use { webUIZipFileOut ->
+
+            val connection = URL(webUIZipURL).openConnection() as HttpURLConnection
+            connection.connect()
+            val contentLength = connection.contentLength
+
+            connection.inputStream.buffered().use { inp ->
+                var totalCount = 0
+
+                print("Download progress: % 00")
+                while (true) {
+                    val count = inp.read(data, 0, 1024)
+
+                    if (count == -1) {
+                        break
+                    }
+
+                    totalCount += count
+                    val percentage =
+                        (totalCount.toFloat() / contentLength * 100).toInt().toString().padStart(2, '0')
+                    print("\b\b$percentage")
+
+                    webUIZipFileOut.write(data, 0, count)
+                }
+                println()
+                logger.info { "Downloading WebUI Done." }
+            }
+        }
+
+        // extract webUI zip
+        logger.info { "Extracting WebUI zip..." }
+        File(applicationDirs.webUIRoot).mkdirs()
+        ZipFile(webUIZipPath).extractAll(applicationDirs.webUIRoot)
+        logger.info { "Extracting WebUI zip Done." }
+    }
+
+    fun isUpdateAvailable(currentVersion: String): Boolean {
+        return try {
+            val latestCompatibleVersion = getLatestCompatibleVersion()
+            latestCompatibleVersion != currentVersion
+        } catch (e: Exception) {
+            false
         }
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -31,106 +31,108 @@ private val tmpDir = System.getProperty("java.io.tmpdir")
 
 private fun ByteArray.toHex(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
 
-private fun directoryMD5(fileDir: String): String {
-    var sum = ""
-    File(fileDir).walk().toList().sortedBy { it.path }.forEach { file ->
-        if (file.isFile) {
-            val md5 = MessageDigest.getInstance("MD5")
-            md5.update(file.readBytes())
-            val digest = md5.digest()
-            sum += digest.toHex()
-        }
-    }
-
-    val md5 = MessageDigest.getInstance("MD5")
-    md5.update(sum.toByteArray(StandardCharsets.UTF_8))
-    val digest = md5.digest()
-    return digest.toHex()
-}
-
-/** Make sure a valid web interface installation is available */
-fun setupWebInterface() {
-    when (serverConfig.webUIFlavor) {
-        "WebUI" -> setupWebUI()
-        "Custom" -> {
-            /* do nothing */
-        }
-        else -> setupWebUI()
-    }
-}
-
-/** Make sure a valid copy of WebUI is available */
-fun setupWebUI() {
-    // check if we have webUI installed and is correct version
-    val webUIRevisionFile = File(applicationDirs.webUIRoot + "/revision")
-    if (webUIRevisionFile.exists() && webUIRevisionFile.readText().trim() == BuildConfig.WEBUI_TAG) {
-        logger.info { "WebUI Static files exists and is the correct revision" }
-        logger.info { "Verifying WebUI Static files..." }
-        logger.info { "md5: " + directoryMD5(applicationDirs.webUIRoot) }
-    } else {
-        File(applicationDirs.webUIRoot).deleteRecursively()
-
-        val webUIZip = "Tachidesk-WebUI-${BuildConfig.WEBUI_TAG}.zip"
-        val webUIZipPath = "$tmpDir/$webUIZip"
-        val webUIZipFile = File(webUIZipPath)
-
-        // try with resources first
-        val resourceWebUI: InputStream? = try {
-            BuildConfig::class.java.getResourceAsStream("/WebUI.zip")
-        } catch (e: NullPointerException) {
-            logger.info { "No bundled WebUI.zip found!" }
-            null
-        }
-
-        if (resourceWebUI == null) { // is not bundled
-            // download webUI zip
-            val webUIZipURL = "${BuildConfig.WEBUI_REPO}/releases/download/${BuildConfig.WEBUI_TAG}/$webUIZip"
-            webUIZipFile.delete()
-
-            logger.info { "Downloading WebUI zip from the Internet..." }
-            val data = ByteArray(1024)
-
-            webUIZipFile.outputStream().use { webUIZipFileOut ->
-
-                val connection = URL(webUIZipURL).openConnection() as HttpURLConnection
-                connection.connect()
-                val contentLength = connection.contentLength
-
-                connection.inputStream.buffered().use { inp ->
-                    var totalCount = 0
-
-                    print("Download progress: % 00")
-                    while (true) {
-                        val count = inp.read(data, 0, 1024)
-
-                        if (count == -1) {
-                            break
-                        }
-
-                        totalCount += count
-                        val percentage = (totalCount.toFloat() / contentLength * 100).toInt().toString().padStart(2, '0')
-                        print("\b\b$percentage")
-
-                        webUIZipFileOut.write(data, 0, count)
-                    }
-                    println()
-                    logger.info { "Downloading WebUI Done." }
-                }
+object WebInterfaceManager {
+    private fun directoryMD5(fileDir: String): String {
+        var sum = ""
+        File(fileDir).walk().toList().sortedBy { it.path }.forEach { file ->
+            if (file.isFile) {
+                val md5 = MessageDigest.getInstance("MD5")
+                md5.update(file.readBytes())
+                val digest = md5.digest()
+                sum += digest.toHex()
             }
+        }
+
+        val md5 = MessageDigest.getInstance("MD5")
+        md5.update(sum.toByteArray(StandardCharsets.UTF_8))
+        val digest = md5.digest()
+        return digest.toHex()
+    }
+
+    /** Make sure a valid web interface installation is available */
+    fun setupWebInterface() {
+        when (serverConfig.webUIFlavor) {
+            "WebUI" -> setupWebUI()
+            "Custom" -> {
+                /* do nothing */
+            }
+            else -> setupWebUI()
+        }
+    }
+
+    /** Make sure a valid copy of WebUI is available */
+    fun setupWebUI() {
+        // check if we have webUI installed and is correct version
+        val webUIRevisionFile = File(applicationDirs.webUIRoot + "/revision")
+        if (webUIRevisionFile.exists() && webUIRevisionFile.readText().trim() == BuildConfig.WEBUI_TAG) {
+            logger.info { "WebUI Static files exists and is the correct revision" }
+            logger.info { "Verifying WebUI Static files..." }
+            logger.info { "md5: " + directoryMD5(applicationDirs.webUIRoot) }
         } else {
-            logger.info { "Using the bundled WebUI zip..." }
+            File(applicationDirs.webUIRoot).deleteRecursively()
 
-            resourceWebUI.use { input ->
-                webUIZipFile.outputStream().use { output ->
-                    input.copyTo(output)
+            val webUIZip = "Tachidesk-WebUI-${BuildConfig.WEBUI_TAG}.zip"
+            val webUIZipPath = "$tmpDir/$webUIZip"
+            val webUIZipFile = File(webUIZipPath)
+
+            // try with resources first
+            val resourceWebUI: InputStream? = try {
+                BuildConfig::class.java.getResourceAsStream("/WebUI.zip")
+            } catch (e: NullPointerException) {
+                logger.info { "No bundled WebUI.zip found!" }
+                null
+            }
+
+            if (resourceWebUI == null) { // is not bundled
+                // download webUI zip
+                val webUIZipURL = "${BuildConfig.WEBUI_REPO}/releases/download/${BuildConfig.WEBUI_TAG}/$webUIZip"
+                webUIZipFile.delete()
+
+                logger.info { "Downloading WebUI zip from the Internet..." }
+                val data = ByteArray(1024)
+
+                webUIZipFile.outputStream().use { webUIZipFileOut ->
+
+                    val connection = URL(webUIZipURL).openConnection() as HttpURLConnection
+                    connection.connect()
+                    val contentLength = connection.contentLength
+
+                    connection.inputStream.buffered().use { inp ->
+                        var totalCount = 0
+
+                        print("Download progress: % 00")
+                        while (true) {
+                            val count = inp.read(data, 0, 1024)
+
+                            if (count == -1) {
+                                break
+                            }
+
+                            totalCount += count
+                            val percentage = (totalCount.toFloat() / contentLength * 100).toInt().toString().padStart(2, '0')
+                            print("\b\b$percentage")
+
+                            webUIZipFileOut.write(data, 0, count)
+                        }
+                        println()
+                        logger.info { "Downloading WebUI Done." }
+                    }
+                }
+            } else {
+                logger.info { "Using the bundled WebUI zip..." }
+
+                resourceWebUI.use { input ->
+                    webUIZipFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
                 }
             }
-        }
 
-        // extract webUI zip
-        logger.info { "Extracting WebUI zip..." }
-        File(applicationDirs.webUIRoot).mkdirs()
-        ZipFile(webUIZipPath).extractAll(applicationDirs.webUIRoot)
-        logger.info { "Extracting WebUI zip Done." }
+            // extract webUI zip
+            logger.info { "Extracting WebUI zip..." }
+            File(applicationDirs.webUIRoot).mkdirs()
+            ZipFile(webUIZipPath).extractAll(applicationDirs.webUIRoot)
+            logger.info { "Extracting WebUI zip Done." }
+        }
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -196,6 +196,10 @@ object WebInterfaceManager {
         try {
             val webUIZipURL = "${getDownloadUrlFor(latestCompatibleVersion)}/$webUIZip"
             downloadVersion(webUIZipURL, webUIZipFile)
+
+            if (!isDownloadValid(webUIZip, webUIZipPath)) {
+                throw Exception("Download is invalid")
+            }
         } catch (e: Exception) {
             val retry = retryCount < 3
             logger.error { "Download failed${if (retry) ", retrying ${retryCount + 1}/3" else ""} - error: $e" }
@@ -247,6 +251,18 @@ object WebInterfaceManager {
                 logger.info { "Downloading WebUI Done." }
             }
         }
+    }
+
+    private fun isDownloadValid(zipFileName: String, zipFilePath: String): Boolean {
+        val tempUnzippedWebUIFolderPath = zipFileName.replace(".zip", "")
+
+        extractDownload(zipFilePath, tempUnzippedWebUIFolderPath)
+
+        val isDownloadValid = isLocalWebUIValid(tempUnzippedWebUIFolderPath)
+
+        File(tempUnzippedWebUIFolderPath).deleteRecursively()
+
+        return isDownloadValid
     }
 
     private fun extractDownload(zipFilePath: String, targetPath: String) {

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -13,6 +13,8 @@ server.webUIFlavor = "WebUI" # "WebUI" or "Custom"
 server.initialOpenInBrowserEnabled = true
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""
+server.webUIChannel = "stable" # "bundled" (the version bundled with the server release), "stable" or "preview" - the webUI version that should be used
+server.webUIAutoUpdate = true # if the server should automatically check for and download webUI updates
 
 # downloader
 server.downloadAsCbz = false

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -14,7 +14,7 @@ server.initialOpenInBrowserEnabled = true
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""
 server.webUIChannel = "stable" # "bundled" (the version bundled with the server release), "stable" or "preview" - the webUI version that should be used
-server.webUIAutoUpdate = true # if the server should automatically check for and download webUI updates
+server.webUIUpdateCheckInterval = 23 # time in hours - 0 to disable auto update - range: 1 <= n < 24 - default 23 hours - how often the server should check for webUI updates
 
 # downloader
 server.downloadAsCbz = false

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -28,6 +28,8 @@ server.webUIEnabled = true
 server.initialOpenInBrowserEnabled = true
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""
+server.webUIChannel = "stable"
+server.webUIAutoUpdate = true
 
 # backup
 server.backupPath = ""

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -29,7 +29,7 @@ server.initialOpenInBrowserEnabled = true
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""
 server.webUIChannel = "stable"
-server.webUIAutoUpdate = true
+server.webUIUpdateCheckInterval = 24
 
 # backup
 server.backupPath = ""


### PR DESCRIPTION
Currently the webUI requires a server release.
This PR enables the webUI to do its own releases by adding the functionality to the server to download the latest webUI version.
The webUI defines which webUI version is compatible with which server version.
Thus, the server can download the latest compatible version based on its version.

The mapping of webUI version to server version is a file inside the webUI repo.
This file gets updated each time a new webUI version gets released which requires a newer server version than the previous release.

example:

 - ui: PREVIEW; server: x
 - ui: v5; server: v3
 - ui: v2; server: v2
 
In this example
 - the current preview version requires a newer server version than v3.
 - each webUI version from ("[": =>; "]": <=; "(": >; ")": <)
   - [v5, PREVIEW) is compatible with server versions [v3, x)
   - [v2, v5) is compatible with server versions [v2, v3)
  
This does not change the current behaviour of the server release bundling a webUI version.
This version is still used as a fallback in case everything else fails.

How the server will setup the webUI:
 - local webUI is available?
   - available: local version is valid?
     - valid: check for update
       - update available?
         - available: download latest version if auto update is enabled
         - up-to-date: -
      - invalid: _download latest version_
        - _download result handling_
   - missing: _download latest version_
     - _download result handling_

_download result handling_:
- download failed?
  - yes: is default webUI
    - yes: fallback to bundled version
    - no: fallback to default webUI and retry _download latest version_
  
Support for different webUIs is also added.
As long as they fullfill the required conditions, e.g. version mapping file in correct format, available version downloads, they can be defined in the server to be provided as an optional webUI that can be used.
In case the server runs into issues with one of these webUIs (e.g. download not possible) it will fallback to the default webUI