### PR TITLE
Improve Downloads Handling

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -22,6 +22,11 @@ object ChapterDownloadHelper {
         index: Int,
     ): Pair<InputStream, String> = provider(mangaId, chapterId).getImage().execute(index)
 
+    fun getImageCount(
+        mangaId: Int,
+        chapterId: Int,
+    ): Int = provider(mangaId, chapterId).getImageCount()
+
     fun delete(
         mangaId: Int,
         chapterId: Int,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -110,7 +110,7 @@ object Page {
             }
         }
 
-        val fileName = getPageName(index)
+        val fileName = getPageName(index, chapterEntry[ChapterTable.pageCount])
 
         val cacheSaveDir = getChapterCachePath(mangaId, chapterId)
 
@@ -121,5 +121,8 @@ object Page {
     }
 
     /** converts 0 to "001" */
-    fun getPageName(index: Int): String = String.format("%03d", index + 1)
+    fun getPageName(
+        index: Int,
+        pageCount: Int,
+    ): String = String.format("%0${pageCount.toString().length.coerceAtLeast(3)}d", index + 1)
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -80,6 +80,8 @@ private class ChapterForDownload(
             markAsNotDownloaded()
 
             updatePageList()
+        } else {
+            updatePageCount(ChapterDownloadHelper.getImageCount(mangaId, chapterId))
         }
 
         return asDataClass()
@@ -160,19 +162,17 @@ private class ChapterForDownload(
             }
         }
 
-        updatePageCount(pageList, chapterId)
+        updatePageCount(pageList.size)
 
         // chapter was updated
         chapterEntry = freshChapterEntry(chapterId, chapterIndex, mangaId)
     }
 
     private fun updatePageCount(
-        pageList: List<Page>,
-        chapterId: Int,
+        pageCount: Int,
     ) {
         transaction {
             ChapterTable.update({ ChapterTable.id eq chapterId }) {
-                val pageCount = pageList.size
                 it[ChapterTable.pageCount] = pageCount
                 it[ChapterTable.lastPageRead] = chapterEntry[ChapterTable.lastPageRead].coerceAtMost(pageCount - 1).coerceAtLeast(0)
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -70,7 +70,7 @@ private class ChapterForDownload(
 
         val isMarkedAsDownloaded = chapterEntry[ChapterTable.isDownloaded]
         val doesFirstPageExist = firstPageExists()
-        val isDownloaded = isMarkedAsDownloaded && doesFirstPageExist
+        val isDownloaded = isMarkedAsDownloaded || doesFirstPageExist
 
         log.debug { "isDownloaded= $isDownloaded (isMarkedAsDownloaded= $isMarkedAsDownloaded, doesFirstPageExist= $doesFirstPageExist)" }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -87,7 +87,14 @@ private class ChapterForDownload(
         return asDataClass()
     }
 
-    private fun asDataClass() = ChapterTable.toDataClass(chapterEntry)
+    private fun asDataClass() = ChapterTable.toDataClass(
+        transaction {
+            ChapterTable
+                .selectAll()
+                .where { ChapterTable.id eq chapterId }
+                .first()
+        }
+    )
 
     init {
         chapterEntry = freshChapterEntry(optChapterId, optChapterIndex, optMangaId)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -87,14 +87,15 @@ private class ChapterForDownload(
         return asDataClass()
     }
 
-    private fun asDataClass() = ChapterTable.toDataClass(
-        transaction {
-            ChapterTable
-                .selectAll()
-                .where { ChapterTable.id eq chapterId }
-                .first()
-        }
-    )
+    private fun asDataClass() =
+        ChapterTable.toDataClass(
+            transaction {
+                ChapterTable
+                    .selectAll()
+                    .where { ChapterTable.id eq chapterId }
+                    .first()
+            },
+        )
 
     init {
         chapterEntry = freshChapterEntry(optChapterId, optChapterIndex, optMangaId)
@@ -175,9 +176,7 @@ private class ChapterForDownload(
         chapterEntry = freshChapterEntry(chapterId, chapterIndex, mangaId)
     }
 
-    private fun updatePageCount(
-        pageCount: Int,
-    ) {
+    private fun updatePageCount(pageCount: Int) {
         transaction {
             ChapterTable.update({ ChapterTable.id eq chapterId }) {
                 it[ChapterTable.pageCount] = pageCount

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
@@ -104,7 +104,13 @@ abstract class ChaptersFilesProvider<Type : FileType>(
         downloadCacheFolder.mkdirs()
 
         val pageCount = download.chapter.pageCount
-        if (downloadCacheFolder.listFiles().orEmpty().size >= pageCount) {
+        if (
+            downloadCacheFolder
+                .listFiles()
+                .orEmpty()
+                .filter { it.name != COMIC_INFO_FILE }
+                .size >= pageCount
+        ) {
             download.progress = 1f
             step(download, false)
         } else {

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/PageTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/PageTest.kt
@@ -15,16 +15,18 @@ import kotlin.test.assertEquals
 class PageTest : ApplicationTest() {
     @Test
     fun testGetPageName() {
-        val tests = listOf(0, 1, 2, 100)
+        val tests = listOf(0 to 5, 1 to 5, 2 to 5, 100 to 100, 998 to 1000, 1400 to 1500)
 
         val testResults =
-            tests.map {
-                getPageName(it)
+            tests.map { (page, count) ->
+                getPageName(page, count)
             }
 
         assertEquals(testResults[0], "001")
         assertEquals(testResults[1], "002")
         assertEquals(testResults[2], "003")
         assertEquals(testResults[3], "101")
+        assertEquals(testResults[4], "0999")
+        assertEquals(testResults[5], "1401")
     }
 }

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/update/TestUpdater.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/update/TestUpdater.kt
@@ -45,10 +45,16 @@ class TestUpdater : IUpdater {
 
     override val status: Flow<UpdateStatus>
         get() = TODO("Not yet implemented")
+    override val updates: Flow<UpdateUpdates>
+        get() = TODO("Not yet implemented")
     override val statusDeprecated: StateFlow<UpdateStatus>
         get() = TODO("Not yet implemented")
 
     override fun reset() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStatus(): UpdateUpdates {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
- If a download already exists and it has a page count over the known page count, it is set as complete
- If a download as 1000+ pages, it uses a `%04d` string format, 10000+ pages, it uses a `%05d`, etc
- Page count after a download is updated in the database based on how many image files there are
- Updates page count for downloaded chapters when getting ready to read
- Assume downloaded if first page is found, this means that chapters not marked as read will be assumed downloaded when getting page count. This is because we now store non-downloaded chapters in the system temp folders

Will fix issues with Mihon long page split chapters and 1000+ page chapters