### PR TITLE
Dequeue downloads of removed chapters

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -261,6 +261,7 @@ object Chapter {
 
                 // we got some clean up due
                 if (chaptersIdsToDelete.isNotEmpty()) {
+                    DownloadManager.dequeue(chaptersIdsToDelete)
                     transaction {
                         PageTable.deleteWhere { chapter inList chaptersIdsToDelete }
                         ChapterTable.deleteWhere { id inList chaptersIdsToDelete }


### PR DESCRIPTION
Otherwise, graphql errors will be caused because the chapters won't be found and are unexpectedly null.

fixes #1358