### PR TITLE
Fix/failing track progress update for logged out trackers

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -281,7 +281,7 @@ object Track {
         val chapter = queryMaxReadChapter(mangaId)
         val chapterNumber = chapter?.get(ChapterTable.chapter_number)
 
-        logger.debug {
+        logger.info {
             "trackChapter(mangaId= $mangaId): maxReadChapter= #$chapterNumber ${chapter?.get(ChapterTable.name)}"
         }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -322,6 +322,12 @@ object Track {
             }
 
             val track = it.toTrack()
+
+            if (!tracker.isLoggedIn) {
+                upsertTrackRecord(track)
+                return@forEach
+            }
+
             tracker.refresh(track)
             upsertTrackRecord(track)
 
@@ -329,7 +335,7 @@ object Track {
 
             log.debug { "tracker= $tracker, remoteLastReadChapter= $lastChapterRead" }
 
-            if (tracker.isLoggedIn && chapterNumber > lastChapterRead) {
+            if (chapterNumber > lastChapterRead) {
                 track.last_chapter_read = chapterNumber.toFloat()
                 tracker.update(track, true)
                 upsertTrackRecord(track)


### PR DESCRIPTION
In case one tracker was logged out, the refresh failed with an unauthenticated error and caused the other trackers to not get updated