### PR TITLE
Fix/backup with duplicated chapters failure

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
@@ -366,10 +366,11 @@ object ProtoBackupImport : ProtoBackupBase() {
         restoreMode: RestoreMode,
         chapters: List<Chapter>,
     ) = dbTransaction {
-        val chaptersLength = chapters.size
+        val uniqueChapters = chapters.distinctBy { it.url }
+        val chaptersLength = uniqueChapters.size
 
         if (restoreMode == RestoreMode.NEW) {
-            ChapterTable.batchInsert(chapters) { chapter ->
+            ChapterTable.batchInsert(uniqueChapters) { chapter ->
                 this[ChapterTable.url] = chapter.url
                 this[ChapterTable.name] = chapter.name
                 if (chapter.date_upload == 0L) {
@@ -394,7 +395,7 @@ object ProtoBackupImport : ProtoBackupBase() {
         // merge chapter data
         val dbChapters = ChapterTable.selectAll().where { ChapterTable.manga eq mangaId }
 
-        chapters.forEach { chapter ->
+        uniqueChapters.forEach { chapter ->
             val dbChapter = dbChapters.find { it[ChapterTable.url] == chapter.url }
 
             if (dbChapter == null) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
@@ -321,9 +321,7 @@ object ProtoBackupImport : ProtoBackupBase() {
                     restoreMangaChapterData(mangaId, RestoreMode.NEW, chapters)
 
                     // insert categories
-                    categories.forEach { backupCategoryOrder ->
-                        CategoryManga.addMangaToCategory(mangaId, categoryMapping[backupCategoryOrder]!!)
-                    }
+                    restoreMangaCategoryData(mangaId, categories, categoryMapping)
 
                     mangaId
                 }
@@ -352,9 +350,7 @@ object ProtoBackupImport : ProtoBackupBase() {
                     restoreMangaChapterData(mangaId, RestoreMode.EXISTING, chapters)
 
                     // merge categories
-                    categories.forEach { backupCategoryOrder ->
-                        CategoryManga.addMangaToCategory(mangaId, categoryMapping[backupCategoryOrder]!!)
-                    }
+                    restoreMangaCategoryData(mangaId, categories, categoryMapping)
 
                     mangaId
                 }
@@ -460,6 +456,16 @@ object ProtoBackupImport : ProtoBackupBase() {
                     it[isBookmarked] = chapter.bookmark || dbChapter[isBookmarked]
                 }
             }
+        }
+    }
+
+    private fun restoreMangaCategoryData(
+        mangaId: Int,
+        categories: List<Int>,
+        categoryMapping: Map<Int, Int>,
+    ) {
+        categories.forEach { backupCategoryOrder ->
+            CategoryManga.addMangaToCategory(mangaId, categoryMapping[backupCategoryOrder]!!)
         }
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/DBTransaction.util.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/DBTransaction.util.kt
@@ -1,0 +1,33 @@
+package suwayomi.tachidesk.server.database
+
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
+
+/**
+ * Performs the given transaction block inside the parent transaction or creates a new transaction if necessary.
+ *
+ * Any rollback or exception in the inner transaction will be propagated to the parent transaction.
+ */
+fun <T> dbTransaction(block: Transaction.() -> T): T {
+    val currentTransaction = TransactionManager.currentOrNull()
+
+    return if (currentTransaction == null) {
+        transaction { block() }
+    } else {
+        block(currentTransaction)
+    }
+}
+
+/**
+ * Creates a nested transaction.
+ *
+ * Any rollback or exception will only roll back the inner (nested) transaction, leaving the parent transaction unaffected.
+ *
+ * Only works in case "useNestedTransactions" is enabled.
+ */
+fun <T> nestedDbTransaction(block: Transaction.() -> T): T =
+    transaction {
+        check(db.useNestedTransactions) { "Nested transactions are not enabled." }
+        block()
+    }


### PR DESCRIPTION
In case a backup contained duplicated chapters for a manga, the manga failed to restore since the ChapterTable has a unique constraint to prevent multiple chapters with the same "url" and "mangaId"