### PR TITLE
Prevent invalid webUI from stopping the server

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -258,7 +258,11 @@ object WebInterfaceManager {
             logger.info { "setupWebUI: found webUI files - flavor= ${serverConfig.webUIFlavor.value}, version= $currentVersion" }
 
             if (!isLocalWebUIValid(applicationDirs.webUIRoot)) {
-                doInitialSetup()
+                try {
+                    doInitialSetup()
+                } catch (e: Exception) {
+                    logger.warn(e) { "WebUI is invalid and failed to install a valid version, proceeding with invalid version" }
+                }
                 return
             }
 


### PR DESCRIPTION
In case there is no internet connection, it is not possible to verify the webUI files, leading to the server to fail from starting up. Instead, the existing webUI should just be used