### PR TITLE
Initialize manga on add to library

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/IUpdater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/IUpdater.kt
@@ -3,6 +3,7 @@ package suwayomi.tachidesk.manga.impl.update
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
+import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 
 interface IUpdater {
     fun getLastUpdateTimestamp(): Long
@@ -12,6 +13,8 @@ interface IUpdater {
         clear: Boolean?,
         forceAll: Boolean,
     )
+
+    fun addMangasToQueue(mangas: List<MangaDataClass>)
 
     val status: Flow<UpdateStatus>
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -329,11 +329,11 @@ class Updater : IUpdater {
         )
     }
 
-    private fun addMangasToQueue(mangasToUpdate: List<MangaDataClass>) {
+    override fun addMangasToQueue(mangas: List<MangaDataClass>) {
         // create all manga update jobs before adding them to the queue so that the client is able to calculate the
         // progress properly right form the start
-        mangasToUpdate.forEach { tracker[it.id] = UpdateJob(it) }
-        mangasToUpdate.forEach { addMangaToQueue(it) }
+        mangas.forEach { tracker[it.id] = UpdateJob(it) }
+        mangas.forEach { addMangaToQueue(it) }
     }
 
     private fun addMangaToQueue(manga: MangaDataClass) {


### PR DESCRIPTION
In case a manga gets added to the library which has not been initialized yet, it should be tried to initialize it. Since it's not an error to have uninitialized manga in the library, this can be done in the background via the updater and the client receives the updated data via the update subscription.