### PR TITLE
[#1497] WebView: Localstorage

### DIFF
--- a/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
+++ b/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
@@ -101,6 +101,7 @@ class KcefWebViewProvider(
     private var chromeClient = WebChromeClient()
     private val mappings: MutableList<FunctionMapping> = mutableListOf()
     private val urlHttpMapping: MutableMap<String, String> = mutableMapOf()
+    private var initialRequestData: InitialRequestData? = null
 
     private var kcefClient: KCEFClient? = null
     private var browser: KCEFBrowser? = null
@@ -117,6 +118,33 @@ class KcefWebViewProvider(
 
     public interface InitBrowserHandler {
         public fun init(provider: KcefWebViewProvider): Unit
+    }
+
+    private data class InitialRequestData(
+        private val additionalHttpHeaders: Map<String, String>? = null,
+        private val myPostData: ByteArray? = null,
+    ) {
+        fun apply(request: CefRequest?) {
+            request?.apply {
+                Log.v(TAG, "Initial request: applying headers and post data")
+                if (!additionalHttpHeaders.isNullOrEmpty()) {
+                    additionalHttpHeaders.forEach {
+                        setHeaderByName(it.key, it.value, true)
+                    }
+                }
+
+                if (myPostData != null) {
+                    this.postData =
+                        CefPostData.create().apply {
+                            addElement(
+                                CefPostDataElement.create().apply {
+                                    setToBytes(myPostData.size, myPostData)
+                                },
+                            )
+                        }
+                }
+            }
+        }
     }
 
     private class CefWebResourceRequest(
@@ -375,6 +403,8 @@ class KcefWebViewProvider(
             frame: CefFrame?,
             request: CefRequest,
         ): Boolean {
+            initialRequestData?.apply(request)
+            initialRequestData = null
             request.setHeaderByName("user-agent", settings.userAgentString, true)
 
             // TODO: we should be calling this on the handler, since CEF calls us on its IO thread
@@ -528,12 +558,12 @@ class KcefWebViewProvider(
         browser?.close(true)
         browser?.dispose()
         chromeClient.onProgressChanged(view, 0)
+        initialRequestData = InitialRequestData(additionalHttpHeaders = additionalHttpHeaders)
         browser =
             kcefClient!!
                 .createBrowser(
                     loadUrl,
                     CefRendering.OFFSCREEN,
-                    context = createContext(additionalHttpHeaders),
                 ).apply {
                     // NOTE: Without this, we don't seem to be receiving any events
                     createImmediately()
@@ -552,12 +582,12 @@ class KcefWebViewProvider(
         browser?.close(true)
         browser?.dispose()
         chromeClient.onProgressChanged(view, 0)
+        initialRequestData = InitialRequestData(myPostData = postData)
         browser =
             kcefClient!!
                 .createBrowser(
                     url,
                     CefRendering.OFFSCREEN,
-                    context = createContext(postData = postData),
                 ).apply {
                     // NOTE: Without this, we don't seem to be receiving any events
                     createImmediately()
@@ -1067,45 +1097,4 @@ class KcefWebViewProvider(
 
         override fun computeScroll(): Unit = throw RuntimeException("Stub!")
     }
-
-    private fun createContext(
-        additionalHttpHeaders: Map<String, String>? = null,
-        postData: ByteArray? = null,
-    ): CefRequestContext =
-        CefRequestContext.createContext {
-            browser,
-            frame,
-            request,
-            isNavigation,
-            isDownload,
-            requestInitiator,
-            disableDefaultHandling,
-            ->
-            KCEFResourceRequestHandler.globalHandler(
-                browser,
-                frame,
-                request.apply {
-                    if (!additionalHttpHeaders.isNullOrEmpty()) {
-                        additionalHttpHeaders.forEach {
-                            setHeaderByName(it.key, it.value, true)
-                        }
-                    }
-
-                    if (postData != null) {
-                        this.postData =
-                            CefPostData.create().apply {
-                                addElement(
-                                    CefPostDataElement.create().apply {
-                                        setToBytes(postData.size, postData)
-                                    },
-                                )
-                            }
-                    }
-                },
-                isNavigation,
-                isDownload,
-                requestInitiator,
-                disableDefaultHandling,
-            )
-        }
 }

--- a/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
+++ b/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
@@ -53,7 +53,6 @@ import android.webkit.WebViewRenderProcessClient
 import dev.datlag.kcef.KCEF
 import dev.datlag.kcef.KCEFBrowser
 import dev.datlag.kcef.KCEFClient
-import dev.datlag.kcef.KCEFResourceRequestHandler
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -62,7 +61,6 @@ import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.browser.CefMessageRouter
 import org.cef.browser.CefRendering
-import org.cef.browser.CefRequestContext
 import org.cef.callback.CefCallback
 import org.cef.callback.CefQueryCallback
 import org.cef.handler.CefDisplayHandlerAdapter

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt
@@ -18,9 +18,13 @@ import org.cef.handler.CefDisplayHandlerAdapter
 import org.cef.handler.CefLoadHandler
 import org.cef.handler.CefLoadHandlerAdapter
 import org.cef.handler.CefRenderHandlerAdapter
+import org.cef.handler.CefRequestHandlerAdapter
+import org.cef.handler.CefResourceRequestHandler
 import org.cef.input.CefTouchEvent
+import org.cef.misc.BoolRef
 import org.cef.network.CefCookie
 import org.cef.network.CefCookieManager
+import org.cef.network.CefRequest
 import uy.kohesive.injekt.injectLazy
 import java.awt.Component
 import java.awt.Rectangle
@@ -176,6 +180,21 @@ class KcefWebView {
         }
     }
 
+    private inner class RequestHandler : CefRequestHandlerAdapter() {
+        override fun getResourceRequestHandler(
+            browser: CefBrowser,
+            frame: CefFrame,
+            request: CefRequest,
+            isNavigation: Boolean,
+            isDownload: Boolean,
+            requestInitiator: String,
+            disableDefaultHandling: BoolRef,
+        ): CefResourceRequestHandler? {
+            logger.info { "Load resource: ${frame.name} - ${request.url}" }
+            return null
+        }
+    }
+
     // Loosely based on
     // https://github.com/JetBrains/jcef/blob/main/java/org/cef/browser/CefBrowserOsr.java
     private inner class RenderHandler : CefRenderHandlerAdapter() {
@@ -222,6 +241,7 @@ class KcefWebView {
             KCEF.newClientBlocking().apply {
                 addDisplayHandler(DisplayHandler())
                 addLoadHandler(LoadHandler())
+                addRequestHandler(RequestHandler())
             }
 
         logger.info { "Start loading cookies" }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -405,7 +405,10 @@ fun applicationSetup() {
                     }
                 }
                 download { github() }
-                settings { windowlessRenderingEnabled = true }
+                settings {
+                    windowlessRenderingEnabled = true
+                    cachePath = (Path(applicationDirs.dataRoot) / "cache/kcef").toString()
+                }
                 appHandler(
                     KCEF.AppHandler(
                         arrayOf("--disable-gpu", "--off-screen-rendering-enabled", "--disable-dev-shm-usage"),


### PR DESCRIPTION
Enables local storage for WebView.

This currently has some problems though: For some reason, the background WebView only sees a part of the storage: `{"storageOnce":"1","proxyHistory":"true"}`. The interactive webview always gets access to the full one, even after multiple reloads and a restart of the server. `window.location.origin` match. Not sure what else to check.