### PR TITLE
Fetch mangas during the update

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -63,6 +63,7 @@ class SettingsMutation {
         updateSetting(settings.excludeNotStarted, serverConfig.excludeNotStarted)
         updateSetting(settings.excludeCompleted, serverConfig.excludeCompleted)
         updateSetting(settings.globalUpdateInterval, serverConfig.globalUpdateInterval)
+        updateSetting(settings.updateMangas, serverConfig.updateMangas)
 
         // Authentication
         updateSetting(settings.basicAuthEnabled, serverConfig.basicAuthEnabled)

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -48,6 +48,7 @@ interface Settings : Node {
     val excludeNotStarted: Boolean?
     val excludeCompleted: Boolean?
     val globalUpdateInterval: Double?
+    val updateMangas: Boolean?
 
     // Authentication
     val basicAuthEnabled: Boolean?
@@ -96,6 +97,7 @@ data class PartialSettingsType(
     override val excludeNotStarted: Boolean?,
     override val excludeCompleted: Boolean?,
     override val globalUpdateInterval: Double?,
+    override val updateMangas: Boolean?,
     // Authentication
     override val basicAuthEnabled: Boolean?,
     override val basicAuthUsername: String?,
@@ -140,6 +142,7 @@ class SettingsType(
     override val excludeNotStarted: Boolean,
     override val excludeCompleted: Boolean,
     override val globalUpdateInterval: Double,
+    override val updateMangas: Boolean,
     // Authentication
     override val basicAuthEnabled: Boolean,
     override val basicAuthUsername: String,
@@ -183,6 +186,7 @@ class SettingsType(
         config.excludeNotStarted.value,
         config.excludeCompleted.value,
         config.globalUpdateInterval.value,
+        config.updateMangas.value,
         // Authentication
         config.basicAuthEnabled.value,
         config.basicAuthUsername.value,

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -133,8 +133,8 @@ class SettingsType(
     override val downloadAsCbz: Boolean,
     override val downloadsPath: String,
     override val autoDownloadNewChapters: Boolean,
-    override val excludeEntryWithUnreadChapters: Boolean?,
-    override val autoDownloadAheadLimit: Int?,
+    override val excludeEntryWithUnreadChapters: Boolean,
+    override val autoDownloadAheadLimit: Int,
     // requests
     override val maxSourcesInParallel: Int,
     // updater
@@ -149,7 +149,7 @@ class SettingsType(
     override val basicAuthPassword: String,
     // misc
     override val debugLogsEnabled: Boolean,
-    override val gqlDebugLogsEnabled: Boolean?,
+    override val gqlDebugLogsEnabled: Boolean,
     override val systemTrayEnabled: Boolean,
     // backup
     override val backupPath: String,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -23,6 +23,7 @@ import mu.KotlinLogging
 import suwayomi.tachidesk.manga.impl.Category
 import suwayomi.tachidesk.manga.impl.CategoryManga
 import suwayomi.tachidesk.manga.impl.Chapter
+import suwayomi.tachidesk.manga.impl.Manga
 import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
 import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
@@ -166,6 +167,9 @@ class Updater : IUpdater {
         tracker[job.manga.id] =
             try {
                 logger.info { "Updating \"${job.manga.title}\" (source: ${job.manga.sourceId})" }
+                if (serverConfig.updateMangas.value) {
+                    Manga.getManga(job.manga.id, true)
+                }
                 Chapter.getChapterList(job.manga.id, true)
                 job.copy(status = JobStatus.COMPLETE)
             } catch (e: Exception) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -92,6 +92,7 @@ class ServerConfig(getConfig: () -> Config, val moduleName: String = SERVER_CONF
     val excludeNotStarted: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val excludeCompleted: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val globalUpdateInterval: MutableStateFlow<Double> by OverrideConfigValue(DoubleConfigAdapter)
+    val updateMangas: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
 
     // Authentication
     val basicAuthEnabled: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -31,6 +31,7 @@ server.excludeUnreadChapters = true
 server.excludeNotStarted = true
 server.excludeCompleted = true
 server.globalUpdateInterval = 12 # time in hours - 0 to disable it - (doesn't have to be full hours e.g. 12.5) - range: 6 <= n < ∞ - default: 12 hours - interval in which the global update will be automatically triggered
+server.updateMangas = false # if the mangas should be updated along with the chapter list during a library/category update
 
 # Authentication
 server.basicAuthEnabled = false

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -21,6 +21,7 @@ server.excludeUnreadChapters = true
 server.excludeNotStarted = true
 server.excludeCompleted = true
 server.globalUpdateInterval = 12
+server.updateMangas = false
 
 # misc
 server.debugLogsEnabled = true


### PR DESCRIPTION
The update only fetched the chapter list of a manga but never the manga itself. Thus, e.g. unless the manga got online fetched via the ui, it would never get recognized if it is completed or not. This would e.g. prevent the update setting, to not update completed mangas, from working as intended