### PR TITLE
Properly bind track privately

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -176,11 +176,11 @@ object Track {
                                 (TrackRecordTable.remoteId eq remoteId)
                         }.first()
                         .toTrack()
-                        .apply {
-                            this.manga_id = mangaId
-                            this.private = private
-                        }
+            }.apply {
+                this.manga_id = mangaId
+                this.private = private
             }
+
         val tracker = TrackerManager.getTracker(trackerId)!!
 
         val chapter = queryMaxReadChapter(mangaId)


### PR DESCRIPTION
In case the track was read from the TrackSearchTable the private status was never applied