### PR TITLE
Handle backups with categories having default category name

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
@@ -77,7 +77,13 @@ object ProtoBackupImport : ProtoBackupBase() {
             val categoryMapping =
                 transaction {
                     backup.backupCategories.associate {
-                        it.order to CategoryTable.select { CategoryTable.name eq it.name }.first()[CategoryTable.id].value
+                        val dbCategory = CategoryTable.select { CategoryTable.name eq it.name }.firstOrNull()
+                        val categoryId =
+                            dbCategory?.let {
+                                    categoryResultRow ->
+                                categoryResultRow[CategoryTable.id].value
+                            } ?: Category.DEFAULT_CATEGORY_ID
+                        it.order to categoryId
                     }
                 }
 


### PR DESCRIPTION
We do not allow any category to have the default categories name ("default" case-insensitive). In case the backup includes a category with this name, it won't be matched to any category in our database and also won't insert a new category. This will then lead to an exception, causing the backup to fail.