### PR TITLE
Ignore authentication for preflight requests

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -10,6 +10,7 @@ package suwayomi.tachidesk.server
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.javalin.Javalin
 import io.javalin.apibuilder.ApiBuilder.path
+import io.javalin.http.HandlerType
 import io.javalin.http.UnauthorizedResponse
 import io.javalin.http.staticfiles.Location
 import kotlinx.coroutines.CoroutineScope
@@ -108,6 +109,11 @@ object JavalinSetup {
             }
 
         app.beforeMatched { ctx ->
+            val isPreFlight = ctx.method() == HandlerType.OPTIONS
+            if (isPreFlight) {
+                return@beforeMatched
+            }
+
             fun credentialsValid(): Boolean {
                 val basicAuthCredentials = ctx.basicAuthCredentials() ?: return false
                 val (username, password) = basicAuthCredentials


### PR DESCRIPTION
Cors preflight requests never include credentials (https://fetch.spec.whatwg.org/#cors-protocol-and-credentials), thus, they always failed due to being unauthorized