### PR TITLE
Return correct latest compatible webUI version

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -452,7 +452,7 @@ object WebInterfaceManager {
 
         for (i in 0 until webUIToServerVersionMappings.size) {
             val webUIToServerVersionEntry = webUIToServerVersionMappings[i].jsonObject
-            var webUIVersion = webUIToServerVersionEntry["uiVersion"].toString()
+            var webUIVersion = webUIToServerVersionEntry["uiVersion"]?.jsonPrimitive?.content ?: throw Exception("Invalid mappingFile")
             val minServerVersionString = webUIToServerVersionEntry["serverVersion"]?.jsonPrimitive?.content ?: throw Exception("Invalid mappingFile")
             val minServerVersionNumber = extractVersion(minServerVersionString)
 


### PR DESCRIPTION
The function always returned the PREVIEW version as the latest compatible version. This was caused by incorrectly selecting the version from the json object, which resulted in the version to be wrapped in '"'.