### PR TITLE
Prevent adding duplicated extensions to the db table

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
@@ -83,7 +83,11 @@ object ExtensionsList {
 
     private fun updateExtensionDatabase(foundExtensions: List<OnlineExtension>) {
         transaction {
-            val uniqueExtensions = foundExtensions.distinctBy { it.pkgName }
+            val uniqueExtensions =
+                foundExtensions.groupBy { it.pkgName }.mapValues {
+                        (_, extension) ->
+                    extension.maxBy { it.versionCode }
+                }.values
             val installedExtensions =
                 ExtensionTable.selectAll().toList()
                     .associateBy { it[ExtensionTable.pkgName] }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
@@ -83,6 +83,7 @@ object ExtensionsList {
 
     private fun updateExtensionDatabase(foundExtensions: List<OnlineExtension>) {
         transaction {
+            val uniqueExtensions = foundExtensions.distinctBy { it.pkgName }
             val installedExtensions =
                 ExtensionTable.selectAll().toList()
                     .associateBy { it[ExtensionTable.pkgName] }
@@ -90,9 +91,9 @@ object ExtensionsList {
             val extensionsToInsert = mutableListOf<OnlineExtension>()
             val extensionsToDelete =
                 installedExtensions.filter { it.value[ExtensionTable.repo] != null }.mapNotNull { (pkgName, extension) ->
-                    extension.takeUnless { foundExtensions.any { it.pkgName == pkgName } }
+                    extension.takeUnless { uniqueExtensions.any { it.pkgName == pkgName } }
                 }
-            foundExtensions.forEach {
+            uniqueExtensions.forEach {
                 val extension = installedExtensions[it.pkgName]
                 if (extension != null) {
                     extensionsToUpdate.add(it to extension)


### PR DESCRIPTION
There is a possibility that multiple extension repos have been added which contain the same extensions. In case these extensions have not been added to the db table yet, they would all get added to the db, which would create duplicated extensions