### PR TITLE
Cleanup gql subscription session state correctly

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/subscriptions/ApolloSubscriptionProtocolHandler.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/subscriptions/ApolloSubscriptionProtocolHandler.kt
@@ -178,6 +178,7 @@ class ApolloSubscriptionProtocolHandler(
     }
 
     private fun onDisconnect(context: WsContext): Flow<SubscriptionOperationMessage> {
+        logger.debug("Session \"${context.sessionId}\" disconnected")
         sessionState.terminateSession(context, CloseStatus(1000, "Normal Closure"))
         return emptyFlow()
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/subscriptions/ApolloSubscriptionSessionState.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/subscriptions/ApolloSubscriptionSessionState.kt
@@ -90,7 +90,7 @@ internal class ApolloSubscriptionSessionState {
         code: CloseStatus,
     ) {
         sessionToOperationId.remove(context.sessionId)?.forEach {
-            activeOperations[it]?.cancel()
+            removeActiveOperation(it)
         }
         cachedGraphQLContext.remove(context.sessionId)
         context.closeSession(code)


### PR DESCRIPTION
In case a socket got disconnected, the session state of the subscriptions did not get correctly cleaned up.
The active operations did get closed but not removed and thus, when the client tried to reconnect, the server incorrectly detected an active subscription for an operation and immediately terminated the subscription.