### PR TITLE
Support partial mutation responses

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/AsDataFetcherResult.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/AsDataFetcherResult.kt
@@ -1,0 +1,25 @@
+package suwayomi.tachidesk.graphql
+
+import com.expediagroup.graphql.server.extensions.toGraphQLError
+import graphql.execution.DataFetcherResult
+import mu.KotlinLogging
+
+val logger = KotlinLogging.logger { }
+
+inline fun <T> asDataFetcherResult(block: () -> T): DataFetcherResult<T?> {
+    val result =
+        runCatching {
+            block()
+        }
+
+    if (result.isFailure) {
+        logger.error(result.exceptionOrNull()) { "asDataFetcherResult: failed due to" }
+        return DataFetcherResult.newResult<T?>()
+            .error(result.exceptionOrNull()?.toGraphQLError())
+            .build()
+    }
+
+    return DataFetcherResult.newResult<T?>()
+        .data(result.getOrNull())
+        .build()
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ExtensionMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ExtensionMutation.kt
@@ -1,9 +1,11 @@
 package suwayomi.tachidesk.graphql.mutations
 
 import eu.kanade.tachiyomi.source.local.LocalSource
+import graphql.execution.DataFetcherResult
 import io.javalin.http.UploadedFile
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
+import suwayomi.tachidesk.graphql.asDataFetcherResult
 import suwayomi.tachidesk.graphql.types.ExtensionType
 import suwayomi.tachidesk.manga.impl.extension.Extension
 import suwayomi.tachidesk.manga.impl.extension.ExtensionsList
@@ -69,41 +71,45 @@ class ExtensionMutation {
         }
     }
 
-    fun updateExtension(input: UpdateExtensionInput): CompletableFuture<UpdateExtensionPayload> {
+    fun updateExtension(input: UpdateExtensionInput): CompletableFuture<DataFetcherResult<UpdateExtensionPayload?>> {
         val (clientMutationId, id, patch) = input
 
         return future {
-            updateExtensions(listOf(id), patch)
-        }.thenApply {
-            val extension =
-                transaction {
-                    ExtensionTable.select { ExtensionTable.pkgName eq id }.firstOrNull()
-                        ?.let { ExtensionType(it) }
-                }
+            asDataFetcherResult {
+                updateExtensions(listOf(id), patch)
 
-            UpdateExtensionPayload(
-                clientMutationId = clientMutationId,
-                extension = extension,
-            )
+                val extension =
+                    transaction {
+                        ExtensionTable.select { ExtensionTable.pkgName eq id }.firstOrNull()
+                            ?.let { ExtensionType(it) }
+                    }
+
+                UpdateExtensionPayload(
+                    clientMutationId = clientMutationId,
+                    extension = extension,
+                )
+            }
         }
     }
 
-    fun updateExtensions(input: UpdateExtensionsInput): CompletableFuture<UpdateExtensionsPayload> {
+    fun updateExtensions(input: UpdateExtensionsInput): CompletableFuture<DataFetcherResult<UpdateExtensionsPayload?>> {
         val (clientMutationId, ids, patch) = input
 
         return future {
-            updateExtensions(ids, patch)
-        }.thenApply {
-            val extensions =
-                transaction {
-                    ExtensionTable.select { ExtensionTable.pkgName inList ids }
-                        .map { ExtensionType(it) }
-                }
+            asDataFetcherResult {
+                updateExtensions(ids, patch)
 
-            UpdateExtensionsPayload(
-                clientMutationId = clientMutationId,
-                extensions = extensions,
-            )
+                val extensions =
+                    transaction {
+                        ExtensionTable.select { ExtensionTable.pkgName inList ids }
+                            .map { ExtensionType(it) }
+                    }
+
+                UpdateExtensionsPayload(
+                    clientMutationId = clientMutationId,
+                    extensions = extensions,
+                )
+            }
         }
     }
 
@@ -116,22 +122,24 @@ class ExtensionMutation {
         val extensions: List<ExtensionType>,
     )
 
-    fun fetchExtensions(input: FetchExtensionsInput): CompletableFuture<FetchExtensionsPayload> {
+    fun fetchExtensions(input: FetchExtensionsInput): CompletableFuture<DataFetcherResult<FetchExtensionsPayload?>> {
         val (clientMutationId) = input
 
         return future {
-            ExtensionsList.fetchExtensions()
-        }.thenApply {
-            val extensions =
-                transaction {
-                    ExtensionTable.select { ExtensionTable.name neq LocalSource.EXTENSION_NAME }
-                        .map { ExtensionType(it) }
-                }
+            asDataFetcherResult {
+                ExtensionsList.fetchExtensions()
 
-            FetchExtensionsPayload(
-                clientMutationId = clientMutationId,
-                extensions = extensions,
-            )
+                val extensions =
+                    transaction {
+                        ExtensionTable.select { ExtensionTable.name neq LocalSource.EXTENSION_NAME }
+                            .map { ExtensionType(it) }
+                    }
+
+                FetchExtensionsPayload(
+                    clientMutationId = clientMutationId,
+                    extensions = extensions,
+                )
+            }
         }
     }
 
@@ -145,18 +153,22 @@ class ExtensionMutation {
         val extension: ExtensionType,
     )
 
-    fun installExternalExtension(input: InstallExternalExtensionInput): CompletableFuture<InstallExternalExtensionPayload> {
+    fun installExternalExtension(
+        input: InstallExternalExtensionInput,
+    ): CompletableFuture<DataFetcherResult<InstallExternalExtensionPayload?>> {
         val (clientMutationId, extensionFile) = input
 
         return future {
-            Extension.installExternalExtension(extensionFile.content, extensionFile.filename)
-        }.thenApply {
-            val dbExtension = transaction { ExtensionTable.select { ExtensionTable.apkName eq extensionFile.filename }.first() }
+            asDataFetcherResult {
+                Extension.installExternalExtension(extensionFile.content, extensionFile.filename)
 
-            InstallExternalExtensionPayload(
-                clientMutationId,
-                extension = ExtensionType(dbExtension),
-            )
+                val dbExtension = transaction { ExtensionTable.select { ExtensionTable.apkName eq extensionFile.filename }.first() }
+
+                InstallExternalExtensionPayload(
+                    clientMutationId,
+                    extension = ExtensionType(dbExtension),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
In case e.g. a mutation was made which looked like this

myMutation {
  mutationA { ... }
  mutationB { ... }
  mutationC { ... }
}

and mutation A and B succeeded while mutation C failed, the response only included the error of C and the successful mutation data response of A and B was missing