### PR TITLE
Correctly handle auto download of new chapters of not started entries

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -264,7 +264,7 @@ object Chapter {
 
         // make sure to only consider the latest chapters. e.g. old unread chapters should be ignored
         val latestReadChapterIndex =
-            updatedChapterList.indexOfFirst { it[ChapterTable.isRead] }.takeIf { it > -1 } ?: return
+            updatedChapterList.indexOfFirst { it[ChapterTable.isRead] }.takeIf { it > -1 } ?: (updatedChapterList.size - 1)
         val unreadChapters =
             updatedChapterList.subList(numberOfNewChapters, latestReadChapterIndex)
                 .filter { !it[ChapterTable.isRead] }


### PR DESCRIPTION
The function incorrectly exited early in case no latest read chapter was found. This rendered disabling the setting "excludeEntryWithUnreadChapters" useless.