### PR TITLE
Correctly read config reference resource in build jar and dev mode

### DIFF
--- a/AndroidCompat/Config/src/main/java/xyz/nulldev/ts/config/ConfigManager.kt
+++ b/AndroidCompat/Config/src/main/java/xyz/nulldev/ts/config/ConfigManager.kt
@@ -117,8 +117,8 @@ open class ConfigManager {
      *  - removes outdated settings
      */
     fun updateUserConfig() {
-        val serverConfigFile = File(javaClass.classLoader.getResource("server-reference.conf")?.file ?: return)
-        val serverConfig = ConfigFactory.parseFile(serverConfigFile)
+        val serverConfigFileContent = this::class.java.getResource("/server-reference.conf")?.readText()
+        val serverConfig = ConfigFactory.parseResources("server-reference.conf")
         val userConfig = getUserConfig()
 
         val hasMissingSettings = serverConfig.entrySet().any { !userConfig.hasPath(it.key) }
@@ -130,7 +130,7 @@ open class ConfigManager {
 
         logger.debug { "user config is out of date, updating... (missingSettings= $hasMissingSettings, outdatedSettings= $hasOutdatedSettings" }
 
-        val serverConfigDoc = ConfigDocumentFactory.parseFile(serverConfigFile)
+        val serverConfigDoc = ConfigDocumentFactory.parseString(serverConfigFileContent)
         userConfigFile.writeText(serverConfigDoc.render())
 
         var newUserConfigDoc: ConfigDocument = serverConfigDoc


### PR DESCRIPTION
The server reference config file was only able to be read while in dev mode. Using the build jar, the content of the file was empty, since in the build jar resources aren't actual files anymore, instead they are streams. This caused the user config content to be replaced with an empty string.