### PR TITLE
Prevent duplicated chapter pages

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0045_PreventDuplicatedChapterPages.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0045_PreventDuplicatedChapterPages.kt
@@ -1,0 +1,26 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+
+@Suppress("ClassName", "unused")
+class M0045_PreventDuplicatedChapterPages : SQLMigration() {
+    override val sql: String =
+        """
+        DELETE FROM PAGE
+        WHERE ID NOT IN (
+            SELECT MIN(ID)
+            FROM PAGE
+            GROUP BY INDEX, "imageUrl", CHAPTER
+        );
+
+        ALTER TABLE PAGE
+            ADD CONSTRAINT UC_PAGE UNIQUE (INDEX, imageUrl, CHAPTER)
+        """.trimIndent()
+}


### PR DESCRIPTION
In case "ChapterForDownload#asDownloadReady" was called in quick succession, the page list got inserted multiple times.

This caused problems with getting the images from the rest endpoint, because they are selected by sorting them by asc index and selecting the page by using the provided index as an offset.

This, however, only works as long as there are no duplicates, otherwise, e.g., page indexes 1, 2; 3, 4; 5, 6; ... will just return the same page.