### PR TITLE
Correctly detect initial fetch of chapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -210,7 +210,7 @@ object Chapter {
         val numberOfNewChapters = updatedNumberOfChapters - currentNumberOfChapters
 
         val areNewChaptersAvailable = numberOfNewChapters > 0
-        val wasInitialFetch = currentNumberOfChapters == 0
+        val wasInitialFetch = currentNumberOfChapters == -1 // has to be -1 - due to converting to index based 1 chapter will be 0
 
         // make sure to ignore initial fetch
         val isDownloadPossible =


### PR DESCRIPTION
Since the number of chapters gets converted to be index based, 1 available chapter would result in 0.

Due to this, in case a manga had exactly one chapter before updating the chapters, it was incorrectly detected as the initial fetch and the new chapters did not get automatically downloaded.