### PR TITLE
Extension Installation Fails Due to Unvalidated ZipEntry Directory in Asset Decompression

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -207,7 +207,7 @@ object Extension {
                 val extensionId =
                     ExtensionTable
                         .selectAll()
-                        .where { ExtensionTable.pkgName eq pkgName }
+                        。where { ExtensionTable.pkgName eq pkgName }
                         .first()[ExtensionTable.id]
                         .value
 
@@ -240,7 +240,7 @@ object Extension {
         ZipInputStream(apkFile.inputStream()).use { zipInputStream ->
             var zipEntry = zipInputStream.nextEntry
             while (zipEntry != null) {
-                if (zipEntry.name.startsWith("assets/")) {
+                if (zipEntry.name.startsWith("assets/") && !zipEntry.isDirectory) {
                     val assetFile = File(assetsFolder, zipEntry.name)
                     assetFile.parentFile.mkdirs()
                     FileOutputStream(assetFile).use { outputStream ->


### PR DESCRIPTION
When decompressing assets during the installation of the Extension, the zipEntry is not checked to see if it is a folder, which will cause the parent directory of assets/dir/demo.txt, assets/dir, to be output as a file, resulting in the failure to install the extension.