### PR TITLE
Move trigger for track progress update to client

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
@@ -10,7 +10,6 @@ import suwayomi.tachidesk.graphql.types.ChapterMetaType
 import suwayomi.tachidesk.graphql.types.ChapterType
 import suwayomi.tachidesk.manga.impl.Chapter
 import suwayomi.tachidesk.manga.impl.chapter.getChapterDownloadReadyById
-import suwayomi.tachidesk.manga.impl.track.Track
 import suwayomi.tachidesk.manga.model.table.ChapterMetaTable
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.server.JavalinSetup.future
@@ -69,13 +68,6 @@ class ChapterMutation {
                         update[lastPageRead] = it
                         update[lastReadAt] = now
                     }
-                }
-                if (patch.isRead == true) {
-                    val mangaIds =
-                        ChapterTable.slice(ChapterTable.manga).select { ChapterTable.id inList ids }
-                            .map { it[ChapterTable.manga].value }
-                            .toSet()
-                    Track.asyncTrackChapter(mangaIds)
                 }
             }
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/TrackMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/TrackMutation.kt
@@ -133,6 +133,33 @@ class TrackMutation {
         }
     }
 
+    data class TrackProgressInput(
+        val clientMutationId: String? = null,
+        val mangaId: Int,
+    )
+
+    data class TrackProgressPayload(
+        val clientMutationId: String?,
+        val trackRecords: List<TrackRecordType>,
+    )
+
+    fun trackProgress(input: TrackProgressInput): CompletableFuture<TrackProgressPayload> {
+        val (clientMutationId, mangaId) = input
+
+        return future {
+            Track.trackChapter(mangaId)
+            val trackRecords =
+                transaction {
+                    TrackRecordTable.select { TrackRecordTable.mangaId eq mangaId }
+                        .toList()
+                }
+            TrackProgressPayload(
+                clientMutationId,
+                trackRecords.map { TrackRecordType(it) },
+            )
+        }
+    }
+
     data class UpdateTrackInput(
         val clientMutationId: String? = null,
         val recordId: Int,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -250,7 +250,7 @@ object Track {
         }
     }
 
-    private suspend fun trackChapter(mangaId: Int) {
+    suspend fun trackChapter(mangaId: Int) {
         val chapter = queryMaxReadChapter(mangaId)
         val chapterNumber = chapter?.get(ChapterTable.chapter_number)
         logger.debug {


### PR DESCRIPTION
Triggering the progress update on server side does not work because the client needs to get the mutation result, otherwise, the clients cache will get outdated