### PR TITLE
Add support for configuring which categories are downloaded automatically

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
@@ -86,6 +86,7 @@ class CategoryMutation {
         val name: String? = null,
         val default: Boolean? = null,
         val includeInUpdate: IncludeOrExclude? = null,
+        val includeInDownload: IncludeOrExclude? = null,
     )
 
     data class UpdateCategoryPayload(
@@ -133,6 +134,13 @@ class CategoryMutation {
                 CategoryTable.update({ CategoryTable.id inList ids }) { update ->
                     patch.includeInUpdate.also {
                         update[includeInUpdate] = it.value
+                    }
+                }
+            }
+            if (patch.includeInDownload != null) {
+                CategoryTable.update({ CategoryTable.id inList ids }) { update ->
+                    patch.includeInDownload.also {
+                        update[includeInDownload] = it.value
                     }
                 }
             }
@@ -230,6 +238,7 @@ class CategoryMutation {
         val order: Int? = null,
         val default: Boolean? = null,
         val includeInUpdate: IncludeOrExclude? = null,
+        val includeInDownload: IncludeOrExclude? = null,
     )
 
     data class CreateCategoryPayload(
@@ -238,7 +247,7 @@ class CategoryMutation {
     )
 
     fun createCategory(input: CreateCategoryInput): CreateCategoryPayload {
-        val (clientMutationId, name, order, default, includeInUpdate) = input
+        val (clientMutationId, name, order, default, includeInUpdate, includeInDownload) = input
         transaction {
             require(CategoryTable.select { CategoryTable.name eq input.name }.isEmpty()) {
                 "'name' must be unique"
@@ -270,6 +279,9 @@ class CategoryMutation {
                         }
                         if (includeInUpdate != null) {
                             it[CategoryTable.includeInUpdate] = includeInUpdate.value
+                        }
+                        if (includeInDownload != null) {
+                            it[CategoryTable.includeInDownload] = includeInDownload.value
                         }
                     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
@@ -19,7 +19,7 @@ import suwayomi.tachidesk.manga.impl.Category
 import suwayomi.tachidesk.manga.impl.Category.DEFAULT_CATEGORY_ID
 import suwayomi.tachidesk.manga.impl.util.lang.isEmpty
 import suwayomi.tachidesk.manga.impl.util.lang.isNotEmpty
-import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
+import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 import suwayomi.tachidesk.manga.model.table.CategoryMangaTable
 import suwayomi.tachidesk.manga.model.table.CategoryMetaTable
 import suwayomi.tachidesk.manga.model.table.CategoryTable
@@ -85,7 +85,7 @@ class CategoryMutation {
     data class UpdateCategoryPatch(
         val name: String? = null,
         val default: Boolean? = null,
-        val includeInUpdate: IncludeInUpdate? = null,
+        val includeInUpdate: IncludeOrExclude? = null,
     )
 
     data class UpdateCategoryPayload(
@@ -229,7 +229,7 @@ class CategoryMutation {
         val name: String,
         val order: Int? = null,
         val default: Boolean? = null,
-        val includeInUpdate: IncludeInUpdate? = null,
+        val includeInUpdate: IncludeOrExclude? = null,
     )
 
     data class CreateCategoryPayload(

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
@@ -15,7 +15,7 @@ import suwayomi.tachidesk.graphql.server.primitives.Edge
 import suwayomi.tachidesk.graphql.server.primitives.Node
 import suwayomi.tachidesk.graphql.server.primitives.NodeList
 import suwayomi.tachidesk.graphql.server.primitives.PageInfo
-import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
+import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 import suwayomi.tachidesk.manga.model.table.CategoryTable
 import java.util.concurrent.CompletableFuture
 
@@ -24,14 +24,14 @@ class CategoryType(
     val order: Int,
     val name: String,
     val default: Boolean,
-    val includeInUpdate: IncludeInUpdate,
+    val includeInUpdate: IncludeOrExclude,
 ) : Node {
     constructor(row: ResultRow) : this(
         row[CategoryTable.id].value,
         row[CategoryTable.order],
         row[CategoryTable.name],
         row[CategoryTable.isDefault],
-        IncludeInUpdate.fromValue(row[CategoryTable.includeInUpdate]),
+        IncludeOrExclude.fromValue(row[CategoryTable.includeInUpdate]),
     )
 
     fun mangas(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<MangaNodeList> {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
@@ -25,6 +25,7 @@ class CategoryType(
     val name: String,
     val default: Boolean,
     val includeInUpdate: IncludeOrExclude,
+    val includeInDownload: IncludeOrExclude,
 ) : Node {
     constructor(row: ResultRow) : this(
         row[CategoryTable.id].value,
@@ -32,6 +33,7 @@ class CategoryType(
         row[CategoryTable.name],
         row[CategoryTable.isDefault],
         IncludeOrExclude.fromValue(row[CategoryTable.includeInUpdate]),
+        IncludeOrExclude.fromValue(row[CategoryTable.includeInDownload]),
     )
 
     fun mangas(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<MangaNodeList> {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/CategoryController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/CategoryController.kt
@@ -65,14 +65,15 @@ object CategoryController {
             formParam<String?>("name"),
             formParam<Boolean?>("default"),
             formParam<Int?>("includeInUpdate"),
+            formParam<Int?>("includeInDownload"),
             documentWith = {
                 withOperation {
                     summary("Category modify")
                     description("Modify a category")
                 }
             },
-            behaviorOf = { ctx, categoryId, name, isDefault, includeInUpdate ->
-                Category.updateCategory(categoryId, name, isDefault, includeInUpdate)
+            behaviorOf = { ctx, categoryId, name, isDefault, includeInUpdate, includeInDownload ->
+                Category.updateCategory(categoryId, name, isDefault, includeInUpdate, includeInDownload)
                 ctx.status(200)
             },
             withResults = {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -55,6 +55,7 @@ object Category {
         name: String?,
         isDefault: Boolean?,
         includeInUpdate: Int?,
+        includeInDownload: Int?,
     ) {
         transaction {
             CategoryTable.update({ CategoryTable.id eq categoryId }) {
@@ -66,6 +67,7 @@ object Category {
                 }
                 if (categoryId != DEFAULT_CATEGORY_ID && isDefault != null) it[CategoryTable.isDefault] = isDefault
                 if (includeInUpdate != null) it[CategoryTable.includeInUpdate] = includeInUpdate
+                if (includeInDownload != null) it[CategoryTable.includeInDownload] = includeInDownload
             }
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -277,6 +277,8 @@ class Updater : IUpdater {
         // In case no manga gets updated and no update job was running before, the client would never receive an info about its update request
         updateStatus(emptyList(), mangasToUpdate.isNotEmpty(), updateStatusCategories, skippedMangas)
 
+        logger.debug { "mangasToUpdate $mangasToUpdate" }
+
         if (mangasToUpdate.isEmpty()) {
             return
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -26,7 +26,7 @@ import suwayomi.tachidesk.manga.impl.CategoryManga
 import suwayomi.tachidesk.manga.impl.Chapter
 import suwayomi.tachidesk.manga.impl.Manga
 import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
-import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
+import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.server.serverConfig
@@ -222,9 +222,9 @@ class Updater : IUpdater {
         }
 
         val includeInUpdateStatusToCategoryMap = categories.groupBy { it.includeInUpdate }
-        val excludedCategories = includeInUpdateStatusToCategoryMap[IncludeInUpdate.EXCLUDE].orEmpty()
-        val includedCategories = includeInUpdateStatusToCategoryMap[IncludeInUpdate.INCLUDE].orEmpty()
-        val unsetCategories = includeInUpdateStatusToCategoryMap[IncludeInUpdate.UNSET].orEmpty()
+        val excludedCategories = includeInUpdateStatusToCategoryMap[IncludeOrExclude.EXCLUDE].orEmpty()
+        val includedCategories = includeInUpdateStatusToCategoryMap[IncludeOrExclude.INCLUDE].orEmpty()
+        val unsetCategories = includeInUpdateStatusToCategoryMap[IncludeOrExclude.UNSET].orEmpty()
         val categoriesToUpdate =
             if (forceAll) {
                 categories

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/CategoryDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/CategoryDataClass.kt
@@ -29,5 +29,6 @@ data class CategoryDataClass(
     val default: Boolean,
     val size: Int,
     val includeInUpdate: IncludeOrExclude,
+    val includeInDownload: IncludeOrExclude,
     val meta: Map<String, String> = emptyMap(),
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/CategoryDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/CategoryDataClass.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonValue
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-enum class IncludeInUpdate(
+enum class IncludeOrExclude(
     @JsonValue val value: Int,
 ) {
     EXCLUDE(0),
@@ -18,7 +18,7 @@ enum class IncludeInUpdate(
     ;
 
     companion object {
-        fun fromValue(value: Int) = IncludeInUpdate.values().find { it.value == value } ?: UNSET
+        fun fromValue(value: Int) = IncludeOrExclude.values().find { it.value == value } ?: UNSET
     }
 }
 
@@ -28,6 +28,6 @@ data class CategoryDataClass(
     val name: String,
     val default: Boolean,
     val size: Int,
-    val includeInUpdate: IncludeInUpdate,
+    val includeInUpdate: IncludeOrExclude,
     val meta: Map<String, String> = emptyMap(),
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/CategoryTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/CategoryTable.kt
@@ -11,13 +11,13 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ResultRow
 import suwayomi.tachidesk.manga.impl.Category
 import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
-import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
+import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 
 object CategoryTable : IntIdTable() {
     val name = varchar("name", 64)
     val order = integer("order").default(0)
     val isDefault = bool("is_default").default(false)
-    val includeInUpdate = integer("include_in_update").default(IncludeInUpdate.UNSET.value)
+    val includeInUpdate = integer("include_in_update").default(IncludeOrExclude.UNSET.value)
 }
 
 fun CategoryTable.toDataClass(categoryEntry: ResultRow) =
@@ -27,6 +27,6 @@ fun CategoryTable.toDataClass(categoryEntry: ResultRow) =
         categoryEntry[name],
         categoryEntry[isDefault],
         Category.getCategorySize(categoryEntry[id].value),
-        IncludeInUpdate.fromValue(categoryEntry[includeInUpdate]),
+        IncludeOrExclude.fromValue(categoryEntry[includeInUpdate]),
         Category.getCategoryMetaMap(categoryEntry[id].value),
     )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/CategoryTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/CategoryTable.kt
@@ -18,6 +18,7 @@ object CategoryTable : IntIdTable() {
     val order = integer("order").default(0)
     val isDefault = bool("is_default").default(false)
     val includeInUpdate = integer("include_in_update").default(IncludeOrExclude.UNSET.value)
+    val includeInDownload = integer("include_in_download").default(IncludeOrExclude.UNSET.value)
 }
 
 fun CategoryTable.toDataClass(categoryEntry: ResultRow) =
@@ -28,5 +29,6 @@ fun CategoryTable.toDataClass(categoryEntry: ResultRow) =
         categoryEntry[isDefault],
         Category.getCategorySize(categoryEntry[id].value),
         IncludeOrExclude.fromValue(categoryEntry[includeInUpdate]),
+        IncludeOrExclude.fromValue(categoryEntry[includeInDownload]),
         Category.getCategoryMetaMap(categoryEntry[id].value),
     )

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0026_CategoryIncludeInUpdate.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0026_CategoryIncludeInUpdate.kt
@@ -8,12 +8,12 @@ package suwayomi.tachidesk.server.database.migration
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import de.neonew.exposed.migrations.helpers.AddColumnMigration
-import suwayomi.tachidesk.manga.model.dataclass.IncludeInUpdate
+import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 
 @Suppress("ClassName", "unused")
 class M0026_CategoryIncludeInUpdate : AddColumnMigration(
     "Category",
     "include_in_update",
     "INT",
-    IncludeInUpdate.UNSET.value.toString(),
+    IncludeOrExclude.UNSET.value.toString(),
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0034_CategoryIncludeInDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0034_CategoryIncludeInDownload.kt
@@ -1,0 +1,19 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.AddColumnMigration
+import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
+
+@Suppress("ClassName", "unused")
+class M0034_CategoryIncludeInDownload : AddColumnMigration(
+    "Category",
+    "include_in_download",
+    "INT",
+    IncludeOrExclude.UNSET.value.toString(),
+)


### PR DESCRIPTION
Implementation is similar to the global update categories. This allows you to configure which manga you want to auto download based on their categories. The default behavior remains the same. If no categories are configured, then automatic downloads will behave the same as prior to this change, which is to say, all manga in your library are considered for automatic downloads.

The idea is that you might have `server.excludeEntryWithUnreadChapters=false` but don't necessarily want all your manga to get downloaded when new chapters come out. 

For example; if you've started a manga, but are taking a break, or if you finished a manga that has some "extra" chapters that come out later, or something. For a setup like this, I have a "currently reading" category, and a "backlog" and "completed" category". I'd set "currently reading" to be included, and the others to be excluded, ensuring only manga in my "currently reading" get auto downloaded as new chapters are released.