### PR TITLE
Fix/gql download subscription

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -30,7 +30,9 @@ import suwayomi.tachidesk.manga.impl.download.model.DownloadState.Queued
 import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdate
 import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdateType.ERROR
 import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdateType.FINISHED
+import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdateType.PAUSED
 import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdateType.PROGRESS
+import suwayomi.tachidesk.manga.impl.download.model.DownloadUpdateType.STOPPED
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -146,14 +148,15 @@ class Downloader(
             } catch (e: CancellationException) {
                 logger.debug("Downloader was stopped")
                 availableSourceDownloads.filter { it.state == Downloading }.forEach { it.state = Queued }
+                notifier(false, DownloadUpdate(STOPPED, download))
             } catch (e: PauseDownloadException) {
                 downloadLogger.debug { "paused" }
                 download.state = Queued
+                notifier(false, DownloadUpdate(PAUSED, download))
             } catch (e: Exception) {
                 downloadLogger.warn("failed due to", e)
                 download.tries++
                 download.state = Error
-            } finally {
                 notifier(false, DownloadUpdate(ERROR, download))
             }
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/Downloader.kt
@@ -101,8 +101,8 @@ class Downloader(
         logger: KLogger,
         download: DownloadChapter,
     ) {
-        downloadQueue -= download
         notifier(true, DownloadUpdate(FINISHED, download))
+        downloadQueue -= download
         onDownloadFinished()
         logger.debug { "finished" }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadUpdate.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/model/DownloadUpdate.kt
@@ -3,6 +3,8 @@ package suwayomi.tachidesk.manga.impl.download.model
 enum class DownloadUpdateType {
     QUEUED,
     DEQUEUED,
+    PAUSED,
+    STOPPED,
     PROGRESS,
     FINISHED,
     ERROR,


### PR DESCRIPTION
for every download there was an update with status ERROR due to the notify with type error being called in the final block...

due to changes in https://github.com/Suwayomi/Suwayomi-Server/commit/168b76cb0c2c424f41380379b3da534c2ebcdd01 for the deprecated download subscription finished downloads were never included in the sent download status due to being removed from the queue before sending the status to the clients