### PR TITLE
Always update uninitialized manga in global update

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -294,7 +294,7 @@ class Updater : IUpdater {
                     }
                 }
                 .filter {
-                    if (serverConfig.excludeNotStarted.value) {
+                    if (it.initialized && serverConfig.excludeNotStarted.value) {
                         it.lastReadAt != null
                     } else {
                         true


### PR DESCRIPTION
fixes #996

Manga can be added to the library while they have not been initialized yet. In this case, depending on the manga exclusion setting, they will never be updated automatically unless they get refreshed once manually.