### PR TITLE
Remove caching of extensions for gql mutation

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
@@ -35,29 +35,34 @@ object ExtensionsList {
 
     suspend fun fetchExtensions() {
         // update if 60 seconds has passed or requested offline and database is empty
+        val extensions =
+            (listOf(ExtensionGithubApi.REPO_URL_PREFIX) + serverConfig.extensionRepos.value).map { repo ->
+                kotlin.runCatching {
+                    ExtensionGithubApi.findExtensions(repo)
+                }.onFailure {
+                    logger.warn(it) {
+                        "Failed to fetch extensions for repo: $repo"
+                    }
+                }
+            }
+        val foundExtensions = extensions.mapNotNull { it.getOrNull() }.flatten()
+        updateExtensionDatabase(foundExtensions)
+    }
+
+    suspend fun fetchExtensionsCached() {
+        // update if 60 seconds has passed or requested offline and database is empty
         if (lastUpdateCheck + 60.seconds.inWholeMilliseconds < System.currentTimeMillis()) {
             logger.debug("Getting extensions list from the internet")
             lastUpdateCheck = System.currentTimeMillis()
 
-            val extensions =
-                (listOf(ExtensionGithubApi.REPO_URL_PREFIX) + serverConfig.extensionRepos.value).map { repo ->
-                    kotlin.runCatching {
-                        ExtensionGithubApi.findExtensions(repo)
-                    }.onFailure {
-                        logger.warn(it) {
-                            "Failed to fetch extensions for repo: $repo"
-                        }
-                    }
-                }
-            val foundExtensions = extensions.mapNotNull { it.getOrNull() }.flatten()
-            updateExtensionDatabase(foundExtensions)
+            fetchExtensions()
         } else {
             logger.debug("used cached extension list")
         }
     }
 
     suspend fun getExtensionList(): List<ExtensionDataClass> {
-        fetchExtensions()
+        fetchExtensionsCached()
         return extensionTableAsDataClass()
     }
 


### PR DESCRIPTION
The client should use the extension query to get "cached" extensions and the mutation to update the extensions