### PR TITLE
Kcef: Disable SHM

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -409,7 +409,7 @@ fun applicationSetup() {
                 settings { windowlessRenderingEnabled = true }
                 appHandler(
                     KCEF.AppHandler(
-                        arrayOf("--disable-gpu", "--off-screen-rendering-enabled"),
+                        arrayOf("--disable-gpu", "--off-screen-rendering-enabled", "--disable-dev-shm-usage"),
                     ),
                 )
 


### PR DESCRIPTION
In Docker, `/dev/shm` is restricted, so Chromium dies of OOM

See also https://stackoverflow.com/a/56941767/7508309 and https://issues.chromium.org/issues/40517415