### PR TITLE
Fix PersistentCookieStore for domains with an underscore

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/PersistentCookieStore.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/PersistentCookieStore.kt
@@ -88,7 +88,7 @@ class PersistentCookieStore(context: Context) : CookieStore {
     }
 
     fun get(url: HttpUrl): List<Cookie> {
-        return get(url.toUri().host ?: return emptyList())
+        return get(url.host)
     }
 
     override fun add(


### PR DESCRIPTION
The `java.net.URI` class does not parse hostnames with an underscore properly.
See a relevant OpenJDK bug report here https://bugs.openjdk.org/browse/JDK-8221675.
Their proposed workaround is
> URI.toURL().getHost()

This pull request adds `.toURL()` calls.

**Example code**

```java
final URI uri1 = new URI("https://iweb_1.mangapicgallery.com");
final URI uri2 = new URI("https://iweb1.mangapicgallery.com");

System.out.println("Host 1 " + uri1.getHost());
System.out.println("Host 1 " + uri1.toURL().getHost());
System.out.println("Host 2 " + uri2.getHost());
```

**Output**

```
Host 1 null
Host 1 iweb_1.mangapicgallery.com
Host 2 iweb1.mangapicgallery.com
```