### PR TITLE
Handle disabled download ahead limit for new chapters auto download

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -243,7 +243,11 @@ object Chapter {
         }
 
         val firstChapterToDownloadIndex =
-            (numberOfNewChapters - serverConfig.autoDownloadAheadLimit.value).coerceAtLeast(0)
+            if (serverConfig.autoDownloadAheadLimit.value > 0) {
+                (numberOfNewChapters - serverConfig.autoDownloadAheadLimit.value).coerceAtLeast(0)
+            } else {
+                0
+            }
 
         val chapterIdsToDownload =
             newChapters.subList(firstChapterToDownloadIndex, numberOfNewChapters)


### PR DESCRIPTION
In case download ahead is disabled, all new chapters should get downloaded. Due to incorrectly calculating the index of the first new chapter to download, no new chapter was downloaded at all