### PR TITLE
Handle missing credentials as being invalid

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -108,7 +108,7 @@ object JavalinSetup {
 
         app.beforeMatched { ctx ->
             fun credentialsValid(): Boolean {
-                val basicAuthCredentials = ctx.basicAuthCredentials() ?: return true
+                val basicAuthCredentials = ctx.basicAuthCredentials() ?: return false
                 val (username, password) = basicAuthCredentials
                 return username == serverConfig.basicAuthUsername.value &&
                     password == serverConfig.basicAuthPassword.value


### PR DESCRIPTION
In case the credentials were missing the basic authentication was just bypassed