### PR TITLE
Prevent importing unsupported tracker from backup

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
@@ -41,6 +41,7 @@ import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupHistory
 import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupManga
 import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupSerializer
 import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupTracking
+import suwayomi.tachidesk.manga.impl.track.tracker.TrackerManager
 import suwayomi.tachidesk.manga.impl.track.tracker.model.toTrack
 import suwayomi.tachidesk.manga.impl.track.tracker.model.toTrackRecordDataClass
 import suwayomi.tachidesk.manga.model.dataclass.TrackRecordDataClass
@@ -404,6 +405,11 @@ object ProtoBackupImport : ProtoBackupBase() {
                     dbTrackRecordsByTrackerId[backupTrack.syncId]
                         ?: // new track
                         return@mapNotNull track
+
+                val isUnsupportedTracker = TrackerManager.getTracker(track.sync_id) == null
+                if (isUnsupportedTracker) {
+                    return@mapNotNull null
+                }
 
                 if (track.toTrackRecordDataClass().forComparison() == dbTrack.toTrackRecordDataClass().forComparison()) {
                     return@mapNotNull null

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -81,27 +81,25 @@ object Track {
             }.associateBy { it.trackerId }
 
         val trackers = TrackerManager.services
-        return trackers
-            .filter { it.isLoggedIn }
-            .map {
-                val record = recordMap[it.id]
-                if (record != null) {
-                    val track =
-                        Track.create(it.id).also { t ->
-                            t.score = record.score.toFloat()
-                        }
-                    record.scoreString = it.displayScore(track)
-                }
-                MangaTrackerDataClass(
-                    id = it.id,
-                    name = it.name,
-                    icon = proxyThumbnailUrl(it.id),
-                    statusList = it.getStatusList(),
-                    statusTextMap = it.getStatusList().associateWith { k -> it.getStatus(k).orEmpty() },
-                    scoreList = it.getScoreList(),
-                    record = record,
-                )
+        return trackers.map {
+            val record = recordMap[it.id]
+            if (record != null) {
+                val track =
+                    Track.create(it.id).also { t ->
+                        t.score = record.score.toFloat()
+                    }
+                record.scoreString = it.displayScore(track)
             }
+            MangaTrackerDataClass(
+                id = it.id,
+                name = it.name,
+                icon = proxyThumbnailUrl(it.id),
+                statusList = it.getStatusList(),
+                statusTextMap = it.getStatusList().associateWith { k -> it.getStatus(k).orEmpty() },
+                scoreList = it.getScoreList(),
+                record = record,
+            )
+        }
     }
 
     suspend fun search(input: SearchInput): List<TrackSearchDataClass> {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0037_RemoveTrackRecordsOfUnsupportedTrackers.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0037_RemoveTrackRecordsOfUnsupportedTrackers.kt
@@ -1,0 +1,19 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+import suwayomi.tachidesk.manga.impl.track.tracker.TrackerManager
+
+@Suppress("ClassName", "unused")
+class M0037_RemoveTrackRecordsOfUnsupportedTrackers : SQLMigration() {
+    override val sql: String =
+        """
+        DELETE FROM TRACKRECORD WHERE SYNC_ID NOT IN (${TrackerManager.MYANIMELIST}, ${TrackerManager.ANILIST}, ${TrackerManager.MANGA_UPDATES})
+        """.trimIndent()
+}


### PR DESCRIPTION
This will lead to graphql field validation errors (non null declared field is null) once the track records get used, since they will point to trackers that do not exist