### PR TITLE
Fix: Validate zipEntry directories during extension asset decompression

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -240,7 +240,7 @@ object Extension {
         ZipInputStream(apkFile.inputStream()).use { zipInputStream ->
             var zipEntry = zipInputStream.nextEntry
             while (zipEntry != null) {
-                if (zipEntry.name.startsWith("assets/")) {
+                if (zipEntry.name.startsWith("assets/") && !zipEntry.isDirectory) {
                     val assetFile = File(assetsFolder, zipEntry.name)
                     assetFile.parentFile.mkdirs()
                     FileOutputStream(assetFile).use { outputStream ->


### PR DESCRIPTION
IpInputStream.nextEntry may be a folder. If it is not checked, the folder will be output as a file by mistake, which will cause the contents in the subsequent folders to be unable to be copied, resulting in the failure of the extension installation.
Although most extension apk files will not be like this, I think it is still necessary to modify the code here to add compatibility
![屏幕截图 2025-05-26 073743](https://github.com/user-attachments/assets/9ac84c24-619d-4820-aa22-e58f8a86bf33)
