### PR TITLE
Prevent mangas from being added to the default category

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
@@ -16,6 +16,7 @@ import suwayomi.tachidesk.graphql.types.CategoryMetaType
 import suwayomi.tachidesk.graphql.types.CategoryType
 import suwayomi.tachidesk.graphql.types.MangaType
 import suwayomi.tachidesk.manga.impl.Category
+import suwayomi.tachidesk.manga.impl.Category.DEFAULT_CATEGORY_ID
 import suwayomi.tachidesk.manga.impl.util.lang.isEmpty
 import suwayomi.tachidesk.manga.impl.util.lang.isNotEmpty
 import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
@@ -371,7 +372,7 @@ class CategoryMutation {
             if (!patch.addToCategories.isNullOrEmpty()) {
                 val newCategories =
                     buildList {
-                        ids.forEach { mangaId ->
+                        ids.filter { it != DEFAULT_CATEGORY_ID }.forEach { mangaId ->
                             patch.addToCategories.forEach { categoryId ->
                                 val existingMapping =
                                     CategoryMangaTable.select {


### PR DESCRIPTION
Mangas are not supposed to be mapped to the default category in the database. In case this happens, the category query won't be able to correctly select mangas in the default category