### PR TITLE
Fix/graphql subscriptions logging

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/subscriptions/ApolloSubscriptionProtocolHandler.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/subscriptions/ApolloSubscriptionProtocolHandler.kt
@@ -35,6 +35,7 @@ import suwayomi.tachidesk.graphql.server.subscriptions.SubscriptionOperationMess
 import suwayomi.tachidesk.graphql.server.subscriptions.SubscriptionOperationMessage.ServerMessages.GQL_ERROR
 import suwayomi.tachidesk.graphql.server.subscriptions.SubscriptionOperationMessage.ServerMessages.GQL_NEXT
 import suwayomi.tachidesk.graphql.server.toGraphQLContext
+import suwayomi.tachidesk.server.serverConfig
 
 /**
  * Implementation of the `graphql-ws` protocol defined by Apollo
@@ -54,7 +55,15 @@ class ApolloSubscriptionProtocolHandler(
 
     fun handleMessage(context: WsMessageContext): Flow<SubscriptionOperationMessage> {
         val operationMessage = convertToMessageOrNull(context.message()) ?: return flowOf(basicConnectionErrorMessage)
-        logger.debug { "GraphQL subscription client message, sessionId=${context.sessionId} operationMessage=$operationMessage" }
+        logger.debug {
+            "GraphQL subscription client message, sessionId=${context.sessionId} ${
+            if (serverConfig.gqlDebugLogsEnabled.value) {
+                "operationMessage=$operationMessage"
+            } else {
+                ""
+            }
+            }"
+        }
 
         return try {
             when (operationMessage.type) {


### PR DESCRIPTION
new log without complete operation message log

	GraphQL subscription client message, sessionId=0e59ae83-f1e9-45bc-85de-d0d82a9090f8 type=connection_init operationName=__UNKNOWN__ 
	GraphQL subscription client message, sessionId=0e59ae83-f1e9-45bc-85de-d0d82a9090f8 type=subscribe operationName=UPDATER_SUBSCRIPTION