### PR TITLE
Always get the latest commit count for jar name

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -14,18 +14,20 @@ val tachideskVersion = System.getenv("ProductVersion") ?: "v0.7.0"
 
 val webUIRevisionTag = System.getenv("WebUIRevision") ?: "r983"
 
-// counts commits on the master branch
-val tachideskRevision = runCatching {
-    System.getenv("ProductRevision") ?: ProcessBuilder()
-        .command("git", "rev-list", "HEAD", "--count")
-        .start()
-        .let { process ->
-            process.waitFor()
-            val output = process.inputStream.use {
-                it.bufferedReader().use(BufferedReader::readText)
+// counts commits on the current checked out branch
+val getTachideskRevision = {
+    runCatching {
+        System.getenv("ProductRevision") ?: ProcessBuilder()
+            .command("git", "rev-list", "HEAD", "--count")
+            .start()
+            .let { process ->
+                process.waitFor()
+                val output = process.inputStream.use {
+                    it.bufferedReader().use(BufferedReader::readText)
+                }
+                process.destroy()
+                "r" + output.trim()
             }
-            process.destroy()
-            "r" + output.trim()
-        }
-}.getOrDefault("r0")
+    }.getOrDefault("r0")
+}
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -107,7 +107,7 @@ buildConfig {
 
     buildConfigField("String", "NAME", quoteWrap(rootProject.name))
     buildConfigField("String", "VERSION", quoteWrap(tachideskVersion))
-    buildConfigField("String", "REVISION", quoteWrap(tachideskRevision))
+    buildConfigField("String", "REVISION", quoteWrap(getTachideskRevision()))
     buildConfigField("String", "BUILD_TYPE", quoteWrap(if (System.getenv("ProductBuildType") == "Stable") "Stable" else "Preview"))
     buildConfigField("long", "BUILD_TIME", Instant.now().epochSecond.toString())
 
@@ -126,12 +126,12 @@ tasks {
                 "Implementation-Title" to rootProject.name,
                 "Implementation-Vendor" to "The Suwayomi Project",
                 "Specification-Version" to tachideskVersion,
-                "Implementation-Version" to tachideskRevision,
+                "Implementation-Version" to getTachideskRevision(),
             )
         }
         archiveBaseName.set(rootProject.name)
         archiveVersion.set(tachideskVersion)
-        archiveClassifier.set(tachideskRevision)
+        archiveClassifier.set(getTachideskRevision())
         destinationDirectory.set(File("$rootDir/server/build"))
     }
 


### PR DESCRIPTION
When adding commits or switching between branches the "shadowJar" gradle task always used the same (outdated) commit count which created jars with confusing names