### PR TITLE
Correctly select enum webui flavor via "ui name"

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -117,7 +117,7 @@ enum class WebUIFlavor(
     ;
 
     companion object {
-        fun from(value: String): WebUIFlavor = entries.find { it.name == value } ?: WEBUI
+        fun from(value: String): WebUIFlavor = entries.find { it.uiName == value } ?: WEBUI
     }
 }
 


### PR DESCRIPTION
The selection always returned the default value fallback due to incorrectly using the enums value name instead of the "uiName" of the enum value