### PR TITLE
Prevent IndexOutOfBoundsException when removing duplicated chapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -370,7 +370,7 @@ object Chapter {
         val actualNewChapters = newChapters.subtract(reUploadedChapters.toSet()).toList()
         val chaptersToConsiderForDownloadLimit =
             if (serverConfig.autoDownloadIgnoreReUploads.value) {
-                actualNewChapters.removeDuplicates(actualNewChapters[0])
+                if (actualNewChapters.isNotEmpty()) actualNewChapters.removeDuplicates(actualNewChapters[0]) else emptyList()
             } else {
                 newChapters.removeDuplicates(newChapters[0])
             }.sortedBy { it.index }


### PR DESCRIPTION
In case the "new" chapters consisted only of re-uploads an out of bound exception was thrown