### PR TITLE
Emit only updater job changes instead of full status

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/UpdateQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/UpdateQuery.kt
@@ -1,6 +1,8 @@
 package suwayomi.tachidesk.graphql.queries
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import kotlinx.coroutines.flow.first
+import suwayomi.tachidesk.graphql.types.LibraryUpdateStatus
 import suwayomi.tachidesk.graphql.types.UpdateStatus
 import suwayomi.tachidesk.manga.impl.update.IUpdater
 import suwayomi.tachidesk.server.JavalinSetup.future
@@ -10,7 +12,10 @@ import java.util.concurrent.CompletableFuture
 class UpdateQuery {
     private val updater: IUpdater by injectLazy()
 
+    @GraphQLDeprecated("Replaced with libraryUpdateStatus", ReplaceWith("libraryUpdateStatus"))
     fun updateStatus(): CompletableFuture<UpdateStatus> = future { UpdateStatus(updater.status.first()) }
+
+    fun libraryUpdateStatus(): CompletableFuture<LibraryUpdateStatus> = future { LibraryUpdateStatus(updater.getStatus()) }
 
     data class LastUpdateTimestampPayload(
         val timestamp: Long,

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/DownloadSubscription.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/DownloadSubscription.kt
@@ -16,7 +16,7 @@ import suwayomi.tachidesk.graphql.types.DownloadUpdates
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
 
 class DownloadSubscription {
-    @GraphQLDeprecated("Replaced width downloadStatusChanged", ReplaceWith("downloadStatusChanged(input)"))
+    @GraphQLDeprecated("Replaced with downloadStatusChanged", ReplaceWith("downloadStatusChanged(input)"))
     fun downloadChanged(): Flow<DownloadStatus> =
         DownloadManager.status.map { downloadStatus ->
             DownloadStatus(downloadStatus)

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/UpdateSubscription.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/UpdateSubscription.kt
@@ -7,17 +7,68 @@
 
 package suwayomi.tachidesk.graphql.subscriptions
 
+import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import suwayomi.tachidesk.graphql.types.UpdateStatus
+import suwayomi.tachidesk.graphql.types.UpdaterUpdates
 import suwayomi.tachidesk.manga.impl.update.IUpdater
+import suwayomi.tachidesk.manga.impl.update.UpdateUpdates
 import uy.kohesive.injekt.injectLazy
 
 class UpdateSubscription {
     private val updater: IUpdater by injectLazy()
 
+    @GraphQLDeprecated("Replaced with updates", ReplaceWith("updates(input)"))
     fun updateStatusChanged(): Flow<UpdateStatus> =
         updater.status.map { updateStatus ->
             UpdateStatus(updateStatus)
         }
+
+    data class LibraryUpdateStatusChangedInput(
+        @GraphQLDescription(
+            "Sets a max number of updates that can be contained in a updater update message." +
+                "Everything above this limit will be omitted and the \"updateStatus\" should be re-fetched via the " +
+                "corresponding query. Due to the graphql subscription execution strategy not supporting batching for data loaders, " +
+                "the data loaders run into the n+1 problem, which can cause the server to get unresponsive until the status " +
+                "update has been handled. This is an issue e.g. when starting an update.",
+        )
+        val maxUpdates: Int?,
+    )
+
+    fun libraryUpdateStatusChanged(input: LibraryUpdateStatusChangedInput): Flow<UpdaterUpdates> {
+        val omitUpdates = input.maxUpdates != null
+        val maxUpdates = input.maxUpdates ?: 50
+
+        return updater.updates.map { updates ->
+            val categoryUpdatesCount = updates.categoryUpdates.size
+            val mangaUpdatesCount = updates.mangaUpdates.size
+            val totalUpdatesCount = categoryUpdatesCount + mangaUpdatesCount
+
+            val needToOmitUpdates = omitUpdates && totalUpdatesCount > maxUpdates
+            if (!needToOmitUpdates) {
+                return@map UpdaterUpdates(updates, omittedUpdates = false)
+            }
+
+            val maxUpdatesAfterCategoryUpdates = (maxUpdates - categoryUpdatesCount).coerceAtLeast(0)
+
+            // the graphql subscription execution strategy does not support data loader batching which causes the n+1 problem,
+            // thus, too many updates (e.g. on mass enqueue or dequeue) causes unresponsiveness of the server until the
+            // update has been handled
+            UpdaterUpdates(
+                UpdateUpdates(
+                    updates.isRunning,
+                    updates.categoryUpdates.subList(0, maxUpdates),
+                    updates.mangaUpdates.subList(0, maxUpdatesAfterCategoryUpdates),
+                    updates.totalJobs,
+                    updates.finishedJobs,
+                    updates.skippedCategoriesCount,
+                    updates.skippedMangasCount,
+                    updates.initial,
+                ),
+                omittedUpdates = true,
+            )
+        }
+    }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
@@ -15,6 +15,7 @@ import suwayomi.tachidesk.graphql.server.primitives.Edge
 import suwayomi.tachidesk.graphql.server.primitives.Node
 import suwayomi.tachidesk.graphql.server.primitives.NodeList
 import suwayomi.tachidesk.graphql.server.primitives.PageInfo
+import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
 import suwayomi.tachidesk.manga.model.dataclass.IncludeOrExclude
 import suwayomi.tachidesk.manga.model.table.CategoryTable
 import java.util.concurrent.CompletableFuture
@@ -34,6 +35,15 @@ class CategoryType(
         row[CategoryTable.isDefault],
         IncludeOrExclude.fromValue(row[CategoryTable.includeInUpdate]),
         IncludeOrExclude.fromValue(row[CategoryTable.includeInDownload]),
+    )
+
+    constructor(dataClass: CategoryDataClass) : this(
+        dataClass.id,
+        dataClass.order,
+        dataClass.name,
+        dataClass.default,
+        dataClass.includeInUpdate,
+        dataClass.includeInDownload,
     )
 
     fun mangas(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<MangaNodeList> =

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/IUpdater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/IUpdater.kt
@@ -16,9 +16,14 @@ interface IUpdater {
 
     fun addMangasToQueue(mangas: List<MangaDataClass>)
 
+    @Deprecated("Replaced with updates", replaceWith = ReplaceWith("updates"))
     val status: Flow<UpdateStatus>
+
+    val updates: Flow<UpdateUpdates>
 
     val statusDeprecated: StateFlow<UpdateStatus>
 
     fun reset()
+
+    fun getStatus(): UpdateUpdates
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateJob.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateJob.kt
@@ -1,5 +1,6 @@
 package suwayomi.tachidesk.manga.impl.update
 
+import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 
 enum class JobStatus {
@@ -13,4 +14,14 @@ enum class JobStatus {
 data class UpdateJob(
     val manga: MangaDataClass,
     val status: JobStatus = JobStatus.PENDING,
+)
+
+enum class CategoryUpdateStatus {
+    UPDATING,
+    SKIPPED,
+}
+
+data class CategoryUpdateJob(
+    val category: CategoryDataClass,
+    val status: CategoryUpdateStatus,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateStatus.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/UpdateStatus.kt
@@ -4,11 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
 import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
 
-enum class CategoryUpdateStatus {
-    UPDATING,
-    SKIPPED,
-}
-
 data class UpdateStatus(
     val categoryStatusMap: Map<CategoryUpdateStatus, List<CategoryDataClass>> = emptyMap(),
     val mangaStatusMap: Map<JobStatus, List<MangaDataClass>> = emptyMap(),
@@ -33,3 +28,14 @@ data class UpdateStatus(
         numberOfJobs = jobs.size,
     )
 }
+
+data class UpdateUpdates(
+    val isRunning: Boolean = false,
+    val categoryUpdates: List<CategoryUpdateJob>,
+    val mangaUpdates: List<UpdateJob>,
+    val totalJobs: Int,
+    val finishedJobs: Int,
+    val skippedCategoriesCount: Int,
+    val skippedMangasCount: Int,
+    val initial: UpdateUpdates?,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/update/Updater.kt
@@ -54,8 +54,14 @@ class Updater : IUpdater {
 
     private val notifyFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
+    @Deprecated("Replaced with updatesFlow", replaceWith = ReplaceWith("updatesFlow"))
     private val statusFlow = MutableSharedFlow<UpdateStatus>()
-    override val status = statusFlow.onStart { emit(getStatus()) }
+
+    @Deprecated("Replaced with updates", replaceWith = ReplaceWith("updates"))
+    override val status = statusFlow.onStart { emit(getStatusDeprecated(null)) }
+
+    private val updatesFlow = MutableSharedFlow<UpdateUpdates>()
+    override val updates = updatesFlow.onStart { emit(getUpdates(addInitial = true)) }
 
     init {
         // has to be in its own scope (notifyFlowScope), otherwise, the collection gets canceled due to canceling the scopes (scope) children in the reset function
@@ -69,8 +75,11 @@ class Updater : IUpdater {
     private val _status = MutableStateFlow(UpdateStatus())
     override val statusDeprecated = _status.asStateFlow()
 
+    private val mangaUpdates = ConcurrentHashMap<Int, UpdateJob>()
+    private val categoryUpdates = ConcurrentHashMap<Int, CategoryUpdateJob>()
     private var updateStatusCategories: Map<CategoryUpdateStatus, List<CategoryDataClass>> = emptyMap()
     private var updateStatusSkippedMangas: List<MangaDataClass> = emptyList()
+
     private val tracker = ConcurrentHashMap<Int, UpdateJob>()
     private val updateChannels = ConcurrentHashMap<String, Channel<UpdateJob>>()
 
@@ -112,7 +121,7 @@ class Updater : IUpdater {
             val lastAutomatedUpdate = preferences.getLong(lastAutomatedUpdateKey, 0)
             preferences.edit().putLong(lastAutomatedUpdateKey, System.currentTimeMillis()).apply()
 
-            if (getStatus().running) {
+            if (getStatus().isRunning) {
                 logger.debug { "Global update is already in progress" }
                 return
             }
@@ -157,28 +166,78 @@ class Updater : IUpdater {
         HAScheduler.schedule(::autoUpdateTask, updateInterval, timeToNextExecution, "global-update")
     }
 
-    private fun getStatus(running: Boolean? = null): UpdateStatus {
+    private fun isRunning(): Boolean =
+        tracker.values.toList().any { job -> job.status == JobStatus.PENDING || job.status == JobStatus.RUNNING }
+
+    // old status that is still required for the deprecated endpoints
+    private fun getStatusDeprecated(running: Boolean? = null): UpdateStatus {
         val jobs = tracker.values.toList()
-        val isRunning =
-            running
-                ?: jobs.any { job ->
-                    job.status == JobStatus.PENDING || job.status == JobStatus.RUNNING
-                }
+        val isRunning = running ?: isRunning()
         return UpdateStatus(this.updateStatusCategories, jobs, this.updateStatusSkippedMangas, isRunning)
     }
+
+    private fun getStatus(
+        categories: List<CategoryUpdateJob>,
+        mangas: List<UpdateJob>,
+        running: Boolean? = null,
+        addInitial: Boolean? = false,
+    ): UpdateUpdates =
+        UpdateUpdates(
+            running ?: isRunning(),
+            categories,
+            mangas,
+            tracker.size,
+            tracker.values.count { it.status == JobStatus.COMPLETE || it.status == JobStatus.FAILED },
+            this.updateStatusCategories[CategoryUpdateStatus.SKIPPED]?.size ?: 0,
+            this.updateStatusSkippedMangas.size,
+            if (addInitial == true) getStatus() else null,
+        )
+
+    override fun getStatus(): UpdateUpdates =
+        getStatus(
+            this.updateStatusCategories[CategoryUpdateStatus.UPDATING]
+                ?.map {
+                    CategoryUpdateJob(
+                        it,
+                        CategoryUpdateStatus.UPDATING,
+                    )
+                }.orEmpty(),
+            tracker.values.toList(),
+        )
+
+    private fun getUpdates(
+        running: Boolean? = null,
+        addInitial: Boolean? = null,
+    ): UpdateUpdates =
+        getStatus(
+            categoryUpdates.values.toList(),
+            mangaUpdates.values.toList(),
+            running,
+            addInitial = addInitial,
+        )
 
     /**
      * Pass "isRunning" to force a specific running state
      */
     private suspend fun updateStatus(
         immediate: Boolean = false,
+        categoryUpdates: List<CategoryUpdateJob> = emptyList(),
+        mangaUpdates: List<UpdateJob> = emptyList(),
         isRunning: Boolean? = null,
     ) {
+        mangaUpdates.forEach { this.mangaUpdates[it.manga.id] = it }
+        categoryUpdates.forEach { this.categoryUpdates[it.category.id] = it }
+
         if (immediate) {
-            val status = getStatus(running = isRunning)
+            val status = getStatusDeprecated(running = isRunning)
+            val updates = getUpdates(isRunning)
+
+            this.mangaUpdates.clear()
+            this.categoryUpdates.clear()
 
             statusFlow.emit(status)
             _status.update { status }
+            updatesFlow.emit(updates)
 
             return
         }
@@ -217,18 +276,15 @@ class Updater : IUpdater {
         }
 
         // fail all updates for source
-        tracker
-            .filter { (_, job) -> !isFailedSourceUpdate(job) }
-            .forEach { (mangaId, job) ->
-                tracker[mangaId] = job.copy(status = JobStatus.FAILED)
-            }
+        val sourceUpdateJobs = tracker.filter { (_, job) -> !isFailedSourceUpdate(job) }
+        sourceUpdateJobs.forEach { (mangaId, job) -> tracker[mangaId] = job.copy(status = JobStatus.FAILED) }
 
-        updateStatus()
+        updateStatus(mangaUpdates = sourceUpdateJobs.values.toList())
     }
 
     private suspend fun process(job: UpdateJob) {
         tracker[job.manga.id] = job.copy(status = JobStatus.RUNNING)
-        updateStatus()
+        updateStatus(mangaUpdates = listOf(tracker[job.manga.id]!!))
 
         tracker[job.manga.id] =
             try {
@@ -248,7 +304,7 @@ class Updater : IUpdater {
 
         // in case this is the last update job, the running flag has to be true, before it gets set to false, to be able
         // to properly clear the dataloader store in UpdateType
-        updateStatus(immediate = wasLastJob, isRunning = true)
+        updateStatus(immediate = wasLastJob, isRunning = true, mangaUpdates = listOf(tracker[job.manga.id]!!))
 
         if (wasLastJob) {
             updateStatus(isRunning = false)
@@ -328,6 +384,18 @@ class Updater : IUpdater {
             return
         }
 
+        scope.launch {
+            updateStatus(
+                categoryUpdates =
+                    updateStatusCategories[CategoryUpdateStatus.UPDATING]
+                        ?.map {
+                            CategoryUpdateJob(it, CategoryUpdateStatus.UPDATING)
+                        }.orEmpty(),
+                mangaUpdates = mangasToUpdate.map { UpdateJob(it) },
+                isRunning = true,
+            )
+        }
+
         addMangasToQueue(
             mangasToUpdate
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER, MangaDataClass::title)),
@@ -350,12 +418,17 @@ class Updater : IUpdater {
 
     override fun reset() {
         scope.coroutineContext.cancelChildren()
+
         tracker.clear()
+        this.mangaUpdates.clear()
+        this.categoryUpdates.clear()
         this.updateStatusCategories = emptyMap()
         this.updateStatusSkippedMangas = emptyList()
+
         scope.launch {
             updateStatus(immediate = true, isRunning = false)
         }
+
         updateChannels.forEach { (_, channel) -> channel.cancel() }
         updateChannels.clear()
     }


### PR DESCRIPTION
The update subscription emitted the full update status, which, depending on how big the status was, took forever because the graphql subscription does not support data loader batching, causing it to run into the n+1 problem

- deprecates the
  - `update status` type
  - `trigger library/category update` mutations
  - `update status` query
  - `update status` subscription

- adds
  - new `update status` type
    - does not group jobs by status
    - does not include skipped jobs (provides count of skipped jobs)
  - new `type` for `update subscription`
    - same structure as `new update status` but different type to prevent it from overwriting the status in the clients cache
    - only sends new job updates (the `status` returns the whole data for the latest update)
  - new mutation to trigger the update
    - one mutation which starts either a `global library update` or `category(ies) update` in case `category ids` get passed
  - new `update status` subscription
    - only sends update job changes
    - an option `maxUpdates` to omit updates by setting a max update limit to prevent n+1 problem - includes a flag `omittedUpdates` which indicates that the `libraryUpdateStatus` queue should get re-fetched