### PR TITLE
Cleanup only created auto backup files

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupExport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupExport.kt
@@ -56,6 +56,7 @@ object ProtoBackupExport : ProtoBackupBase() {
     private var backupSchedulerJobId: String = ""
     private const val LAST_AUTOMATED_BACKUP_KEY = "lastAutomatedBackup"
     private val preferences = Injekt.get<Application>().getSharedPreferences("server_util", Context.MODE_PRIVATE)
+    private const val AUTO_BACKUP_FILENAME = "auto"
 
     init {
         serverConfig.subscribeTo(
@@ -114,7 +115,7 @@ object ProtoBackupExport : ProtoBackupBase() {
             val automatedBackupDir = File(applicationDirs.automatedBackupRoot)
             automatedBackupDir.mkdirs()
 
-            val backupFile = File(applicationDirs.automatedBackupRoot, Backup.getFilename())
+            val backupFile = File(applicationDirs.automatedBackupRoot, Backup.getFilename(AUTO_BACKUP_FILENAME))
 
             backupFile.outputStream().use { output -> input.copyTo(output) }
         }
@@ -133,7 +134,7 @@ object ProtoBackupExport : ProtoBackupBase() {
             return
         }
 
-        automatedBackupDir.walkTopDown().forEach { file ->
+        automatedBackupDir.listFiles { file -> file.name.startsWith(Backup.getBasename(AUTO_BACKUP_FILENAME)) }?.forEach { file ->
             try {
                 cleanupAutomatedBackupFile(file)
             } catch (e: Exception) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/Backup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/Backup.kt
@@ -2,6 +2,7 @@ package suwayomi.tachidesk.manga.impl.backup.proto.models
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
+import xyz.nulldev.androidcompat.util.SafePath
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -19,9 +20,18 @@ data class Backup(
     }
 
     companion object {
-        fun getFilename(): String {
+        fun getBasename(name: String = ""): String {
+            val namePrefix = "org.suwayomi.tachidesk"
+            val namePrefixSeparator = if (name.isNotEmpty()) "." else ""
+
+            return SafePath.buildValidFilename(namePrefix + namePrefixSeparator + name)
+        }
+
+        fun getFilename(name: String = ""): String {
             val date = SimpleDateFormat("yyyy-MM-dd_HH-mm").format(Date())
-            return "org.suwayomi.tachidesk_$date.tachibk"
+            val ext = ".tachibk"
+
+            return getBasename(name + "_$date") + ext
         }
     }
 }


### PR DESCRIPTION
The automated backup cleanup just deleted every file (recursively in subfolders as well) in the set folder in case it was older than the set backup ttl. This made it impossible to save the automated backups into a folder with different files.