### PR TITLE
Apply natural sort to local manga pages in Directory format

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/LocalSource.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/LocalSource.kt
@@ -328,8 +328,8 @@ class LocalSource(
         return when (val format = getFormat(chapter)) {
             is Format.Directory -> {
                 format.file.listFiles().orEmpty()
-                    .sortedBy { it.name }
                     .filter { !it.isDirectory && ImageUtil.isImage(it.name, it::inputStream) }
+                    .sortedWith { f1, f2 -> f1.name.compareToCaseInsensitiveNaturalOrder(f2.name) }
                     .mapIndexed { index, page ->
                         Page(
                             index,


### PR DESCRIPTION
Directories were the only format that wasn't using natural sorting, causing pages to be out of order when using local images.