### PR TITLE
Prevent IndexOutOfBoundsException in "libraryUpdate" subscription

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/UpdateSubscription.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/subscriptions/UpdateSubscription.kt
@@ -59,8 +59,8 @@ class UpdateSubscription {
             UpdaterUpdates(
                 UpdateUpdates(
                     updates.isRunning,
-                    updates.categoryUpdates.subList(0, maxUpdates),
-                    updates.mangaUpdates.subList(0, maxUpdatesAfterCategoryUpdates),
+                    updates.categoryUpdates.take(maxUpdates),
+                    updates.mangaUpdates.take(maxUpdatesAfterCategoryUpdates),
                     updates.totalJobs,
                     updates.finishedJobs,
                     updates.skippedCategoriesCount,


### PR DESCRIPTION
not directly related but apparently the `exception handler` that can be passed to the `subscription strategy` does not do anything...

https://github.com/Suwayomi/Suwayomi-Server/blob/4c5598cedfcd40c2dffab31e45f38d692b2c3741/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLServer.kt#L79