### PR TITLE
Remove extension obsolete flag when updating db after extension list fetch

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
@@ -115,6 +115,14 @@ object ExtensionsList {
                             // add these because batch updates need matching columns
                             this[ExtensionTable.hasUpdate] = extensionRecord[ExtensionTable.hasUpdate]
                             this[ExtensionTable.isObsolete] = extensionRecord[ExtensionTable.isObsolete]
+
+                            // a previously removed extension is now available again
+                            if (extensionRecord[ExtensionTable.isObsolete] &&
+                                foundExtension.versionCode >= extensionRecord[ExtensionTable.versionCode]
+                            ) {
+                                this[ExtensionTable.isObsolete] = false
+                            }
+
                             when {
                                 foundExtension.versionCode > extensionRecord[ExtensionTable.versionCode] -> {
                                     // there is an update


### PR DESCRIPTION
In case an extension got marked as obsolete and was found again in a set repo, the obsolete flag has to be removed