### PR TITLE
Handle missing track search results on bind

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -122,7 +122,7 @@ object Track {
         }
     }
 
-    private fun ResultRow.toTrack(mangaId: Int): Track =
+    private fun ResultRow.toTrackFromSearch(mangaId: Int): Track =
         Track.create(this[TrackSearchTable.trackerId]).also {
             it.manga_id = mangaId
             it.media_id = this[TrackSearchTable.remoteId]
@@ -143,8 +143,18 @@ object Track {
                     .where {
                         TrackSearchTable.trackerId eq trackerId and
                             (TrackSearchTable.remoteId eq remoteId)
-                    }.first()
-                    .toTrack(mangaId)
+                    }.firstOrNull()
+                    ?.toTrackFromSearch(mangaId)
+                    ?: TrackRecordTable
+                        .selectAll()
+                        .where {
+                            (TrackRecordTable.trackerId eq trackerId) and
+                                (TrackRecordTable.remoteId eq remoteId)
+                        }.first()
+                        .toTrack()
+                        .apply {
+                            manga_id = mangaId
+                        }
             }
         val tracker = TrackerManager.getTracker(trackerId)!!
 


### PR DESCRIPTION
It's possible that a manga is bound to a tracker while there is no search result. This happens when e.g. restoring a backup which includes track bindings for which there was never a tracker search.

In that case when trying to e.g. copy the binding to another manga, the mutation would fail due to not finding a search result. These cases can be handled by additionally checking the TrackRecordTable to get the necessary track info.