### PR TITLE
Remove manga artist, author length limit

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
@@ -22,8 +22,8 @@ object MangaTable : IntIdTable() {
     val title = varchar("title", 512)
     val initialized = bool("initialized").default(false)
 
-    val artist = varchar("artist", 512).nullable()
-    val author = varchar("author", 512).nullable()
+    val artist = varchar("artist", Integer.MAX_VALUE).nullable()
+    val author = varchar("author", Integer.MAX_VALUE).nullable()
     val description = varchar("description", Integer.MAX_VALUE).nullable()
     val genre = varchar("genre", Integer.MAX_VALUE).nullable()
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0042_MangaRemoveLengthLimit_II.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0042_MangaRemoveLengthLimit_II.kt
@@ -1,0 +1,19 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+
+@Suppress("ClassName", "unused")
+class M0042_MangaRemoveLengthLimit_II : SQLMigration() {
+    override val sql =
+        """
+        ALTER TABLE MANGA ALTER COLUMN ARTIST VARCHAR; -- the default length is `Integer.MAX_VALUE`
+        ALTER TABLE MANGA ALTER COLUMN AUTHOR VARCHAR; -- the default length is `Integer.MAX_VALUE`
+        """.trimIndent()
+}


### PR DESCRIPTION
There are cases where the artist/author exceeds the length of 512 which causes the browse/search request to fail