### PR TITLE
Fix release version extraction from jar name

### DIFF
--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -28,7 +28,7 @@ main() {
   OS="$1"
   JAR="$(ls server/build/*.jar | tail -n1)"
   RELEASE_NAME="$(echo "${JAR%.*}" | xargs basename)-$OS"
-  RELEASE_VERSION="$(tmp="${JAR%-*}"; echo "${tmp##*-}" | tr -d v)"
+  RELEASE_VERSION=$(echo "$JAR" | grep -oP "v\K[0-9]+\.[0-9]+\.[0-9]+")
   #RELEASE_REVISION_NUMBER="$(tmp="${JAR%.*}" && echo "${tmp##*-}" | tr -d r)"
   local electron_version="v28.1.3"
 


### PR DESCRIPTION
Broke due to the changes made in 3167d8aa15cc5c7b7064a61eccb0e28336808241