### PR TITLE
Feature/graphql download queue subscription send only updates

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
@@ -96,7 +96,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first {
+                                DownloadManager.updates.first {
                                     DownloadManager.getStatus().queue.any { it.chapter.id in chapters }
                                 }.let { DownloadManager.getStatus() },
                             )
@@ -128,7 +128,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first { it.updates.any { it.downloadChapter.chapter.id == chapter } }
+                                DownloadManager.updates.first { it.updates.any { it.downloadChapter.chapter.id == chapter } }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -161,7 +161,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first {
+                                DownloadManager.updates.first {
                                     it.updates.none {
                                         it.downloadChapter.chapter.id in chapters && it.type != DEQUEUED
                                     }
@@ -196,7 +196,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first {
+                                DownloadManager.updates.first {
                                     it.updates.none {
                                         it.downloadChapter.chapter.id == chapter && it.type != DEQUEUED
                                     }
@@ -228,7 +228,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first { it.status == Status.Started }
+                                DownloadManager.updates.first { it.status == Status.Started }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -255,7 +255,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first { it.status == Status.Stopped }
+                                DownloadManager.updates.first { it.status == Status.Stopped }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -282,7 +282,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first { it.status == Status.Stopped }
+                                DownloadManager.updates.first { it.status == Status.Stopped }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -313,7 +313,7 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.status.first { it.updates.indexOfFirst { it.downloadChapter.chapter.id == chapter } <= to }
+                                DownloadManager.updates.first { it.updates.indexOfFirst { it.downloadChapter.chapter.id == chapter } <= to }
                                     .let { DownloadManager.getStatus() },
                             )
                         },

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/DownloadMutation.kt
@@ -96,9 +96,10 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first {
-                                    DownloadManager.getStatus().queue.any { it.chapter.id in chapters }
-                                }.let { DownloadManager.getStatus() },
+                                DownloadManager.updates
+                                    .first {
+                                        DownloadManager.getStatus().queue.any { it.chapter.id in chapters }
+                                    }.let { DownloadManager.getStatus() },
                             )
                         },
                 )
@@ -128,7 +129,8 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first { it.updates.any { it.downloadChapter.chapter.id == chapter } }
+                                DownloadManager.updates
+                                    .first { it.updates.any { it.downloadChapter.chapter.id == chapter } }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -161,12 +163,12 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first {
-                                    it.updates.none {
-                                        it.downloadChapter.chapter.id in chapters && it.type != DEQUEUED
-                                    }
-                                }
-                                    .let { DownloadManager.getStatus() },
+                                DownloadManager.updates
+                                    .first {
+                                        it.updates.none {
+                                            it.downloadChapter.chapter.id in chapters && it.type != DEQUEUED
+                                        }
+                                    }.let { DownloadManager.getStatus() },
                             )
                         },
                 )
@@ -196,12 +198,12 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first {
-                                    it.updates.none {
-                                        it.downloadChapter.chapter.id == chapter && it.type != DEQUEUED
-                                    }
-                                }
-                                    .let { DownloadManager.getStatus() },
+                                DownloadManager.updates
+                                    .first {
+                                        it.updates.none {
+                                            it.downloadChapter.chapter.id == chapter && it.type != DEQUEUED
+                                        }
+                                    }.let { DownloadManager.getStatus() },
                             )
                         },
                 )
@@ -228,7 +230,8 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first { it.status == Status.Started }
+                                DownloadManager.updates
+                                    .first { it.status == Status.Started }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -255,7 +258,8 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first { it.status == Status.Stopped }
+                                DownloadManager.updates
+                                    .first { it.status == Status.Stopped }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -282,7 +286,8 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first { it.status == Status.Stopped }
+                                DownloadManager.updates
+                                    .first { it.status == Status.Stopped }
                                     .let { DownloadManager.getStatus() },
                             )
                         },
@@ -313,7 +318,8 @@ class DownloadMutation {
                     downloadStatus =
                         withTimeout(30.seconds) {
                             DownloadStatus(
-                                DownloadManager.updates.first { it.updates.indexOfFirst { it.downloadChapter.chapter.id == chapter } <= to }
+                                DownloadManager.updates
+                                    .first { it.updates.indexOfFirst { it.downloadChapter.chapter.id == chapter } <= to }
                                     .let { DownloadManager.getStatus() },
                             )
                         },

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/DownloadQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/DownloadQuery.kt
@@ -1,6 +1,5 @@
 package suwayomi.tachidesk.graphql.queries
 
-import kotlinx.coroutines.flow.first
 import suwayomi.tachidesk.graphql.types.DownloadStatus
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
 import suwayomi.tachidesk.server.JavalinSetup.future
@@ -9,6 +8,6 @@ import java.util.concurrent.CompletableFuture
 class DownloadQuery {
     fun downloadStatus(): CompletableFuture<DownloadStatus> =
         future {
-            DownloadStatus(DownloadManager.status.first())
+            DownloadStatus(DownloadManager.getStatus())
         }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/DownloadSubscription.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/DownloadSubscription.kt
@@ -8,6 +8,7 @@
 package suwayomi.tachidesk.graphql.subscriptions
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import suwayomi.tachidesk.graphql.types.DownloadStatus
@@ -21,8 +22,39 @@ class DownloadSubscription {
             DownloadStatus(downloadStatus)
         }
 
-    fun downloadStatusChanged(): Flow<DownloadUpdates> =
-        DownloadManager.updates.map { downloadUpdates ->
-            DownloadUpdates(downloadUpdates)
+    data class DownloadChangedInput(
+        @GraphQLDescription(
+            "Sets a max number of updates that can be contained in a download update message." +
+                "Everything above this limit will be omitted and the \"downloadStatus\" should be re-fetched via the " +
+                "corresponding query. Due to the graphql subscription execution strategy not supporting batching for data loaders, " +
+                "the data loaders run into the n+1 problem, which can cause the server to get unresponsive until the status " +
+                "update has been handled. This is an issue e.g. when mass en- or dequeuing downloads.",
+        )
+        val maxUpdates: Int?,
+    )
+
+    fun downloadStatusChanged(input: DownloadChangedInput): Flow<DownloadUpdates> {
+        val omitUpdates = input.maxUpdates != null
+        val maxUpdates = input.maxUpdates ?: 50
+
+        return DownloadManager.updates.map { downloadUpdates ->
+            val omittedUpdates = omitUpdates && downloadUpdates.updates.size > maxUpdates
+
+            // the graphql subscription execution strategy does not support data loader batching which causes the n+1 problem,
+            // thus, too many updates (e.g. on mass enqueue or dequeue) causes unresponsiveness of the server until the
+            // update has been handled
+            val actualDownloadUpdates =
+                if (omittedUpdates) {
+                    suwayomi.tachidesk.manga.impl.download.model.DownloadUpdates(
+                        downloadUpdates.status,
+                        downloadUpdates.updates.subList(0, maxUpdates),
+                        downloadUpdates.initial,
+                    )
+                } else {
+                    downloadUpdates
+                }
+
+            DownloadUpdates(actualDownloadUpdates, omittedUpdates)
         }
+    }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/DownloadSubscription.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/DownloadSubscription.kt
@@ -7,14 +7,22 @@
 
 package suwayomi.tachidesk.graphql.subscriptions
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import suwayomi.tachidesk.graphql.types.DownloadStatus
+import suwayomi.tachidesk.graphql.types.DownloadUpdates
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
 
 class DownloadSubscription {
+    @GraphQLDeprecated("Replaced width downloadStatusChanged", ReplaceWith("downloadStatusChanged(input)"))
     fun downloadChanged(): Flow<DownloadStatus> =
         DownloadManager.status.map { downloadStatus ->
             DownloadStatus(downloadStatus)
+        }
+
+    fun downloadStatusChanged(): Flow<DownloadUpdates> =
+        DownloadManager.updates.map { downloadUpdates ->
+            DownloadUpdates(downloadUpdates)
         }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/DownloadType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/DownloadType.kt
@@ -7,6 +7,7 @@
 
 package suwayomi.tachidesk.graphql.types
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.expediagroup.graphql.server.extensions.getValueFromDataLoader
 import graphql.schema.DataFetchingEnvironment
@@ -41,6 +42,8 @@ data class DownloadStatus(
 data class DownloadUpdates(
     val state: DownloaderState,
     val updates: List<suwayomi.tachidesk.graphql.types.DownloadUpdate>,
+    @GraphQLDescription("The current download queue at the time of sending initial message. Is null for all following messages")
+    val initial: List<DownloadType>?,
 ) {
     constructor(downloadUpdates: DownloadUpdates) : this(
         when (downloadUpdates.status) {
@@ -48,6 +51,7 @@ data class DownloadUpdates(
             Status.Started -> DownloaderState.STARTED
         },
         downloadUpdates.updates.map { DownloadUpdate(it) },
+        downloadUpdates.initial?.map { DownloadType(it) },
     )
 }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/DownloadType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/DownloadType.kt
@@ -44,14 +44,20 @@ data class DownloadUpdates(
     val updates: List<suwayomi.tachidesk.graphql.types.DownloadUpdate>,
     @GraphQLDescription("The current download queue at the time of sending initial message. Is null for all following messages")
     val initial: List<DownloadType>?,
+    @GraphQLDescription(
+        "Indicates whether updates have been omitted based on the \"maxUpdates\" subscription variable. " +
+            "In case updates have been omitted, the \"downloadStatus\" query should be re-fetched.",
+    )
+    val omittedUpdates: Boolean,
 ) {
-    constructor(downloadUpdates: DownloadUpdates) : this(
+    constructor(downloadUpdates: DownloadUpdates, omittedUpdates: Boolean) : this(
         when (downloadUpdates.status) {
             Status.Stopped -> DownloaderState.STOPPED
             Status.Started -> DownloaderState.STARTED
         },
         downloadUpdates.updates.map { DownloadUpdate(it) },
         downloadUpdates.initial?.map { DownloadType(it) },
+        omittedUpdates,
     )
 }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -142,7 +142,7 @@ object DownloadManager {
     val status = statusFlow.onStart { emit(getStatus()) }
 
     private val updatesFlow = MutableSharedFlow<DownloadUpdates>()
-    val updates = updatesFlow.onStart { emit(getDownloadUpdates()) }
+    val updates = updatesFlow.onStart { emit(getDownloadUpdates(addInitial = true)) }
 
     init {
         scope.launch {
@@ -200,7 +200,7 @@ object DownloadManager {
             downloadQueue.toList(),
         )
 
-    private fun getDownloadUpdates(): DownloadUpdates {
+    private fun getDownloadUpdates(addInitial: Boolean = false): DownloadUpdates {
         return DownloadUpdates(
             if (downloadQueue.none { it.state == Downloading }) {
                 Status.Stopped
@@ -208,6 +208,7 @@ object DownloadManager {
                 Status.Started
             },
             downloadUpdates.toList(),
+            if (addInitial) downloadQueue.toList() else null,
         )
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -200,8 +200,8 @@ object DownloadManager {
             downloadQueue.toList(),
         )
 
-    private fun getDownloadUpdates(addInitial: Boolean = false): DownloadUpdates {
-        return DownloadUpdates(
+    private fun getDownloadUpdates(addInitial: Boolean = false): DownloadUpdates =
+        DownloadUpdates(
             if (downloadQueue.none { it.state == Downloading }) {
                 Status.Stopped
             } else {
@@ -210,7 +210,6 @@ object DownloadManager {
             downloadUpdates.toList(),
             if (addInitial) downloadQueue.toList() else null,
         )
-    }
 
     private val downloaderWatch = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.sample
@@ -36,6 +35,9 @@ import suwayomi.tachidesk.manga.impl.download.model.DownloadState.Downloading
 import suwayomi.tachidesk.manga.impl.download.model.DownloadState.Error
 import suwayomi.tachidesk.manga.impl.download.model.DownloadState.Queued
 import suwayomi.tachidesk.manga.impl.download.model.DownloadStatus
+import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdate
+import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdateType
+import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdates
 import suwayomi.tachidesk.manga.impl.download.model.Status
 import suwayomi.tachidesk.manga.model.dataclass.ChapterDataClass
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
@@ -47,6 +49,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.reflect.jvm.jvmName
 import kotlin.time.Duration.Companion.seconds
 
@@ -57,6 +60,7 @@ object DownloadManager {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val clients = ConcurrentHashMap<String, WsContext>()
     private val downloadQueue = CopyOnWriteArrayList<DownloadChapter>()
+    private val downloadUpdates = CopyOnWriteArraySet<DownloadUpdate>()
     private val downloaders = ConcurrentHashMap<String, Downloader>()
 
     private const val DOWNLOAD_QUEUE_KEY = "downloadQueueKey"
@@ -79,6 +83,13 @@ object DownloadManager {
 
     private fun triggerSaveDownloadQueue() {
         scope.launch { saveQueueFlow.emit(Unit) }
+    }
+
+    private fun handleDownloadUpdate(
+        immediate: Boolean,
+        download: DownloadUpdate? = null,
+    ) {
+        notifyAllClients(immediate, listOfNotNull(download))
     }
 
     fun restoreAndResumeDownloads() {
@@ -124,8 +135,14 @@ object DownloadManager {
 
     private val notifyFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
+    @Deprecated("Replaced with updatesFlow", replaceWith = ReplaceWith("updatesFlow"))
     private val statusFlow = MutableSharedFlow<DownloadStatus>()
+
+    @Deprecated("Replaced with updates", replaceWith = ReplaceWith("updates"))
     val status = statusFlow.onStart { emit(getStatus()) }
+
+    private val updatesFlow = MutableSharedFlow<DownloadUpdates>()
+    val updates = updatesFlow.onStart { emit(getDownloadUpdates()) }
 
     init {
         scope.launch {
@@ -147,12 +164,21 @@ object DownloadManager {
         }
     }
 
-    private fun notifyAllClients(immediate: Boolean = false) {
+    private fun notifyAllClients(
+        immediate: Boolean = false,
+        downloads: List<DownloadUpdate> = emptyList(),
+    ) {
+        downloadUpdates.addAll(downloads)
+
         if (immediate) {
             val status = getStatus()
+            val updates = getDownloadUpdates()
+
+            downloadUpdates.clear()
 
             scope.launch {
                 statusFlow.emit(status)
+                updatesFlow.emit(updates)
                 sendStatusToAllClients(status)
             }
 
@@ -164,7 +190,7 @@ object DownloadManager {
         }
     }
 
-    private fun getStatus(): DownloadStatus =
+    fun getStatus(): DownloadStatus =
         DownloadStatus(
             if (downloadQueue.none { it.state == Downloading }) {
                 Status.Stopped
@@ -173,6 +199,17 @@ object DownloadManager {
             },
             downloadQueue.toList(),
         )
+
+    private fun getDownloadUpdates(): DownloadUpdates {
+        return DownloadUpdates(
+            if (downloadQueue.none { it.state == Downloading }) {
+                Status.Stopped
+            } else {
+                Status.Started
+            },
+            downloadUpdates.toList(),
+        )
+    }
 
     private val downloaderWatch = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
@@ -234,7 +271,7 @@ object DownloadManager {
                 scope = scope,
                 sourceId = sourceId,
                 downloadQueue = downloadQueue,
-                notifier = ::notifyAllClients,
+                notifier = ::handleDownloadUpdate,
                 onComplete = ::refreshDownloaders,
                 onDownloadFinished = ::triggerSaveDownloadQueue,
             )
@@ -303,7 +340,7 @@ object DownloadManager {
         val addedChapters = inputs.mapNotNull { addToQueue(it.first, it.second) }
         if (addedChapters.isNotEmpty()) {
             start()
-            notifyAllClients(true)
+            notifyAllClients(false, addedChapters.map { DownloadUpdate(DownloadUpdateType.QUEUED, it) })
         }
         scope.launch {
             downloaderWatch.emit(Unit)
@@ -328,6 +365,7 @@ object DownloadManager {
                     manga.id,
                     chapter,
                     manga,
+                    downloadQueue.size,
                 )
             downloadQueue.add(newDownloadChapter)
             triggerSaveDownloadQueue()
@@ -374,7 +412,7 @@ object DownloadManager {
         downloadQueue.removeAll(chapterDownloads)
         triggerSaveDownloadQueue()
 
-        notifyAllClients()
+        notifyAllClients(false, chapterDownloads.toList().map { DownloadUpdate(DownloadUpdateType.DEQUEUED, it) })
     }
 
     fun reorder(
@@ -410,6 +448,8 @@ object DownloadManager {
 
         downloadQueue -= download
         downloadQueue.add(to, download)
+        download.position = to
+        notifyAllClients(false, listOf(DownloadUpdate(DownloadUpdateType.POSITION, download)))
         triggerSaveDownloadQueue()
     }
 
@@ -439,9 +479,10 @@ object DownloadManager {
         logger.debug { "clear" }
 
         stop()
+        val removedDownloads = downloadQueue.toList().map { DownloadUpdate(DownloadUpdateType.DEQUEUED, it) }
         downloadQueue.clear()
         triggerSaveDownloadQueue()
-        notifyAllClients()
+        notifyAllClients(false, removedDownloads)
     }
 }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadChapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadChapter.kt
@@ -16,6 +16,7 @@ class DownloadChapter(
     val mangaId: Int,
     var chapter: ChapterDataClass,
     var manga: MangaDataClass,
+    var position: Int,
     var state: DownloadState = Queued,
     var progress: Float = 0f,
     var tries: Int = 0,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadStatus.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadStatus.kt
@@ -16,3 +16,8 @@ data class DownloadStatus(
     val status: Status,
     val queue: List<DownloadChapter>,
 )
+
+data class DownloadUpdates(
+    val status: Status,
+    val updates: List<DownloadUpdate>,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadStatus.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadStatus.kt
@@ -20,4 +20,5 @@ data class DownloadStatus(
 data class DownloadUpdates(
     val status: Status,
     val updates: List<DownloadUpdate>,
+    val initial: List<DownloadChapter>?,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadUpdate.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadUpdate.kt
@@ -9,4 +9,7 @@ enum class DownloadUpdateType {
     POSITION,
 }
 
-data class DownloadUpdate(val type: DownloadUpdateType, val downloadChapter: DownloadChapter)
+data class DownloadUpdate(
+    val type: DownloadUpdateType,
+    val downloadChapter: DownloadChapter,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadUpdate.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadUpdate.kt
@@ -1,0 +1,12 @@
+package suwayomi.tachidesk.manga.impl.download.model
+
+enum class DownloadUpdateType {
+    QUEUED,
+    DEQUEUED,
+    PROGRESS,
+    FINISHED,
+    ERROR,
+    POSITION,
+}
+
+data class DownloadUpdate(val type: DownloadUpdateType, val downloadChapter: DownloadChapter)


### PR DESCRIPTION
the old download changed subscription has been marked as deprecated and a new subscription has been added

the new subscription sends only changed downloads instead of the full status with every message

the type includes the following fields

- the `initial` download queue within the initial message **(n+1)**
- `updates` for
  - en- and dequeuing  **(n+1 without combination of omitting updates)**
  - repositioning downloads
  - errors
  - finished downloads
- an option `maxUpdates` to omit updates by setting a max update limit to prevent n+1 problem - includes a flag `omittedUpdates` which indicates that the `downloadStatus` queue should get re-fetched