### PR TITLE
Add support for opds-pse for undownloaded chapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -434,16 +434,15 @@ object MangaController {
     val downloadChapter =
         handler(
             pathParam<Int>("chapterId"),
-            queryParam<Boolean?>("markAsRead"),
             documentWith = {
                 withOperation {
                     summary("Download chapter as CBZ")
                     description("Get the CBZ file of the specified chapter")
                 }
             },
-            behaviorOf = { ctx, chapterId, markAsRead ->
+            behaviorOf = { ctx, chapterId ->
                 ctx.future {
-                    future { ChapterDownloadHelper.getCbzForDownload(chapterId, markAsRead) }
+                    future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
                         .thenApply { (inputStream, fileName, fileSize) ->
                             ctx.header("Content-Type", "application/vnd.comicbook+zip")
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -434,15 +434,16 @@ object MangaController {
     val downloadChapter =
         handler(
             pathParam<Int>("chapterId"),
+            queryParam<Boolean?>("markAsRead"),
             documentWith = {
                 withOperation {
                     summary("Download chapter as CBZ")
                     description("Get the CBZ file of the specified chapter")
                 }
             },
-            behaviorOf = { ctx, chapterId ->
+            behaviorOf = { ctx, chapterId, markAsRead ->
                 ctx.future {
-                    future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
+                    future { ChapterDownloadHelper.getCbzForDownload(chapterId, markAsRead) }
                         .thenApply { (inputStream, fileName, fileSize) ->
                             ctx.header("Content-Type", "application/vnd.comicbook+zip")
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -437,7 +437,7 @@ object MangaController {
             },
             behaviorOf = { ctx, chapterId ->
                 ctx.future {
-                    future { ChapterDownloadHelper.getCbzDownload(chapterId) }
+                    future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
                         .thenApply { (inputStream, contentType, fileName) ->
                             ctx.header("Content-Type", contentType)
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -401,6 +401,7 @@ object MangaController {
             pathParam<Int>("mangaId"),
             pathParam<Int>("chapterIndex"),
             pathParam<Int>("index"),
+            queryParam<Boolean?>("updateProgress"),
             documentWith = {
                 withOperation {
                     summary("Get a chapter page")
@@ -409,14 +410,18 @@ object MangaController {
                     )
                 }
             },
-            behaviorOf = { ctx, mangaId, chapterIndex, index ->
+            behaviorOf = { ctx, mangaId, chapterIndex, index, updateProgress ->
                 ctx.future {
-                    future { Page.getPageImage(mangaId, chapterIndex, index) }
+                    future { Page.getPageImage(mangaId, chapterIndex, index, null) }
                         .thenApply {
                             ctx.header("content-type", it.second)
                             val httpCacheSeconds = 1.days.inWholeSeconds
                             ctx.header("cache-control", "max-age=$httpCacheSeconds")
                             ctx.result(it.first)
+
+                            if (updateProgress == true) {
+                                Chapter.updateChapterProgress(mangaId, chapterIndex, pageNo = index)
+                            }
                         }
                 }
             },
@@ -438,9 +443,10 @@ object MangaController {
             behaviorOf = { ctx, chapterId ->
                 ctx.future {
                     future { ChapterDownloadHelper.getCbzForDownload(chapterId) }
-                        .thenApply { (inputStream, contentType, fileName) ->
-                            ctx.header("Content-Type", contentType)
+                        .thenApply { (inputStream, fileName, fileSize) ->
+                            ctx.header("Content-Type", "application/vnd.comicbook+zip")
                             ctx.header("Content-Disposition", "attachment; filename=\"$fileName\"")
+                            ctx.header("Content-Length", fileSize.toString())
                             ctx.result(inputStream)
                         }
                 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -717,7 +717,7 @@ object Chapter {
             mangaId,
             chapterIndex,
             isRead = isRead,
-            lastPageRead = oneIndexedPageNo,
+            lastPageRead = pageNo,
             isBookmarked = null,
             markPrevRead = null,
         )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -52,7 +52,10 @@ object ChapterDownloadHelper {
         chapterId: Int,
     ): Pair<InputStream, Long> = provider(mangaId, chapterId).getAsArchiveStream()
 
-    fun getCbzForDownload(chapterId: Int): Triple<InputStream, String, Long> {
+    fun getCbzForDownload(
+        chapterId: Int,
+        markAsRead: Boolean?,
+    ): Triple<InputStream, String, Long> {
         val (chapterData, mangaTitle) =
             transaction {
                 val row =
@@ -68,6 +71,17 @@ object ChapterDownloadHelper {
         val fileName = "$mangaTitle - [${chapterData.scanlator}] ${chapterData.name}.cbz"
 
         val cbzFile = provider(chapterData.mangaId, chapterData.id).getAsArchiveStream()
+
+        if (markAsRead == true) {
+            Chapter.modifyChapter(
+                chapterData.mangaId,
+                chapterData.index,
+                isRead = true,
+                isBookmarked = null,
+                markPrevRead = null,
+                lastPageRead = null,
+            )
+        }
 
         return Triple(cbzFile.first, fileName, cbzFile.second)
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -15,7 +15,6 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.batchInsert
-import org.jetbrains.exposed.sql.count
 import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -27,16 +26,6 @@ import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.PageTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
-
-suspend fun getPageCountForChapter(
-    chapterId: Int? = null,
-    chapterIndex: Int? = null,
-    mangaId: Int? = null,
-    forceRefresh: Boolean,
-): ChapterDataClass {
-    val chapter = ChapterForDownload(chapterId, chapterIndex, mangaId)
-    return chapter.refreshPageListForChapter(forceRefresh)
-}
 
 suspend fun getChapterDownloadReady(
     chapterId: Int? = null,
@@ -65,22 +54,6 @@ private class ChapterForDownload(
     val mangaId: Int
 
     val logger: KLogger
-
-    suspend fun refreshPageListForChapter(forceRefresh: Boolean): ChapterDataClass {
-        val log = KotlinLogging.logger("${logger.name}::updateChapterPageCount")
-
-        val pageEntityCount =
-            transaction { PageTable.select(PageTable.index.count()).where((PageTable.chapter eq chapterId)).count() }
-        val hasSamePageSizeAsCount = chapterEntry[ChapterTable.pageCount].toLong() == pageEntityCount
-
-        log.debug { "alwaysUpdate= $forceRefresh (pageTableCount= $pageEntityCount, hasSamePageSizeAsCount= $hasSamePageSizeAsCount)" }
-
-        if (hasSamePageSizeAsCount && !forceRefresh) {
-            return asDataClass()
-        }
-
-        return asDownloadReady()
-    }
 
     suspend fun asDownloadReady(): ChapterDataClass {
         val log = KotlinLogging.logger("${logger.name}::asDownloadReady")

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
@@ -125,7 +125,10 @@ abstract class ChaptersFilesProvider<Type : FileType>(
                                 .distinctUntilChanged()
                                 .onEach {
                                     download.progress = (pageNum.toFloat() + (it.toFloat() * 0.01f)) / pageCount
-                                    step(null, false) // don't throw on canceled download here since we can't do anything
+                                    step(
+                                        null,
+                                        false,
+                                    ) // don't throw on canceled download here since we can't do anything
                                 }.launchIn(scope)
                     }.first
                     .close()
@@ -159,4 +162,6 @@ abstract class ChaptersFilesProvider<Type : FileType>(
         FileDownload3Args(::downloadImpl)
 
     abstract override fun delete(): Boolean
+
+    abstract fun getAsArchiveStream(): Pair<InputStream, Long>
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
@@ -88,6 +88,15 @@ class ArchiveProvider(
         return cbzDeleted
     }
 
+    override fun getAsArchiveStream(): Pair<InputStream, Long> {
+        val cbzFile =
+            File(getChapterCbzPath(mangaId, chapterId))
+                .takeIf { it.exists() }
+                ?: throw Exception("CBZ file not found for chapter ID: $chapterId (Manga ID: $mangaId)")
+
+        return cbzFile.inputStream() to cbzFile.length()
+    }
+
     private fun extractCbzFile(
         cbzFile: File,
         chapterFolder: File,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
@@ -92,7 +92,7 @@ class ArchiveProvider(
         val cbzFile =
             File(getChapterCbzPath(mangaId, chapterId))
                 .takeIf { it.exists() }
-                ?: throw Exception("CBZ file not found for chapter ID: $chapterId (Manga ID: $mangaId)")
+                ?: throw IllegalArgumentException("CBZ file not found for chapter ID: $chapterId (Manga ID: $mangaId)")
 
         return cbzFile.inputStream() to cbzFile.length()
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/FolderProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/FolderProvider.kt
@@ -7,8 +7,14 @@ import suwayomi.tachidesk.manga.impl.util.getChapterDownloadPath
 import suwayomi.tachidesk.manga.impl.util.storage.FileDeletionHelper
 import suwayomi.tachidesk.server.ApplicationDirs
 import uy.kohesive.injekt.injectLazy
+import java.io.BufferedOutputStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileInputStream
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 private val applicationDirs: ApplicationDirs by injectLazy()
 
@@ -57,5 +63,32 @@ class FolderProvider(
         val chapterDirDeleted = chapterDir.deleteRecursively()
         FileDeletionHelper.cleanupParentFoldersFor(chapterDir, applicationDirs.mangaDownloadsRoot)
         return chapterDirDeleted
+    }
+
+    override fun getAsArchiveStream(): Pair<InputStream, Long> {
+        val chapterDir = File(getChapterDownloadPath(mangaId, chapterId))
+
+        if (!chapterDir.exists() || !chapterDir.isDirectory || chapterDir.listFiles().isNullOrEmpty()) {
+            throw IllegalArgumentException("Invalid folder to create CBZ for chapter ID: $chapterId")
+        }
+
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        ZipOutputStream(BufferedOutputStream(byteArrayOutputStream)).use { zipOutputStream ->
+            chapterDir
+                .listFiles()
+                ?.filter { it.isFile }
+                ?.sortedBy { it.name }
+                ?.forEach { imageFile ->
+                    FileInputStream(imageFile).use { fileInputStream ->
+                        val zipEntry = ZipEntry(imageFile.name)
+                        zipOutputStream.putNextEntry(zipEntry)
+                        fileInputStream.copyTo(zipOutputStream)
+                        zipOutputStream.closeEntry()
+                    }
+                }
+        }
+
+        val zipData = byteArrayOutputStream.toByteArray()
+        return ByteArrayInputStream(zipData) to zipData.size.toLong()
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/ChapterTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/ChapterTable.kt
@@ -41,31 +41,43 @@ object ChapterTable : IntIdTable() {
     val manga = reference("manga", MangaTable, ReferenceOption.CASCADE)
 }
 
-fun ChapterTable.toDataClass(chapterEntry: ResultRow) =
-    ChapterDataClass(
-        id = chapterEntry[id].value,
-        url = chapterEntry[url],
-        name = chapterEntry[name],
-        uploadDate = chapterEntry[date_upload],
-        chapterNumber = chapterEntry[chapter_number],
-        scanlator = chapterEntry[scanlator],
-        mangaId = chapterEntry[manga].value,
-        read = chapterEntry[isRead],
-        bookmarked = chapterEntry[isBookmarked],
-        lastPageRead = chapterEntry[lastPageRead],
-        lastReadAt = chapterEntry[lastReadAt],
-        index = chapterEntry[sourceOrder],
-        fetchedAt = chapterEntry[fetchedAt],
-        realUrl = chapterEntry[realUrl],
-        downloaded = chapterEntry[isDownloaded],
-        pageCount = chapterEntry[pageCount],
-        chapterCount =
+fun ChapterTable.toDataClass(
+    chapterEntry: ResultRow,
+    fetchChapterCount: Boolean = true,
+    fetchChapterMeta: Boolean = true,
+) = ChapterDataClass(
+    id = chapterEntry[id].value,
+    url = chapterEntry[url],
+    name = chapterEntry[name],
+    uploadDate = chapterEntry[date_upload],
+    chapterNumber = chapterEntry[chapter_number],
+    scanlator = chapterEntry[scanlator],
+    mangaId = chapterEntry[manga].value,
+    read = chapterEntry[isRead],
+    bookmarked = chapterEntry[isBookmarked],
+    lastPageRead = chapterEntry[lastPageRead],
+    lastReadAt = chapterEntry[lastReadAt],
+    index = chapterEntry[sourceOrder],
+    fetchedAt = chapterEntry[fetchedAt],
+    realUrl = chapterEntry[realUrl],
+    downloaded = chapterEntry[isDownloaded],
+    pageCount = chapterEntry[pageCount],
+    chapterCount =
+        if (fetchChapterCount) {
             transaction {
                 ChapterTable
                     .selectAll()
                     .where { manga eq chapterEntry[manga].value }
                     .count()
                     .toInt()
-            },
-        meta = getChapterMetaMap(chapterEntry[id]),
-    )
+            }
+        } else {
+            null
+        },
+    meta =
+        if (fetchChapterMeta) {
+            getChapterMetaMap(chapterEntry[id])
+        } else {
+            emptyMap()
+        },
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/ChapterTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/ChapterTable.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.manga.impl.Chapter.getChapterMetaMap
 import suwayomi.tachidesk.manga.model.dataclass.ChapterDataClass
-import suwayomi.tachidesk.manga.model.table.MangaTable.nullable
 
 object ChapterTable : IntIdTable() {
     val url = varchar("url", 2048)
@@ -43,8 +42,8 @@ object ChapterTable : IntIdTable() {
 
 fun ChapterTable.toDataClass(
     chapterEntry: ResultRow,
-    fetchChapterCount: Boolean = true,
-    fetchChapterMeta: Boolean = true,
+    includeChapterCount: Boolean = true,
+    includeChapterMeta: Boolean = true,
 ) = ChapterDataClass(
     id = chapterEntry[id].value,
     url = chapterEntry[url],
@@ -63,7 +62,7 @@ fun ChapterTable.toDataClass(
     downloaded = chapterEntry[isDownloaded],
     pageCount = chapterEntry[pageCount],
     chapterCount =
-        if (fetchChapterCount) {
+        if (includeChapterCount) {
             transaction {
                 ChapterTable
                     .selectAll()
@@ -75,7 +74,7 @@ fun ChapterTable.toDataClass(
             null
         },
     meta =
-        if (fetchChapterMeta) {
+        if (includeChapterMeta) {
             getChapterMetaMap(chapterEntry[id])
         } else {
             emptyMap()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
@@ -46,28 +46,35 @@ object MangaTable : IntIdTable() {
     val updateStrategy = varchar("update_strategy", 256).default(UpdateStrategy.ALWAYS_UPDATE.name)
 }
 
-fun MangaTable.toDataClass(mangaEntry: ResultRow) =
-    MangaDataClass(
-        id = mangaEntry[this.id].value,
-        sourceId = mangaEntry[sourceReference].toString(),
-        url = mangaEntry[url],
-        title = mangaEntry[title],
-        thumbnailUrl = proxyThumbnailUrl(mangaEntry[this.id].value),
-        thumbnailUrlLastFetched = mangaEntry[thumbnailUrlLastFetched],
-        initialized = mangaEntry[initialized],
-        artist = mangaEntry[artist],
-        author = mangaEntry[author],
-        description = mangaEntry[description],
-        genre = mangaEntry[genre].toGenreList(),
-        status = Companion.valueOf(mangaEntry[status]).name,
-        inLibrary = mangaEntry[inLibrary],
-        inLibraryAt = mangaEntry[inLibraryAt],
-        meta = getMangaMetaMap(mangaEntry[id].value),
-        realUrl = mangaEntry[realUrl],
-        lastFetchedAt = mangaEntry[lastFetchedAt],
-        chaptersLastFetchedAt = mangaEntry[chaptersLastFetchedAt],
-        updateStrategy = UpdateStrategy.valueOf(mangaEntry[updateStrategy]),
-    )
+fun MangaTable.toDataClass(
+    mangaEntry: ResultRow,
+    fetchMangaMeta: Boolean = true,
+) = MangaDataClass(
+    id = mangaEntry[this.id].value,
+    sourceId = mangaEntry[sourceReference].toString(),
+    url = mangaEntry[url],
+    title = mangaEntry[title],
+    thumbnailUrl = proxyThumbnailUrl(mangaEntry[this.id].value),
+    thumbnailUrlLastFetched = mangaEntry[thumbnailUrlLastFetched],
+    initialized = mangaEntry[initialized],
+    artist = mangaEntry[artist],
+    author = mangaEntry[author],
+    description = mangaEntry[description],
+    genre = mangaEntry[genre].toGenreList(),
+    status = Companion.valueOf(mangaEntry[status]).name,
+    inLibrary = mangaEntry[inLibrary],
+    inLibraryAt = mangaEntry[inLibraryAt],
+    meta =
+        if (fetchMangaMeta) {
+            getMangaMetaMap(mangaEntry[id].value)
+        } else {
+            emptyMap()
+        },
+    realUrl = mangaEntry[realUrl],
+    lastFetchedAt = mangaEntry[lastFetchedAt],
+    chaptersLastFetchedAt = mangaEntry[chaptersLastFetchedAt],
+    updateStrategy = UpdateStrategy.valueOf(mangaEntry[updateStrategy]),
+)
 
 enum class MangaStatus(
     val value: Int,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/MangaTable.kt
@@ -48,7 +48,7 @@ object MangaTable : IntIdTable() {
 
 fun MangaTable.toDataClass(
     mangaEntry: ResultRow,
-    fetchMangaMeta: Boolean = true,
+    includeMangaMeta: Boolean = true,
 ) = MangaDataClass(
     id = mangaEntry[this.id].value,
     sourceId = mangaEntry[sourceReference].toString(),
@@ -65,7 +65,7 @@ fun MangaTable.toDataClass(
     inLibrary = mangaEntry[inLibrary],
     inLibraryAt = mangaEntry[inLibraryAt],
     meta =
-        if (fetchMangaMeta) {
+        if (includeMangaMeta) {
             getMangaMetaMap(mangaEntry[id].value)
         } else {
             emptyMap()

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -23,6 +23,7 @@ object OpdsAPI {
             get("genres", OpdsV1Controller.genresFeed)
             get("status", OpdsV1Controller.statusFeed)
             get("languages", OpdsV1Controller.languagesFeed)
+            get("library-updates", OpdsV1Controller.libraryUpdatesFeed)
 
             // Faceted feeds (Acquisition Feeds)
             path("manga/{mangaId}") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -29,6 +29,10 @@ object OpdsAPI {
                 get(OpdsV1Controller.mangaFeed)
             }
 
+            path("manga/{mangaId}/chapter/{chapterId}/fetch") {
+                get(OpdsV1Controller.chapterMetadataFeed)
+            }
+
             path("source/{sourceId}") {
                 get(OpdsV1Controller.sourceFeed)
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
@@ -278,6 +278,31 @@ object OpdsV1Controller {
             },
         )
 
+    var chapterMetadataFeed =
+        handler(
+            pathParam<Int>("mangaId"),
+            pathParam<Int>("chapterId"),
+            documentWith = {
+                withOperation {
+                    summary("OPDS Chapter Details Feed")
+                    description("OPDS feed for a specific undownloaded chapter of a manga")
+                }
+            },
+            behaviorOf = { ctx, mangaId, chapterId ->
+                ctx.future {
+                    future {
+                        Opds.getChapterMetadataFeed(mangaId, chapterId, BASE_URL)
+                    }.thenApply { xml ->
+                        ctx.contentType(OPDS_MIME).result(xml)
+                    }
+                }
+            },
+            withResults = {
+                httpCode(HttpStatus.OK)
+                httpCode(HttpStatus.NOT_FOUND)
+            },
+        )
+
     // Specific Source Feed
     val sourceFeed =
         handler(

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
@@ -432,4 +432,28 @@ object OpdsV1Controller {
                 httpCode(HttpStatus.NOT_FOUND)
             },
         )
+
+    // Main Library Updates Feed
+    val libraryUpdatesFeed =
+        handler(
+            queryParam<Int?>("pageNumber"),
+            documentWith = {
+                withOperation {
+                    summary("OPDS Library Updates Feed")
+                    description("OPDS feed listing recent manga chapter updates")
+                }
+            },
+            behaviorOf = { ctx, pageNumber ->
+                ctx.future {
+                    future {
+                        Opds.getLibraryUpdatesFeed(BASE_URL, pageNumber ?: 1)
+                    }.thenApply { xml ->
+                        ctx.contentType(OPDS_MIME).result(xml)
+                    }
+                }
+            },
+            withResults = {
+                httpCode(HttpStatus.OK)
+            },
+        )
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -486,7 +486,7 @@ object Opds {
         val chapterDetails = "${manga.title} | ${chapter.name} | By ${chapter.scanlator}"
         return OpdsXmlModels.Entry(
             id = "chapter/${chapter.id}",
-            title = chapter.name,
+            title = if (isCbzAvailable) "[D] ${chapter.name}" else chapter.name,
             updated = opdsDateFormatter.format(Instant.ofEpochMilli(chapter.uploadDate)),
             content = OpdsXmlModels.Content(value = chapterDetails),
             summary = OpdsXmlModels.Summary(value = chapterDetails),

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -535,6 +535,7 @@ object Opds {
                 when {
                     chapter.read -> "✅ ${chapter.name}"
                     chapter.lastPageRead > 0 -> "⌛ ${chapter.name}"
+                    chapter.pageCount == 0 -> "❌ ${chapter.name}"
                     else -> "⭕ ${chapter.name}"
                 },
             updated = opdsDateFormatter.format(Instant.ofEpochMilli(chapter.uploadDate)),

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -559,7 +559,7 @@ object Opds {
                         .join(ChapterTable, JoinType.INNER, onColumn = MangaTable.id, otherColumn = ChapterTable.manga)
                         .select(MangaTable.columns)
                         .where {
-                            (MangaTable.sourceReference eq sourceId) and (ChapterTable.isDownloaded eq true)
+                            (MangaTable.sourceReference eq sourceId)
                         }.groupBy(MangaTable.id)
                         .orderBy(MangaTable.title to SortOrder.ASC)
 
@@ -600,7 +600,7 @@ object Opds {
                         .join(MangaTable, JoinType.INNER, onColumn = CategoryMangaTable.manga, otherColumn = MangaTable.id)
                         .join(ChapterTable, JoinType.INNER, onColumn = MangaTable.id, otherColumn = ChapterTable.manga)
                         .select(MangaTable.columns)
-                        .where { (CategoryMangaTable.category eq categoryId) and (ChapterTable.isDownloaded eq true) }
+                        .where { (CategoryMangaTable.category eq categoryId) }
                         .groupBy(MangaTable.id)
                         .orderBy(MangaTable.title to SortOrder.ASC)
                 val totalCount = query.count()
@@ -631,7 +631,7 @@ object Opds {
                     MangaTable
                         .join(ChapterTable, JoinType.INNER, onColumn = MangaTable.id, otherColumn = ChapterTable.manga)
                         .select(MangaTable.columns)
-                        .where { (MangaTable.genre like "%$genre%") and (ChapterTable.isDownloaded eq true) }
+                        .where { (MangaTable.genre like "%$genre%") }
                         .groupBy(MangaTable.id)
                         .orderBy(MangaTable.title to SortOrder.ASC)
                 val totalCount = query.count()
@@ -668,7 +668,7 @@ object Opds {
                     MangaTable
                         .join(ChapterTable, JoinType.INNER, onColumn = MangaTable.id, otherColumn = ChapterTable.manga)
                         .select(MangaTable.columns)
-                        .where { (MangaTable.status eq statusId.toInt()) and (ChapterTable.isDownloaded eq true) }
+                        .where { (MangaTable.status eq statusId.toInt()) }
                         .groupBy(MangaTable.id)
                         .orderBy(MangaTable.title to SortOrder.ASC)
                 val totalCount = query.count()

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/Opds.kt
@@ -506,7 +506,7 @@ object Opds {
                     add(
                         OpdsXmlModels.Link(
                             rel = "http://opds-spec.org/acquisition/open-access",
-                            href = "/api/v1/chapter/${chapter.id}/download?markAsRead=true",
+                            href = "/api/v1/chapter/${chapter.id}/download",
                             type = "application/vnd.comicbook+zip",
                         ),
                     )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/model/OpdsXmlModels.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/model/OpdsXmlModels.kt
@@ -64,6 +64,8 @@ data class OpdsXmlModels(
         val title: String? = null,
         @XmlSerialName("pse:count", "", "")
         val pseCount: Int? = null,
+        @XmlSerialName("pse:lastRead", "", "")
+        val pseLastRead: Int? = null,
         @XmlSerialName("opds:facetGroup", "", "")
         val facetGroup: String? = null,
         @XmlSerialName("opds:activeFacet", "", "")


### PR DESCRIPTION
## Relates to https://github.com/Suwayomi/Suwayomi-Server/issues/1265.

### Changes
- Added OPDS-PSE support for undownloaded chapters.
- Modified GET chapter/{{chapterId}/download to create a CBZ file for folder downloads.
- Removed manga descriptions from chapter entries to reduce XML size for manga with very long descriptions. Each chapter entry now returns the manga title, chapter name, and the scanlator.
- Adds unicodes as a prefix to chapter titles in the OPDS feed when the chapter is has been read, in progress, or not started.
- Page streaming now updates the lastPageRead for chapter

### Notes
- OPDS-PSE doesn't work without pageCount, and the redirected endpoint also fails even if we return a hardcoded count in the chapter entry. So, added a check in [ChapterForDownload](https://github.com/Suwayomi/Suwayomi-Server/blob/4f7962c98bb7fd0c04771e894a2aa72a2c155711/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt#L41-L40) to update the PageTableList & PageCount only when there is a mismatch.
-I tried making this call for all chapters in the paginated manga feed, but even with just 20 entries per page, it felt pretty slow. Plus, OPDS clients don’t really seem to support seamless chapter reading (KOReader definitely doesn’t). So instead, I added a separate “detail” page for each chapter when the page count is missing. This way, we can read undownloaded chapters, and if we revisit the chapter later, it won’t redirect us to the detail page again.

**_FYI: I use KOReader to read manga, so this entire modification is based on that._**

<details> 
<summary>KOReader screen recording for this change</summary>

https://github.com/user-attachments/assets/458fb38f-510a-4d26-990c-9d0672eb6f9e

</details> 
<details> 
<summary>KoReader with "D" as prefix for downloaded chapter</summary>
Chapter 126 for Slime's manga was downloaded in a folder. 

![image](https://github.com/user-attachments/assets/2bca1b69-7488-4471-bd0b-0db6837320a1)

https://github.com/user-attachments/assets/01dacacc-4abb-4f94-beda-b22dc91b2da2

</details>