### PR TITLE
Initialize uninitialized manga during global update

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -225,7 +225,7 @@ class Updater : IUpdater {
         tracker[job.manga.id] =
             try {
                 logger.info { "Updating ${job.manga}" }
-                if (serverConfig.updateMangas.value) {
+                if (serverConfig.updateMangas.value || !job.manga.initialized) {
                     Manga.getManga(job.manga.id, true)
                 }
                 Chapter.getChapterList(job.manga.id, true)


### PR DESCRIPTION
They were only initialized in case the setting to refresh manga metadata during an update was enabled. However, this should always be done for uninitialized manga, regardless of the setting.

06bfc33e72de3879b3b5da75ada6d98aa0ad18af prevents uninitialized manga from getting filtered out, however, it did not ensure to initialize the manga