### PR TITLE
Add setting to use the flaresolverr response

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -98,6 +98,7 @@ class SettingsMutation {
         updateSetting(settings.flareSolverrTimeout, serverConfig.flareSolverrTimeout)
         updateSetting(settings.flareSolverrSessionName, serverConfig.flareSolverrSessionName)
         updateSetting(settings.flareSolverrSessionTtl, serverConfig.flareSolverrSessionTtl)
+        updateSetting(settings.flareSolverrAsResponseFallback, serverConfig.flareSolverrAsResponseFallback)
     }
 
     fun setSettings(input: SetSettingsInput): SetSettingsPayload {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -89,6 +89,7 @@ interface Settings : Node {
     val flareSolverrTimeout: Int?
     val flareSolverrSessionName: String?
     val flareSolverrSessionTtl: Int?
+    val flareSolverrAsResponseFallback: Boolean?
 }
 
 data class PartialSettingsType(
@@ -151,6 +152,7 @@ data class PartialSettingsType(
     override val flareSolverrTimeout: Int?,
     override val flareSolverrSessionName: String?,
     override val flareSolverrSessionTtl: Int?,
+    override val flareSolverrAsResponseFallback: Boolean?,
 ) : Settings
 
 class SettingsType(
@@ -213,6 +215,7 @@ class SettingsType(
     override val flareSolverrTimeout: Int,
     override val flareSolverrSessionName: String,
     override val flareSolverrSessionTtl: Int,
+    override val flareSolverrAsResponseFallback: Boolean,
 ) : Settings {
     constructor(config: ServerConfig = serverConfig) : this(
         config.ip.value,
@@ -270,5 +273,6 @@ class SettingsType(
         config.flareSolverrTimeout.value,
         config.flareSolverrSessionName.value,
         config.flareSolverrSessionTtl.value,
+        config.flareSolverrAsResponseFallback.value,
     )
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -141,6 +141,7 @@ class ServerConfig(getConfig: () -> Config, val moduleName: String = SERVER_CONF
     val flareSolverrTimeout: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
     val flareSolverrSessionName: MutableStateFlow<String> by OverrideConfigValue(StringConfigAdapter)
     val flareSolverrSessionTtl: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
+    val flareSolverrAsResponseFallback: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun <T> subscribeTo(

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -67,3 +67,4 @@ server.flareSolverrUrl = "http://localhost:8191"
 server.flareSolverrTimeout = 60 # time in seconds
 server.flareSolverrSessionName = "suwayomi"
 server.flareSolverrSessionTtl = 15 # time in minutes
+server.flareSolverrAsResponseFallback = false

--- a/server/src/test/resources/server-reference.conf
+++ b/server/src/test/resources/server-reference.conf
@@ -67,3 +67,4 @@ server.flareSolverrUrl = "http://localhost:8191"
 server.flareSolverrTimeout = 60 # time in seconds
 server.flareSolverrSessionName = "suwayomi"
 server.flareSolverrSessionTtl = 15 # time in minutes
+server.flareSolverrAsResponseFallback = false


### PR DESCRIPTION
In some cases the Suwayomi server receives a cloudflare challenge but the flaresolverr does not.
When this happens and this setting is configured, it passes the response from flaresolverr back to suwayomi.

Sadly this does not work for images because chrome render a small html template which is what flaresolverr responds with, instead of the actual image data.