### PR TITLE
Throw error instead of returning null

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/CategoryQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/CategoryQuery.kt
@@ -40,7 +40,7 @@ import suwayomi.tachidesk.manga.model.table.CategoryTable
 import java.util.concurrent.CompletableFuture
 
 class CategoryQuery {
-    fun category(dataFetchingEnvironment: DataFetchingEnvironment, id: Int): CompletableFuture<CategoryType?> {
+    fun category(dataFetchingEnvironment: DataFetchingEnvironment, id: Int): CompletableFuture<CategoryType> {
         return dataFetchingEnvironment.getValueFromDataLoader("CategoryDataLoader", id)
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/ChapterQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/ChapterQuery.kt
@@ -48,7 +48,7 @@ import java.util.concurrent.CompletableFuture
  * - Get page list?
  */
 class ChapterQuery {
-    fun chapter(dataFetchingEnvironment: DataFetchingEnvironment, id: Int): CompletableFuture<ChapterType?> {
+    fun chapter(dataFetchingEnvironment: DataFetchingEnvironment, id: Int): CompletableFuture<ChapterType> {
         return dataFetchingEnvironment.getValueFromDataLoader("ChapterDataLoader", id)
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/ExtensionQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/ExtensionQuery.kt
@@ -41,7 +41,7 @@ import suwayomi.tachidesk.manga.model.table.ExtensionTable
 import java.util.concurrent.CompletableFuture
 
 class ExtensionQuery {
-    fun extension(dataFetchingEnvironment: DataFetchingEnvironment, pkgName: String): CompletableFuture<ExtensionType?> {
+    fun extension(dataFetchingEnvironment: DataFetchingEnvironment, pkgName: String): CompletableFuture<ExtensionType> {
         return dataFetchingEnvironment.getValueFromDataLoader("ExtensionDataLoader", pkgName)
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
@@ -43,7 +43,7 @@ import suwayomi.tachidesk.manga.model.table.MangaTable
 import java.util.concurrent.CompletableFuture
 
 class MangaQuery {
-    fun manga(dataFetchingEnvironment: DataFetchingEnvironment, id: Int): CompletableFuture<MangaType?> {
+    fun manga(dataFetchingEnvironment: DataFetchingEnvironment, id: Int): CompletableFuture<MangaType> {
         return dataFetchingEnvironment.getValueFromDataLoader("MangaDataLoader", id)
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MetaQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MetaQuery.kt
@@ -36,8 +36,8 @@ import suwayomi.tachidesk.graphql.types.GlobalMetaType
 import java.util.concurrent.CompletableFuture
 
 class MetaQuery {
-    fun meta(dataFetchingEnvironment: DataFetchingEnvironment, key: String): CompletableFuture<GlobalMetaType?> {
-        return dataFetchingEnvironment.getValueFromDataLoader<String, GlobalMetaType?>("GlobalMetaDataLoader", key)
+    fun meta(dataFetchingEnvironment: DataFetchingEnvironment, key: String): CompletableFuture<GlobalMetaType> {
+        return dataFetchingEnvironment.getValueFromDataLoader("GlobalMetaDataLoader", key)
     }
 
     enum class MetaOrderBy(override val column: Column<out Comparable<*>>) : OrderBy<GlobalMetaType> {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/SourceQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/SourceQuery.kt
@@ -40,8 +40,8 @@ import suwayomi.tachidesk.manga.model.table.SourceTable
 import java.util.concurrent.CompletableFuture
 
 class SourceQuery {
-    fun source(dataFetchingEnvironment: DataFetchingEnvironment, id: Long): CompletableFuture<SourceType?> {
-        return dataFetchingEnvironment.getValueFromDataLoader<Long, SourceType?>("SourceDataLoader", id)
+    fun source(dataFetchingEnvironment: DataFetchingEnvironment, id: Long): CompletableFuture<SourceType> {
+        return dataFetchingEnvironment.getValueFromDataLoader("SourceDataLoader", id)
     }
 
     enum class SourceOrderBy(override val column: Column<out Comparable<*>>) : OrderBy<SourceType> {


### PR DESCRIPTION
In case e.g. no manga exists for the passed id, the query returned null. This makes it harder to have a "streamlined" error handling in the client, since these types of queries need a special handling to detect that the query returned an error.

Could be further improved to return custom errors, but for now, having a default error response is good enough