### PR TITLE
Feature/auto download ahead

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
@@ -259,14 +259,18 @@ class DownloadMutation {
         }
     }
 
-    data class DownloadAheadInput(val clientMutationId: String? = null, val mangaIds: List<Int>)
+    data class DownloadAheadInput(
+        val clientMutationId: String? = null,
+        val mangaIds: List<Int> = emptyList(),
+        val latestReadChapterIds: List<Int>? = null
+    )
 
     data class DownloadAheadPayload(val clientMutationId: String?)
 
     fun downloadAhead(input: DownloadAheadInput): DownloadAheadPayload {
-        val (clientMutationId, mangaIds) = input
+        val (clientMutationId, mangaIds, latestReadChapterIds) = input
 
-        Manga.downloadAhead(mangaIds)
+        Manga.downloadAhead(mangaIds, latestReadChapterIds ?: emptyList())
 
         return DownloadAheadPayload(clientMutationId)
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.graphql.types.ChapterType
 import suwayomi.tachidesk.graphql.types.DownloadStatus
 import suwayomi.tachidesk.manga.impl.Chapter
+import suwayomi.tachidesk.manga.impl.Manga
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
 import suwayomi.tachidesk.manga.impl.download.model.Status
 import suwayomi.tachidesk.manga.model.table.ChapterTable
@@ -256,5 +257,17 @@ class DownloadMutation {
                 }
             )
         }
+    }
+
+    data class DownloadAheadInput(val clientMutationId: String? = null, val mangaIds: List<Int>)
+
+    data class DownloadAheadPayload(val clientMutationId: String?)
+
+    fun downloadAhead(input: DownloadAheadInput): DownloadAheadPayload {
+        val (clientMutationId, mangaIds) = input
+
+        Manga.downloadAhead(mangaIds)
+
+        return DownloadAheadPayload(clientMutationId)
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -327,6 +327,10 @@ object DownloadManager {
         dequeue(downloadQueue.filter { it.mangaId == mangaId && it.chapterIndex == chapterIndex }.toSet())
     }
 
+    fun dequeue(mangaIds: List<Int>, chaptersToIgnore: List<Int> = emptyList()) {
+        dequeue(downloadQueue.filter { it.mangaId in mangaIds && it.chapter.id !in chaptersToIgnore }.toSet())
+    }
+
     private fun dequeue(chapterDownloads: Set<DownloadChapter>) {
         logger.debug { "dequeue ${chapterDownloads.size} chapters [${chapterDownloads.joinToString(separator = ", ") { "$it" }}]" }
 


### PR DESCRIPTION
Adds the logic to "download ahead".
By using the "autoDownloadAheadLimit" setting, this logic downloads the latest unread and not downloaded chapters until the set limit is reached.

The logic does not get triggered automatically by the server, but instead, the client has to call the gql mutation.

To make this work, additional logic was added to the downloader and chapters.
Each chapter now has a "downloadReason" property, which indicates, what caused that chapter to get downloaded (e.g. user, download ahead).
This is also attached to the "DownloadChapter".
This makes it possible to only delete chapters that were added with a specific cause.

A different use case for this flag, besides the "download ahead" logic, could be to provide the option to automatically delete chapters after marking them as read.
While this should (only?) delete automatically downloaded chapters, it would also delete manually downloaded chapters.
To prevent this, the newly added flag can be used, to prevent automatically deleting manually downloaded chapters.