### PR TITLE
Exit early in case of empty chapter id list

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
@@ -57,6 +57,10 @@ class ChapterMutation {
         ids: List<Int>,
         patch: UpdateChapterPatch,
     ) {
+        if (ids.isEmpty()) {
+            return
+        }
+
         transaction {
             val chapterIdToPageCount =
                 if (patch.lastPageRead != null) {


### PR DESCRIPTION
In case the list was empty, the batch update failed with a NoSuchElement exception