### PR TITLE
Correctly calculate the first chapter to download index

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -308,7 +308,6 @@ object Chapter {
                     ")",
             )
 
-        // convert numbers to be index based
         val newNumberOfChapters = updatedChapterList.size
         val numberOfNewChapters = newNumberOfChapters - prevNumberOfChapters
 
@@ -340,7 +339,7 @@ object Chapter {
 
         val firstChapterToDownloadIndex =
             if (serverConfig.autoDownloadAheadLimit.value > 0) {
-                (numberOfNewChapters - serverConfig.autoDownloadAheadLimit.value - 1).coerceAtLeast(0)
+                (numberOfNewChapters - serverConfig.autoDownloadAheadLimit.value).coerceAtLeast(0)
             } else {
                 0
             }


### PR DESCRIPTION
Subtracting 1 from the first chapter to download index caused an additional chapter to get downloaded (e.g. limit 4 would download 5 chapters)

Regression was introduced with 05bf4f552542053689ea491951c0afb1686e40b5