### PR TITLE
Check download categories in downloadAheadChapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -32,12 +32,12 @@ import org.jetbrains.exposed.sql.statements.BatchUpdateStatement
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import suwayomi.tachidesk.manga.impl.Manga.getManga
+import suwayomi.tachidesk.manga.impl.Manga.shouldDownloadManga
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
 import suwayomi.tachidesk.manga.impl.download.DownloadManager.EnqueueInput
 import suwayomi.tachidesk.manga.impl.track.Track
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
 import suwayomi.tachidesk.manga.model.dataclass.ChapterDataClass
-import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 import suwayomi.tachidesk.manga.model.dataclass.MangaChapterDataClass
 import suwayomi.tachidesk.manga.model.dataclass.PaginatedList
 import suwayomi.tachidesk.manga.model.dataclass.paginatedFrom
@@ -336,41 +336,9 @@ object Chapter {
             return
         }
 
-        // Verify the manga is configured to be downloaded based on it's categories.
-        var mangaCategories = CategoryManga.getMangaCategories(mangaId).toSet()
-        // if the manga has no categories, then it's implicitly in the default category
-        if (mangaCategories.isEmpty()) {
-            val defaultCategory = Category.getCategoryById(Category.DEFAULT_CATEGORY_ID)
-            if (defaultCategory != null) {
-                mangaCategories = setOf(defaultCategory)
-            } else {
-                log.warn { "missing default category" }
-            }
-        }
-
-        if (mangaCategories.isNotEmpty()) {
-            val downloadCategoriesMap = Category.getCategoryList().groupBy { it.includeInDownload }
-            val unsetCategories = downloadCategoriesMap[IncludeOrExclude.UNSET].orEmpty()
-            // We only download if it's in the include list, and not in the exclude list.
-            // Use the unset categories as the included categories if the included categories is
-            // empty
-            val includedCategories = downloadCategoriesMap[IncludeOrExclude.INCLUDE].orEmpty().ifEmpty { unsetCategories }
-            val excludedCategories = downloadCategoriesMap[IncludeOrExclude.EXCLUDE].orEmpty()
-            // Only download manga that aren't in any excluded categories
-            val mangaExcludeCategories = mangaCategories.intersect(excludedCategories.toSet())
-            if (mangaExcludeCategories.isNotEmpty()) {
-                log.debug { "download excluded by categories: '${mangaExcludeCategories.joinToString("', '") { it.name }}'" }
-                return
-            }
-            val mangaDownloadCategories = mangaCategories.intersect(includedCategories.toSet())
-            if (mangaDownloadCategories.isNotEmpty()) {
-                log.debug { "download inluded by categories: '${mangaDownloadCategories.joinToString("', '") { it.name }}'" }
-            } else {
-                log.debug { "skipping download due to download categories configuration" }
-                return
-            }
-        } else {
-            log.debug { "no categories configured, skipping check for category download include/excludes" }
+        if (!shouldDownloadManga(mangaId)) {
+            log.debug { "manga is not configured to be downloaded" }
+            return
         }
 
         val newChapters = updatedChapterList.subList(0, numberOfNewChapters)


### PR DESCRIPTION
Obey download categories configuration in download ahead feature. I missed handling this in the PR introducing download the categories setting: https://github.com/Suwayomi/Suwayomi-Server/pull/832.

I opted to not do this in the download manager because users should still be able to download chapters if they decide to explicitly download them, rather than during an update/while reading.