### PR TITLE
Do not reset already loaded config when updating config file

### DIFF
--- a/AndroidCompat/Config/src/main/java/xyz/nulldev/ts/config/ConfigManager.kt
+++ b/AndroidCompat/Config/src/main/java/xyz/nulldev/ts/config/ConfigManager.kt
@@ -111,12 +111,14 @@ open class ConfigManager {
         }
     }
 
-    fun resetUserConfig(): ConfigDocument {
+    fun resetUserConfig(updateInternalConfig: Boolean = true): ConfigDocument {
         val serverConfigFileContent = this::class.java.getResource("/server-reference.conf")?.readText()
         val serverConfigDoc = ConfigDocumentFactory.parseString(serverConfigFileContent)
         userConfigFile.writeText(serverConfigDoc.render())
 
-        getUserConfig().entrySet().forEach { internalConfig = internalConfig.withValue(it.key, it.value) }
+        if (updateInternalConfig) {
+            getUserConfig().entrySet().forEach { internalConfig = internalConfig.withValue(it.key, it.value) }
+        }
 
         return serverConfigDoc
     }
@@ -140,7 +142,7 @@ open class ConfigManager {
 
         logger.debug { "user config is out of date, updating... (missingSettings= $hasMissingSettings, outdatedSettings= $hasOutdatedSettings" }
 
-        var newUserConfigDoc: ConfigDocument = resetUserConfig()
+        var newUserConfigDoc: ConfigDocument = resetUserConfig(false)
         userConfig.entrySet().filter { serverConfig.hasPath(it.key) }.forEach { newUserConfigDoc = newUserConfigDoc.withValue(it.key, it.value) }
 
         userConfigFile.writeText(newUserConfigDoc.render())


### PR DESCRIPTION
In case the user config file has to be updated, the file needs to get reset. While doing the reset, the already loaded internal state of the config got also reset, but was never updated again. Due to this, the internal state of the config was the default config reference until the next server startup

Regression introduced with a31446557d4f3151ecacd960a37d9425010f2d90.