### PR TITLE
Update served webUI after update

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -72,13 +72,19 @@ object JavalinSetup {
         val app =
             Javalin.create { config ->
                 if (serverConfig.webUIEnabled.value) {
+                    val serveWebUI = {
+                        config.addSinglePageRoot("/", applicationDirs.webUIRoot + "/index.html", Location.EXTERNAL)
+                    }
+                    WebInterfaceManager.setServeWebUI(serveWebUI)
+
                     runBlocking {
                         WebInterfaceManager.setupWebUI()
                     }
 
                     logger.info { "Serving web static files for ${serverConfig.webUIFlavor.value}" }
                     config.addStaticFiles(applicationDirs.webUIRoot, Location.EXTERNAL)
-                    config.addSinglePageRoot("/", applicationDirs.webUIRoot + "/index.html", Location.EXTERNAL)
+                    serveWebUI()
+
                     config.registerPlugin(OpenApiPlugin(getOpenApiOptions()))
                 }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -167,6 +167,12 @@ object WebInterfaceManager {
         )
     }
 
+    private var serveWebUI: () -> Unit = {}
+
+    fun setServeWebUI(serveWebUI: () -> Unit) {
+        this.serveWebUI = serveWebUI
+    }
+
     private fun isAutoUpdateEnabled(): Boolean {
         return serverConfig.webUIUpdateCheckInterval.value.toInt() != 0
     }
@@ -566,6 +572,8 @@ object WebInterfaceManager {
             log.info { "Extracting WebUI zip Done." }
 
             emitStatus(version, FINISHED, 100)
+
+            serveWebUI()
         } catch (e: Exception) {
             emitStatus(version, ERROR, 0)
             throw e


### PR DESCRIPTION
fixes #758

The served file gets cached and thus, it won't reflect the latest version of the file.
This was a problem after the webUI got updated, since now the served "index.html" was outdated and pointed to files that didn't exist anymore.