### PR TITLE
Disable download ahead limit by default

### DIFF
--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -21,7 +21,7 @@ server.downloadAsCbz = false
 server.downloadsPath = ""
 server.autoDownloadNewChapters = false # if new chapters that have been retrieved should get automatically downloaded
 server.excludeEntryWithUnreadChapters = true # ignore automatic chapter downloads of entries with unread chapters
-server.autoDownloadAheadLimit = 5 # 0 to disable it - how many unread downloaded chapters should be available - if the limit is reached, new chapters won't be downloaded automatically
+server.autoDownloadAheadLimit = 0 # 0 to disable it - how many unread downloaded chapters should be available - if the limit is reached, new chapters won't be downloaded automatically. this limit will also be applied to the auto download of new chapters on an update
 
 # requests
 server.maxSourcesInParallel = 6 # range: 1 <= n <= 20 - default: 6 - sets how many sources can do requests (updates, downloads) in parallel. updates/downloads are grouped by source and all mangas of a source are updated/downloaded synchronously

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -11,7 +11,7 @@ server.socksProxyPort = ""
 server.downloadAsCbz = false
 server.autoDownloadNewChapters = false
 server.excludeEntryWithUnreadChapters = true
-server.autoDownloadAheadLimit = 5
+server.autoDownloadAheadLimit = 0
 
 # requests
 server.maxSourcesInParallel = 10


### PR DESCRIPTION
Currently, it causes the download ahead while reading logic in the WebUI to be enabled by default, which should be disabled by default