### PR TITLE
Migrate preferences only if necessary

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -48,8 +48,6 @@ import java.io.File
 import java.security.Security
 import java.util.Locale
 import java.util.prefs.Preferences
-import kotlin.io.path.exists
-import kotlin.io.path.outputStream
 
 private val logger = KotlinLogging.logger {}
 
@@ -217,9 +215,13 @@ fun applicationSetup() {
         }
     }, ignoreInitialValue = false)
 
-    val preferences = Preferences.userRoot().node("suwayomi/tachidesk")
-    migratePreferences(null, preferences)
-    preferences.removeNode()
+    val prefRootNode = "suwayomi/tachidesk"
+    val isMigrationRequired = Preferences.userRoot().nodeExists(prefRootNode)
+    if (isMigrationRequired) {
+        val preferences = Preferences.userRoot().node(prefRootNode)
+        migratePreferences(null, preferences)
+        preferences.removeNode()
+    }
 
     // Disable jetty's logging
     System.setProperty("org.eclipse.jetty.util.log.announce", "false")


### PR DESCRIPTION
Currently, the server tries to migrate the preference on every startup, even if the migration was already done. This can lead to an unhandled exception, if the write permission to the system preference was revoked. In case the migration has already happened, these permissions should not be required