### PR TITLE
Correctly check for existing download when downloading a chapter

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/FolderProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/FolderProvider.kt
@@ -30,11 +30,6 @@ class FolderProvider(mangaId: Int, chapterId: Int) : ChaptersFilesProvider(manga
         val chapterDir = getChapterDownloadPath(mangaId, chapterId)
         val folder = File(chapterDir)
 
-        val alreadyDownloaded = folder.exists()
-        if (alreadyDownloaded) {
-            return true
-        }
-
         val downloadSucceeded = super.downloadImpl(download, scope, step)
         if (!downloadSucceeded) {
             return false


### PR DESCRIPTION
Check for all downloaded pages during a chapter download

In case a chapter is marked as not downloaded, but the download folder exists already, the chapter did not get downloaded again.
 This could cause issues in case the previous download failed or has missing pages.
Instead of only checking if the folder exists, each page should be checked individually

This was previously done and was incorrectly changed with 1c9a139006f7a9e399c964b2a88650fb757d8369.