### PR TITLE
Feature/remove download ahead logic

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -12,7 +12,7 @@ const val MainClass = "suwayomi.tachidesk.MainKt"
 // should be bumped with each stable release
 val tachideskVersion = System.getenv("ProductVersion") ?: "v0.7.0"
 
-val webUIRevisionTag = System.getenv("WebUIRevision") ?: "r1396"
+val webUIRevisionTag = System.getenv("WebUIRevision") ?: "r1397"
 
 // counts commits on the current checked out branch
 val getTachideskRevision = {

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -12,7 +12,7 @@ const val MainClass = "suwayomi.tachidesk.MainKt"
 // should be bumped with each stable release
 val tachideskVersion = System.getenv("ProductVersion") ?: "v0.7.0"
 
-val webUIRevisionTag = System.getenv("WebUIRevision") ?: "r1335"
+val webUIRevisionTag = System.getenv("WebUIRevision") ?: "r1396"
 
 // counts commits on the current checked out branch
 val getTachideskRevision = {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.graphql.types.ChapterType
 import suwayomi.tachidesk.graphql.types.DownloadStatus
 import suwayomi.tachidesk.manga.impl.Chapter
-import suwayomi.tachidesk.manga.impl.Manga
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
 import suwayomi.tachidesk.manga.impl.download.model.Status
 import suwayomi.tachidesk.manga.model.table.ChapterTable
@@ -268,21 +267,5 @@ class DownloadMutation {
                     },
             )
         }
-    }
-
-    data class DownloadAheadInput(
-        val clientMutationId: String? = null,
-        val mangaIds: List<Int> = emptyList(),
-        val latestReadChapterIds: List<Int>? = null,
-    )
-
-    data class DownloadAheadPayload(val clientMutationId: String?)
-
-    fun downloadAhead(input: DownloadAheadInput): DownloadAheadPayload {
-        val (clientMutationId, mangaIds, latestReadChapterIds) = input
-
-        Manga.downloadAhead(mangaIds, latestReadChapterIds ?: emptyList())
-
-        return DownloadAheadPayload(clientMutationId)
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -53,7 +53,7 @@ class SettingsMutation {
         updateSetting(settings.downloadsPath, serverConfig.downloadsPath)
         updateSetting(settings.autoDownloadNewChapters, serverConfig.autoDownloadNewChapters)
         updateSetting(settings.excludeEntryWithUnreadChapters, serverConfig.excludeEntryWithUnreadChapters)
-        updateSetting(settings.autoDownloadAheadLimit, serverConfig.autoDownloadAheadLimit)
+        updateSetting(settings.autoDownloadNewChaptersLimit, serverConfig.autoDownloadNewChaptersLimit)
 
         // extension
         updateSetting(settings.extensionRepos, serverConfig.extensionRepos)

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -53,6 +53,7 @@ class SettingsMutation {
         updateSetting(settings.downloadsPath, serverConfig.downloadsPath)
         updateSetting(settings.autoDownloadNewChapters, serverConfig.autoDownloadNewChapters)
         updateSetting(settings.excludeEntryWithUnreadChapters, serverConfig.excludeEntryWithUnreadChapters)
+        updateSetting(settings.autoDownloadAheadLimit, serverConfig.autoDownloadNewChaptersLimit) // deprecated
         updateSetting(settings.autoDownloadNewChaptersLimit, serverConfig.autoDownloadNewChaptersLimit)
 
         // extension

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -7,6 +7,7 @@
 
 package suwayomi.tachidesk.graphql.types
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import suwayomi.tachidesk.graphql.server.primitives.Node
 import suwayomi.tachidesk.server.ServerConfig
 import suwayomi.tachidesk.server.serverConfig
@@ -38,6 +39,12 @@ interface Settings : Node {
     val downloadsPath: String?
     val autoDownloadNewChapters: Boolean?
     val excludeEntryWithUnreadChapters: Boolean?
+
+    @GraphQLDeprecated(
+        "Replaced with autoDownloadNewChaptersLimit",
+        replaceWith = ReplaceWith("autoDownloadNewChaptersLimit"),
+    )
+    val autoDownloadAheadLimit: Int?
     val autoDownloadNewChaptersLimit: Int?
 
     // extension
@@ -99,6 +106,11 @@ data class PartialSettingsType(
     override val downloadsPath: String?,
     override val autoDownloadNewChapters: Boolean?,
     override val excludeEntryWithUnreadChapters: Boolean?,
+    @GraphQLDeprecated(
+        "Replaced with autoDownloadNewChaptersLimit",
+        replaceWith = ReplaceWith("autoDownloadNewChaptersLimit"),
+    )
+    override val autoDownloadAheadLimit: Int?,
     override val autoDownloadNewChaptersLimit: Int?,
     // extension
     override val extensionRepos: List<String>?,
@@ -152,6 +164,11 @@ class SettingsType(
     override val downloadsPath: String,
     override val autoDownloadNewChapters: Boolean,
     override val excludeEntryWithUnreadChapters: Boolean,
+    @GraphQLDeprecated(
+        "Replaced with autoDownloadNewChaptersLimit",
+        replaceWith = ReplaceWith("autoDownloadNewChaptersLimit"),
+    )
+    override val autoDownloadAheadLimit: Int,
     override val autoDownloadNewChaptersLimit: Int,
     // extension
     override val extensionRepos: List<String>,
@@ -204,6 +221,7 @@ class SettingsType(
         config.downloadsPath.value,
         config.autoDownloadNewChapters.value,
         config.excludeEntryWithUnreadChapters.value,
+        config.autoDownloadNewChaptersLimit.value, // deprecated
         config.autoDownloadNewChaptersLimit.value,
         // extension
         config.extensionRepos.value,

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -38,7 +38,7 @@ interface Settings : Node {
     val downloadsPath: String?
     val autoDownloadNewChapters: Boolean?
     val excludeEntryWithUnreadChapters: Boolean?
-    val autoDownloadAheadLimit: Int?
+    val autoDownloadNewChaptersLimit: Int?
 
     // extension
     val extensionRepos: List<String>?
@@ -99,7 +99,7 @@ data class PartialSettingsType(
     override val downloadsPath: String?,
     override val autoDownloadNewChapters: Boolean?,
     override val excludeEntryWithUnreadChapters: Boolean?,
-    override val autoDownloadAheadLimit: Int?,
+    override val autoDownloadNewChaptersLimit: Int?,
     // extension
     override val extensionRepos: List<String>?,
     // requests
@@ -152,7 +152,7 @@ class SettingsType(
     override val downloadsPath: String,
     override val autoDownloadNewChapters: Boolean,
     override val excludeEntryWithUnreadChapters: Boolean,
-    override val autoDownloadAheadLimit: Int,
+    override val autoDownloadNewChaptersLimit: Int,
     // extension
     override val extensionRepos: List<String>,
     // requests
@@ -204,7 +204,7 @@ class SettingsType(
         config.downloadsPath.value,
         config.autoDownloadNewChapters.value,
         config.excludeEntryWithUnreadChapters.value,
-        config.autoDownloadAheadLimit.value,
+        config.autoDownloadNewChaptersLimit.value,
         // extension
         config.extensionRepos.value,
         // requests

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -310,7 +310,7 @@ object Chapter {
                     "mangaId= $mangaId, " +
                     "prevNumberOfChapters= $prevNumberOfChapters, " +
                     "updatedChapterList= ${updatedChapterList.size}, " +
-                    "downloadAheadLimit= ${serverConfig.autoDownloadAheadLimit.value}" +
+                    "autoDownloadNewChaptersLimit= ${serverConfig.autoDownloadNewChaptersLimit.value}" +
                     ")",
             )
 
@@ -389,8 +389,8 @@ object Chapter {
         }
 
         val firstChapterToDownloadIndex =
-            if (serverConfig.autoDownloadAheadLimit.value > 0) {
-                (numberOfNewChapters - serverConfig.autoDownloadAheadLimit.value).coerceAtLeast(0)
+            if (serverConfig.autoDownloadNewChaptersLimit.value > 0) {
+                (numberOfNewChapters - serverConfig.autoDownloadNewChaptersLimit.value).coerceAtLeast(0)
             } else {
                 0
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -97,7 +97,7 @@ class ServerConfig(getConfig: () -> Config, val moduleName: String = SERVER_CONF
     val downloadsPath: MutableStateFlow<String> by OverrideConfigValue(StringConfigAdapter)
     val autoDownloadNewChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val excludeEntryWithUnreadChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
-    val autoDownloadAheadLimit: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
+    val autoDownloadNewChaptersLimit: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
 
     // extensions
     val extensionRepos: MutableStateFlow<List<String>> by OverrideConfigValues(StringConfigAdapter)

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -21,7 +21,7 @@ server.downloadAsCbz = false
 server.downloadsPath = ""
 server.autoDownloadNewChapters = false # if new chapters that have been retrieved should get automatically downloaded
 server.excludeEntryWithUnreadChapters = true # ignore automatic chapter downloads of entries with unread chapters
-server.autoDownloadAheadLimit = 0 # 0 to disable it - how many unread downloaded chapters should be available - if the limit is reached, new chapters won't be downloaded automatically. this limit will also be applied to the auto download of new chapters on an update
+server.autoDownloadNewChaptersLimit = 0 # 0 to disable it - how many unread downloaded chapters should be available - if the limit is reached, new chapters won't be downloaded automatically. this limit will also be applied to the auto download of new chapters on an update
 
 # extension repos
 server.extensionRepos = [

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -11,7 +11,7 @@ server.socksProxyPort = ""
 server.downloadAsCbz = false
 server.autoDownloadNewChapters = false
 server.excludeEntryWithUnreadChapters = true
-server.autoDownloadAheadLimit = 0
+server.autoDownloadNewChaptersLimit = 0
 
 # requests
 server.maxSourcesInParallel = 10


### PR DESCRIPTION
Unnecessary on server side (and was incorrectly implemented anyway), should just be done by the client

keep "autoDownloadAheadLimit" setting as "autoDownloadNewChaptersLimit" to prevent unnecessary downloads on a mass release of new chapters (e.g. after a manga hasn't been updated in a while)