### PR TITLE
Fetch downloaded chapters page again in case the stored file can't be retrevied

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -88,8 +88,12 @@ object Page {
 
         val fileName = getPageName(index)
 
-        if (chapterEntry[ChapterTable.isDownloaded]) {
-            return ChapterDownloadHelper.getImage(mangaId, chapterId, index)
+        try {
+            if (chapterEntry[ChapterTable.isDownloaded]) {
+                return ChapterDownloadHelper.getImage(mangaId, chapterId, index)
+            }
+        } catch (_: Exception) {
+            // ignore and fetch again
         }
 
         val cacheSaveDir = getChapterCachePath(mangaId, chapterId)


### PR DESCRIPTION
In case the file could not be retrieved, the page retrieve just failed and wasn't triggered again. In case of the downloader, the chapter download just kept failing 3 times and was aborted