### PR TITLE
Delete outdated thumbnails when inserting mangas into database

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -329,7 +329,7 @@ object Manga {
         return fetchMangaThumbnail(mangaId)
     }
 
-    private fun clearThumbnail(mangaId: Int) {
+    fun clearThumbnail(mangaId: Int) {
         val fileName = mangaId.toString()
 
         clearCachedImage(applicationDirs.tempThumbnailCacheRoot, fileName)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
@@ -56,20 +56,26 @@ object MangaList {
                         (MangaTable.url eq manga.url) and (MangaTable.sourceReference eq sourceId)
                     }.firstOrNull()
                 if (mangaEntry == null) { // create manga entry
-                    MangaTable.insertAndGetId {
-                        it[url] = manga.url
-                        it[title] = manga.title
+                    val mangaId =
+                        MangaTable.insertAndGetId {
+                            it[url] = manga.url
+                            it[title] = manga.title
 
-                        it[artist] = manga.artist
-                        it[author] = manga.author
-                        it[description] = manga.description
-                        it[genre] = manga.genre
-                        it[status] = manga.status
-                        it[thumbnail_url] = manga.thumbnail_url
-                        it[updateStrategy] = manga.update_strategy.name
+                            it[artist] = manga.artist
+                            it[author] = manga.author
+                            it[description] = manga.description
+                            it[genre] = manga.genre
+                            it[status] = manga.status
+                            it[thumbnail_url] = manga.thumbnail_url
+                            it[updateStrategy] = manga.update_strategy.name
 
-                        it[sourceReference] = sourceId
-                    }.value
+                            it[sourceReference] = sourceId
+                        }.value
+
+                    // delete thumbnail in case cached data still exists
+                    Manga.clearThumbnail(mangaId)
+
+                    mangaId
                 } else {
                     mangaEntry[MangaTable.id].value
                 }
@@ -102,6 +108,9 @@ object MangaList {
 
                                 it[sourceReference] = sourceId
                             }.value
+
+                        // delete thumbnail in case cached data still exists
+                        Manga.clearThumbnail(mangaId)
 
                         mangaEntry =
                             MangaTable.select {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
@@ -22,6 +22,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import suwayomi.tachidesk.manga.impl.Category
 import suwayomi.tachidesk.manga.impl.CategoryManga
+import suwayomi.tachidesk.manga.impl.Manga.clearThumbnail
 import suwayomi.tachidesk.manga.impl.backup.models.Chapter
 import suwayomi.tachidesk.manga.impl.backup.models.Manga
 import suwayomi.tachidesk.manga.impl.backup.models.Track
@@ -187,6 +188,9 @@ object ProtoBackupImport : ProtoBackupBase() {
 
                         it[inLibraryAt] = TimeUnit.MILLISECONDS.toSeconds(manga.date_added)
                     }.value
+
+                // delete thumbnail in case cached data still exists
+                clearThumbnail(mangaId)
 
                 // insert chapter data
                 val chaptersLength = chapters.size


### PR DESCRIPTION
In case the database got deleted without deleting cached/downloaded thumbnails, the next time a manga gets inserted, it's possible that a thumbnail was already downloaded for its id. This then causes mangas to be displayed with incorrect thumbnails due to using the outdated cached/downloaded thumbnails