### PR TITLE
Compare webUI version with bundled webUI version

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -610,11 +610,9 @@ object WebInterfaceManager {
                 webUIVersion = fetchPreviewVersion(flavor)
             }
 
-            val isCompatibleVersion =
-                minServerVersionNumber <= currentServerVersionNumber && extractVersion(webUIVersion) >=
-                    extractVersion(
-                        BuildConfig.WEBUI_TAG,
-                    )
+            val isDefaultFlavor = WebUIFlavor.default == WebUIFlavor.current
+            val isNewerThanBundled = !isDefaultFlavor || extractVersion(webUIVersion) >= extractVersion(BuildConfig.WEBUI_TAG)
+            val isCompatibleVersion = minServerVersionNumber <= currentServerVersionNumber && isNewerThanBundled
             if (isCompatibleVersion) {
                 return webUIVersion
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -611,7 +611,7 @@ object WebInterfaceManager {
             }
 
             val isCompatibleVersion =
-                minServerVersionNumber <= currentServerVersionNumber && minServerVersionNumber >=
+                minServerVersionNumber <= currentServerVersionNumber && extractVersion(webUIVersion) >=
                     extractVersion(
                         BuildConfig.WEBUI_TAG,
                     )

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -136,6 +136,8 @@ enum class WebUIFlavor(
     }
 }
 
+fun WebUIFlavor.isDefault(): Boolean = this == WebUIFlavor.default
+
 object WebInterfaceManager {
     private val logger = KotlinLogging.logger {}
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -314,10 +316,7 @@ object WebInterfaceManager {
             // check if the bundled webUI version is a newer version than the current used version
             // this could be the case in case no compatible webUI version is available and a newer server version was installed
             val shouldUpdateToBundledVersion =
-                flavor.uiName == WebUIFlavor.default.uiName && extractVersion(getLocalVersion()) <
-                    extractVersion(
-                        BuildConfig.WEBUI_TAG,
-                    )
+                flavor.isDefault() && extractVersion(getLocalVersion()) < extractVersion(BuildConfig.WEBUI_TAG)
             if (shouldUpdateToBundledVersion) {
                 log.debug { "update to bundled version \"${BuildConfig.WEBUI_TAG}\"" }
 
@@ -375,7 +374,7 @@ object WebInterfaceManager {
             return
         }
 
-        if (flavor.uiName != WebUIFlavor.default.uiName) {
+        if (!flavor.isDefault()) {
             log.warn { "fallback to default webUI \"${WebUIFlavor.default.uiName}\"" }
 
             serverConfig.webUIFlavor.value = WebUIFlavor.default.uiName
@@ -610,8 +609,8 @@ object WebInterfaceManager {
                 webUIVersion = fetchPreviewVersion(flavor)
             }
 
-            val isDefaultFlavor = WebUIFlavor.default == WebUIFlavor.current
-            val isNewerThanBundled = !isDefaultFlavor || extractVersion(webUIVersion) >= extractVersion(BuildConfig.WEBUI_TAG)
+            val isNewerThanBundled =
+                !flavor.isDefault() || extractVersion(webUIVersion) >= extractVersion(BuildConfig.WEBUI_TAG)
             val isCompatibleVersion = minServerVersionNumber <= currentServerVersionNumber && isNewerThanBundled
             if (isCompatibleVersion) {
                 return webUIVersion


### PR DESCRIPTION
The bundled webUI version was incorrectly compared with the minimum server version.
This worked until the latest release, because the bundled webUI version had a lower revision number than the server revision, however, with the latest release, it is now higher, resulting in no compatible webUI version to be found