### PR TITLE
Send every download status change to the subscriber

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/DownloadQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/DownloadQuery.kt
@@ -1,11 +1,16 @@
 package suwayomi.tachidesk.graphql.queries
 
+import kotlinx.coroutines.flow.first
 import suwayomi.tachidesk.graphql.types.DownloadStatus
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
+import suwayomi.tachidesk.server.JavalinSetup.future
+import java.util.concurrent.CompletableFuture
 
 class DownloadQuery {
 
-    fun downloadStatus(): DownloadStatus {
-        return DownloadStatus(DownloadManager.status.value)
+    fun downloadStatus(): CompletableFuture<DownloadStatus> {
+        return future {
+            DownloadStatus(DownloadManager.status.first())
+        }
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -19,12 +19,11 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.sample
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import mu.KotlinLogging
@@ -118,10 +117,8 @@ object DownloadManager {
     private val notifyFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
     val status = notifyFlow.sample(1.seconds)
-        .map {
-            getStatus()
-        }
-        .stateIn(scope, SharingStarted.Eagerly, getStatus())
+        .onStart { emit(Unit) }
+        .map { getStatus() }
 
     init {
         scope.launch {


### PR DESCRIPTION
Flow::stateIn has "Strong equality-based conflation" (see documentation). Thus, it omits every value in case it's equal to the previous one. Since the DownloadManger::getStatus function returns a status with a queue, that contains all current "DownloadChapters" by reference, the equality check was always true. Thus, progress changes of downloads were never sent to subscribers. Subscriber were only notified about finished downloads (size of queue changed) or downloader status changes