### PR TITLE
Serve webui on all unmatched routes

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -43,7 +43,7 @@ object JavalinSetup {
             Javalin.create { config ->
                 if (serverConfig.webUIEnabled.value) {
                     val serveWebUI = {
-                        config.spaRoot.addFile("/root", applicationDirs.webUIRoot + "/index.html", Location.EXTERNAL)
+                        config.spaRoot.addFile("/", applicationDirs.webUIRoot + "/index.html", Location.EXTERNAL)
                     }
                     WebInterfaceManager.setServeWebUI(serveWebUI)
 


### PR DESCRIPTION
with "/root" only "http:localhost:4567" opened the webui all other endpoints resulted in "Endpoint GET /endpoint not found"