### PR TITLE
Update metadata in source browse only if new data is not null

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/MangaList.kt
@@ -88,12 +88,12 @@ object MangaList {
                     mangaToUpdate.forEach { (sManga, manga) ->
                         addBatch(EntityID(manga[MangaTable.id].value, MangaTable))
                         this[MangaTable.title] = sManga.title
-                        this[MangaTable.artist] = sManga.artist
-                        this[MangaTable.author] = sManga.author
-                        this[MangaTable.description] = sManga.description
-                        this[MangaTable.genre] = sManga.genre
+                        this[MangaTable.artist] = sManga.artist ?: manga[MangaTable.artist]
+                        this[MangaTable.author] = sManga.author ?: manga[MangaTable.author]
+                        this[MangaTable.description] = sManga.description ?: manga[MangaTable.description]
+                        this[MangaTable.genre] = sManga.genre ?: manga[MangaTable.genre]
                         this[MangaTable.status] = sManga.status
-                        this[MangaTable.thumbnail_url] = sManga.thumbnail_url
+                        this[MangaTable.thumbnail_url] = sManga.thumbnail_url ?: manga[MangaTable.thumbnail_url]
                         this[MangaTable.updateStrategy] = sManga.update_strategy.name
                         if (!sManga.thumbnail_url.isNullOrEmpty() && manga[MangaTable.thumbnail_url] != sManga.thumbnail_url) {
                             this[MangaTable.thumbnailUrlLastFetched] = Instant.now().epochSecond


### PR DESCRIPTION
Browsing a source loads only a minimal representation of a manga which does not include some metadata. This metadata is only loaded when the specific manga gets fetched.

Thus, when the extra metadata of a manga was already loaded, it got removed when browsing the source and a page response included this manga