### PR TITLE
Correctly check if a new version is available for the preview channel

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -251,7 +251,7 @@ object WebInterfaceManager {
 
     private fun fetchPreviewVersion(): String {
         val releaseInfoJson = URL(WebUI.WEBUI.latestReleaseInfoUrl).readText()
-        return Json.decodeFromString<JsonObject>(releaseInfoJson)["tag_name"]?.jsonPrimitive?.content ?: ""
+        return Json.decodeFromString<JsonObject>(releaseInfoJson)["tag_name"]?.jsonPrimitive?.content ?: throw Exception("Failed to get the preview version tag")
     }
 
     private fun getLatestCompatibleVersion(): String {
@@ -385,7 +385,13 @@ object WebInterfaceManager {
 
     fun isUpdateAvailable(currentVersion: String): Boolean {
         return try {
-            val latestCompatibleVersion = getLatestCompatibleVersion()
+            val version = getLatestCompatibleVersion()
+            val latestCompatibleVersion = if (version == webUIPreviewVersion) {
+                fetchPreviewVersion()
+            } else {
+                version
+            }
+
             latestCompatibleVersion != currentVersion
         } catch (e: Exception) {
             logger.debug { "isUpdateAvailable: check failed due to $e" }


### PR DESCRIPTION
The actual version of the preview was never loaded and compared to the local version. Instead, for the preview channel it was incorrectly decided that a new version is available on every update check