### PR TITLE
Remove unnecessary "downloadNewChapters" call in "fetchChapters" mutation

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
@@ -121,21 +121,17 @@ class ChapterMutation {
         val (clientMutationId, mangaId) = input
 
         return future {
-            val numberOfCurrentChapters = Chapter.getCountOfMangaChapters(mangaId)
             Chapter.fetchChapterList(mangaId)
-            numberOfCurrentChapters
-        }.thenApply { numberOfCurrentChapters ->
+        }.thenApply {
             val chapters = transaction {
                 ChapterTable.select { ChapterTable.manga eq mangaId }
                     .orderBy(ChapterTable.sourceOrder)
+                    .map { ChapterType(it) }
             }
-
-            // download new chapters if settings flag is enabled
-            Chapter.downloadNewChapters(mangaId, numberOfCurrentChapters, chapters.toList())
 
             FetchChaptersPayload(
                 clientMutationId = clientMutationId,
-                chapters = chapters.map { ChapterType(it) }
+                chapters = chapters
             )
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -201,7 +201,7 @@ object Chapter {
         return chapterList
     }
 
-    fun downloadNewChapters(mangaId: Int, prevNumberOfChapters: Int, newChapters: List<ResultRow>) {
+    private fun downloadNewChapters(mangaId: Int, prevNumberOfChapters: Int, newChapters: List<ResultRow>) {
         // convert numbers to be index based
         val currentNumberOfChapters = (prevNumberOfChapters - 1).coerceAtLeast(0)
         val updatedNumberOfChapters = (newChapters.size - 1).coerceAtLeast(0)


### PR DESCRIPTION
Gets already called by "Chapter::fetchChapterList", thus, this is unnecessary. Additionally, "chapters.toList()" and "chapters.map()" have to be called in a transaction block, which they are not, and thus, cause an unhandled exception, breaking the mutation