### PR TITLE
Update to bundled webUI version if necessary

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -118,6 +118,17 @@ object WebInterfaceManager {
                 checkForUpdate()
             }
 
+            // check if the bundled webUI version is a newer version than the current used version
+            // this could be the case in case no compatible webUI version is available and a newer server version was installed
+            val shouldUpdateToBundledVersion =
+                serverConfig.webUIFlavor == DEFAULT_WEB_UI && extractVersion(getLocalVersion(applicationDirs.webUIRoot)) < extractVersion(
+                    BuildConfig.WEBUI_TAG
+                )
+            if (shouldUpdateToBundledVersion) {
+                logger.debug { "Update to bundled version \"${BuildConfig.WEBUI_TAG}\"" }
+                extractBundledWebUI()
+            }
+
             return
         }
 


### PR DESCRIPTION
In case on the startup no webUI update was available but the bundled version of the server is newer than the current used version, then the bundled version should be used.

This could be the case in case a new server version was installed and no compatible webUI version is available