### PR TITLE
Fix/updater update stuck in running status after failure

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -156,6 +157,7 @@ class Updater : IUpdater {
                 logger.error(it) { "Error during updates (source: $source)" }
                 handleChannelUpdateFailure(source)
             }
+            .onCompletion { updateChannels.remove(source) }
             .launchIn(scope)
         return channel
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -195,8 +195,8 @@ class Updater : IUpdater {
                 Chapter.getChapterList(job.manga.id, true)
                 job.copy(status = JobStatus.COMPLETE)
             } catch (e: Exception) {
-                if (e is CancellationException) throw e
                 logger.error(e) { "Error while updating ${job.manga.title}" }
+                if (e is CancellationException) throw e
                 job.copy(status = JobStatus.FAILED)
             }
 


### PR DESCRIPTION
In case the channel failed due to an exception, the update for the source failed completely.
This however was never handled and the pending updates for the source were never set to failed.
Due to this, the global updates running state was always true