### PR TITLE
Order chapters to download by manga and source order

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -246,6 +246,8 @@ object DownloadManager {
         val chapters = transaction {
             (ChapterTable innerJoin MangaTable)
                 .select { ChapterTable.id inList input.chapterIds }
+                .orderBy(ChapterTable.manga)
+                .orderBy(ChapterTable.sourceOrder)
                 .toList()
         }
 


### PR DESCRIPTION
Chapters were added to the queue by database index order. In case a chapters of different mangas got added to the queue, downloads got mingled instead of being group inserted per manga. Also sort manga chapters by source order, to make sure, that, in case chapters of a manga are, for some reason, not in the correct order in the database, they will still get downloaded in the order of the source.