### PR TITLE
Allow cors with credentials

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -91,7 +91,8 @@ object JavalinSetup {
 
                 config.bundledPlugins.enableCors { cors ->
                     cors.addRule {
-                        it.anyHost()
+                        it.allowCredentials = true
+                        it.reflectClientOrigin = true
                     }
                 }
 


### PR DESCRIPTION
"anyHost" is not allowed in combination with "Access-Control-Allow-Credentials" (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sect2). At least the default webUI always includes credentials which causes a cors policy violation