### PR TITLE
Update version "name" and "code" when installing external extension

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -181,6 +181,8 @@ object Extension {
                     it[this.apkName] = apkName
                     it[this.isInstalled] = true
                     it[this.classFQName] = className
+                    it[versionName] = packageInfo.versionName
+                    it[versionCode] = packageInfo.versionCode
                 }
 
                 val extensionId =


### PR DESCRIPTION
In case a newer version of the extension is installed  and the extension gets manually downgraded, the version in db is still the one of the newer version. This will prevent detection of available updates, since it won't get recognized, that an older version is currently installed.