### PR TITLE
Prevent chapter lastReadPage coerceIn error

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/ChapterMutation.kt
@@ -85,7 +85,7 @@ class ChapterMutation {
                             this[ChapterTable.isBookmarked] = it
                         }
                         patch.lastPageRead?.also {
-                            this[ChapterTable.lastPageRead] = it.coerceIn(0, chapterIdToPageCount[chapterId])
+                            this[ChapterTable.lastPageRead] = it.coerceAtMost(chapterIdToPageCount[chapterId] ?: 0).coerceAtLeast(0)
                             this[ChapterTable.lastReadAt] = now
                         }
                     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -159,7 +159,7 @@ private class ChapterForDownload(
             ChapterTable.update({ ChapterTable.id eq chapterId }) {
                 val pageCount = pageList.size
                 it[ChapterTable.pageCount] = pageCount
-                it[ChapterTable.lastPageRead] = chapterEntry[ChapterTable.lastPageRead].coerceIn(0, pageCount - 1)
+                it[ChapterTable.lastPageRead] = chapterEntry[ChapterTable.lastPageRead].coerceAtMost(pageCount - 1).coerceAtLeast(0)
             }
         }
     }


### PR DESCRIPTION
coerceIn throws an error in case the max value is less than the min value ("Cannot coerce value to an empty range: maximum <max> is less than minimum <min>")

Regression from c8bd39b4bfee44005614df5b647e803279e5218e