### PR TITLE
Extract downloaded webUI zip in temp folder for validation

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -613,16 +613,13 @@ object WebInterfaceManager {
             }
         }
 
-        if (!isDownloadValid(zipFile.name, filePath)) {
+        if (!isDownloadValid(filePath)) {
             throw Exception("Download is invalid")
         }
     }
 
-    private suspend fun isDownloadValid(
-        zipFileName: String,
-        zipFilePath: String,
-    ): Boolean {
-        val tempUnzippedWebUIFolderPath = zipFileName.replace(".zip", "")
+    private suspend fun isDownloadValid(zipFilePath: String): Boolean {
+        val tempUnzippedWebUIFolderPath = zipFilePath.replace(".zip", "")
 
         extractDownload(zipFilePath, tempUnzippedWebUIFolderPath)
 


### PR DESCRIPTION
Could cause issues due to not having permission to create the folder to extract the zip into