### PR TITLE
Correctly emit the current status immediately

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -119,16 +119,13 @@ object DownloadManager {
 
     private val notifyFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
-    private val statusFlow = MutableSharedFlow<Unit>()
-    val status =
-        statusFlow.onStart { emit(Unit) }
-            .map { getStatus() }
+    private val statusFlow = MutableSharedFlow<DownloadStatus>()
+    val status = statusFlow.onStart { emit(getStatus()) }
 
     init {
         scope.launch {
             notifyFlow.sample(1.seconds).collect {
-                statusFlow.emit(Unit)
-                sendStatusToAllClients()
+                notifyAllClients(immediate = true)
             }
         }
     }
@@ -139,23 +136,26 @@ object DownloadManager {
         saveQueueFlow.onEach { saveDownloadQueue() }.launchIn(scope)
     }
 
-    private fun sendStatusToAllClients() {
-        val status = getStatus()
+    private fun sendStatusToAllClients(status: DownloadStatus) {
         clients.forEach {
             it.value.send(status)
         }
     }
 
     private fun notifyAllClients(immediate: Boolean = false) {
+        if (immediate) {
+            val status = getStatus()
+
+            scope.launch {
+                statusFlow.emit(status)
+                sendStatusToAllClients(status)
+            }
+
+            return
+        }
+
         scope.launch {
             notifyFlow.emit(Unit)
-
-            if (immediate) {
-                statusFlow.emit(Unit)
-            }
-        }
-        if (immediate) {
-            sendStatusToAllClients()
         }
     }
 


### PR DESCRIPTION
For finished downloads the immediate emission did not work because the emission was done async and by the time the state got updated with the new status, the finished download was already removed from the queue. Thus, the new state was missing the finished download.