### PR TITLE
Restore download queue async

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -71,11 +71,13 @@ object DownloadManager {
     }
 
     fun restoreAndResumeDownloads() {
-        logger.debug { "restoreAndResumeDownloads: Restore download queue..." }
-        enqueue(EnqueueInput(loadDownloadQueue()))
+        scope.launch {
+            logger.debug { "restoreAndResumeDownloads: Restore download queue..." }
+            enqueue(EnqueueInput(loadDownloadQueue()))
 
-        if (downloadQueue.size > 0) {
-            logger.info { "restoreAndResumeDownloads: Restored download queue, starting downloads..." }
+            if (downloadQueue.size > 0) {
+                logger.info { "restoreAndResumeDownloads: Restored download queue, starting downloads..." }
+            }
         }
     }
 


### PR DESCRIPTION
The download queue was blocking the main thread, thus, slowing down the startup. In case the stored queue was huge, this could take multiple seconds