### PR TITLE
Change "download conversion compression level" type to Double

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SettingsType.kt
@@ -117,13 +117,13 @@ interface Settings : Node {
 interface SettingsDownloadConversion {
     val mimeType: String
     val target: String
-    val compressionLevel: Float?
+    val compressionLevel: Double?
 }
 
 class SettingsDownloadConversionType(
     override val mimeType: String,
     override val target: String,
-    override val compressionLevel: Float?,
+    override val compressionLevel: Double?,
 ) : SettingsDownloadConversion
 
 data class PartialSettingsType(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupServerSettings.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupServerSettings.kt
@@ -89,6 +89,6 @@ data class BackupServerSettings(
     class BackupSettingsDownloadConversionType(
         @ProtoNumber(1) override val mimeType: String,
         @ProtoNumber(2) override val target: String,
-        @ProtoNumber(3) override val compressionLevel: Float?,
+        @ProtoNumber(3) override val compressionLevel: Double?,
     ) : SettingsDownloadConversion
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
@@ -231,7 +231,7 @@ abstract class ChaptersFilesProvider<Type : FileType>(
                     val writerParams = writer.defaultWriteParam
                     targetConversion.compressionLevel?.let {
                         writerParams.compressionMode = ImageWriteParam.MODE_EXPLICIT
-                        writerParams.compressionQuality = it
+                        writerParams.compressionQuality = it.toFloat()
                     }
                     val success =
                         try {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -130,7 +130,7 @@ class ServerConfig(
 
     data class DownloadConversion(
         val target: String,
-        val compressionLevel: Float? = null,
+        val compressionLevel: Double? = null,
     )
 
     // extensions


### PR DESCRIPTION
https://opensource.expediagroup.com/graphql-kotlin/docs/schema-generator/writing-schemas/scalars/#primitive-types

Cannot cast java.lang.Double to java.lang.Float
at java.base/java.lang.Class.cast(Unknown Source)