### PR TITLE
Delete existing download of new chapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SettingsMutation.kt
@@ -59,6 +59,7 @@ class SettingsMutation {
         updateSetting(settings.autoDownloadAheadLimit, serverConfig.autoDownloadNewChaptersLimit) // deprecated
         updateSetting(settings.autoDownloadNewChaptersLimit, serverConfig.autoDownloadNewChaptersLimit)
         updateSetting(settings.autoDownloadIgnoreReUploads, serverConfig.autoDownloadIgnoreReUploads)
+        updateSetting(settings.autoDownloadDeleteExistingFiles, serverConfig.autoDownloadDeleteExistingFiles)
 
         // extension
         updateSetting(settings.extensionRepos, serverConfig.extensionRepos)

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -50,6 +50,7 @@ interface Settings : Node {
     val autoDownloadAheadLimit: Int?
     val autoDownloadNewChaptersLimit: Int?
     val autoDownloadIgnoreReUploads: Boolean?
+    val autoDownloadDeleteExistingFiles: Boolean?
 
     // extension
     val extensionRepos: List<String>?
@@ -121,6 +122,7 @@ data class PartialSettingsType(
     override val autoDownloadAheadLimit: Int?,
     override val autoDownloadNewChaptersLimit: Int?,
     override val autoDownloadIgnoreReUploads: Boolean?,
+    override val autoDownloadDeleteExistingFiles: Boolean?,
     // extension
     override val extensionRepos: List<String>?,
     // requests
@@ -184,6 +186,7 @@ class SettingsType(
     override val autoDownloadAheadLimit: Int,
     override val autoDownloadNewChaptersLimit: Int,
     override val autoDownloadIgnoreReUploads: Boolean?,
+    override val autoDownloadDeleteExistingFiles: Boolean,
     // extension
     override val extensionRepos: List<String>,
     // requests
@@ -242,6 +245,7 @@ class SettingsType(
         config.autoDownloadNewChaptersLimit.value, // deprecated
         config.autoDownloadNewChaptersLimit.value,
         config.autoDownloadIgnoreReUploads.value,
+        config.autoDownloadDeleteExistingFiles.value,
         // extension
         config.extensionRepos.value,
         // requests

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -185,7 +185,7 @@ class SettingsType(
     )
     override val autoDownloadAheadLimit: Int,
     override val autoDownloadNewChaptersLimit: Int,
-    override val autoDownloadIgnoreReUploads: Boolean?,
+    override val autoDownloadIgnoreReUploads: Boolean,
     override val autoDownloadDeleteExistingFiles: Boolean,
     // extension
     override val extensionRepos: List<String>,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -377,6 +377,12 @@ object Chapter {
             return
         }
 
+        // The downloader checks if pages are already downloaded to prevent unnecessary downloads. However, in case this
+        // is e.g. a re-uploaded chapter, this will prevent the new pages from getting downloaded
+        if (serverConfig.autoDownloadDeleteExistingFiles.value) {
+            deleteChapters(chapterIdsToDownload)
+        }
+
         log.info { "download ${chapterIdsToDownload.size} new chapter(s)..." }
 
         DownloadManager.enqueue(EnqueueInput(chapterIdsToDownload))

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -102,6 +102,7 @@ class ServerConfig(getConfig: () -> Config, val moduleName: String = SERVER_CONF
     val excludeEntryWithUnreadChapters: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
     val autoDownloadNewChaptersLimit: MutableStateFlow<Int> by OverrideConfigValue(IntConfigAdapter)
     val autoDownloadIgnoreReUploads: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
+    val autoDownloadDeleteExistingFiles: MutableStateFlow<Boolean> by OverrideConfigValue(BooleanConfigAdapter)
 
     // extensions
     val extensionRepos: MutableStateFlow<List<String>> by OverrideConfigValues(StringConfigAdapter)

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -26,6 +26,7 @@ server.autoDownloadNewChapters = false # if new chapters that have been retrieve
 server.excludeEntryWithUnreadChapters = true # ignore automatic chapter downloads of entries with unread chapters
 server.autoDownloadNewChaptersLimit = 0 # 0 to disable it - how many unread downloaded chapters should be available - if the limit is reached, new chapters won't be downloaded automatically. this limit will also be applied to the auto download of new chapters on an update
 server.autoDownloadIgnoreReUploads = false # decides if re-uploads should be ignored during auto download of new chapters
+server.autoDownloadDeleteExistingFiles = false # WARNING: this can cause a lot of downloads in case the app incorrectly detects "new" chapters due to a source changing chapter urls - delete existing downloads for new chapters to prevent pages from getting detected as already downloaded due to outdated pages of the existing download.
 
 # extension repos
 server.extensionRepos = [


### PR DESCRIPTION
The downloader checks if pages are already downloaded to prevent unnecessary downloads. However, in case this is e.g. a re-uploaded chapter, this will prevent the new pages from getting downloaded