### PR TITLE
systemd: use startup script, X server

### DIFF
--- a/scripts/resources/pkg/suwayomi-server.sh
+++ b/scripts/resources/pkg/suwayomi-server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export LD_PRELOAD="/usr/share/java/suwayomi-server/bin/catch_abort.so"
-exec /usr/bin/java -jar /usr/share/java/suwayomi-server/bin/Suwayomi-Server.jar
+exec /usr/bin/java "$@" -jar /usr/share/java/suwayomi-server/bin/Suwayomi-Server.jar

--- a/scripts/resources/pkg/suwayomi-server.sh
+++ b/scripts/resources/pkg/suwayomi-server.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 
 export LD_PRELOAD="/usr/share/java/suwayomi-server/bin/catch_abort.so"
-exec /usr/bin/java "$@" -jar /usr/share/java/suwayomi-server/bin/Suwayomi-Server.jar
+
+if [ -z "$DISPLAY" ] && command -v Xvfb >/dev/null; then
+  echo "-- START: Spawning X server using xvfb-run --"
+  exec xvfb-run /usr/bin/java "$@" -jar /usr/share/java/suwayomi-server/bin/Suwayomi-Server.jar
+else
+  exec /usr/bin/java "$@" -jar /usr/share/java/suwayomi-server/bin/Suwayomi-Server.jar
+fi

--- a/scripts/resources/pkg/systemd/suwayomi-server.service
+++ b/scripts/resources/pkg/systemd/suwayomi-server.service
@@ -10,7 +10,7 @@ Group=suwayomi-server
 SyslogIdentifier=suwayomi-server
 
 EnvironmentFile=/etc/suwayomi/server.conf
-ExecStart=/usr/bin/java $JAVA_ARGS -Dsuwayomi.tachidesk.config.server.rootDir="${TACHIDESK_ROOT_DIR}" -jar /usr/share/java/suwayomi-server/bin/Suwayomi-Server.jar
+ExecStart=/usr/bin/suwayomi-server $JAVA_ARGS -Dsuwayomi.tachidesk.config.server.rootDir="${TACHIDESK_ROOT_DIR}"
 Restart=on-failure
 
 ProtectSystem=full


### PR DESCRIPTION
The systemd unit did not have the helper from #1456, since it was using its own command line. Instead have everything go through the helper script.
Also start an X server if necessary (and possible), since systemd won't allow us to access the main X/xwayland server.

https://discord.com/channels/801021177333940224/1387727303345180692