### PR TITLE
Prevent last page read to be greater than max page count

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
@@ -228,7 +228,9 @@ class ChapterMutation {
                     this[PageTable.chapter] = chapterId
                 }
                 ChapterTable.update({ ChapterTable.id eq chapterId }) {
-                    it[ChapterTable.pageCount] = pageList.size
+                    val pageCount = pageList.size
+                    it[ChapterTable.pageCount] = pageCount
+                    it[ChapterTable.lastPageRead] = chapter[ChapterTable.lastPageRead].coerceAtMost(pageCount - 1)
                 }
             }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -118,8 +118,11 @@ private class ChapterForDownload(
         val pageCount = pageList.count()
 
         transaction {
+            val lastPageRead = ChapterTable.select { ChapterTable.id eq chapterId }.firstOrNull()?.get(ChapterTable.lastPageRead) ?: 0
+
             ChapterTable.update({ ChapterTable.id eq chapterId }) {
                 it[ChapterTable.pageCount] = pageCount
+                it[ChapterTable.lastPageRead] = lastPageRead.coerceAtMost(pageCount - 1)
             }
         }
     }


### PR DESCRIPTION
There were cases where the last page read was greater than the max page count of a chapter. This is not possible and is just invalid data, that is saved in the database, possible leading to other errors down the line.

This could happen in case the chapter was loaded at some point with e.g. 18 pages and after some time got fetched again from the source, now with fewer pages than before e.g. 15. If the chapters last page was already read by that time, the last read page would have been 18, while the chapter now has only 15 pages.