### PR TITLE
Overhaul OPDS feeds for discovery, filtering, and enhanced UX

### DIFF
--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -7,9 +7,6 @@
     <string name="opds_feeds_manga_chapters">%1$s Chapters</string>
     <string name="opds_feeds_chapter_details">%1$s | %2$s | Details</string>
 
-    <string name="opds_feeds_library_title">Library</string>
-    <string name="opds_feeds_library_entry_content">Browse all series in your library</string>
-
     <string name="opds_feeds_explore_title">Explore</string>
     <string name="opds_feeds_explore_entry_content">Explore new series from your sources</string>
 

--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -99,6 +99,11 @@
     <string name="opds_chapter_details_scanlator"> | By %1$s</string>
     <string name="opds_chapter_details_progress"> | Progress: %1$d of %2$d</string>
 
+    <string name="opds_manga_summary_status">Status: %1$s</string>
+    <string name="opds_manga_summary_source">Source: %1$s</string>
+    <string name="opds_manga_summary_language">Language: %1$s</string>
+    <string name="opds_linktitle_view_on_web">View on web</string>
+
     <string name="manga_status_unknown">Unknown</string>
     <string name="manga_status_ongoing">Ongoing</string>
     <string name="manga_status_completed">Completed</string>

--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -8,7 +8,7 @@
     <string name="opds_feeds_chapter_details">%1$s | %2$s | Details</string>
 
     <string name="opds_feeds_library_title">Library</string>
-    <string name="opds_feeds_library_entry_content">Browse all series saved in your library</string>
+    <string name="opds_feeds_library_entry_content">Browse all series in your library</string>
 
     <string name="opds_feeds_explore_title">Explore</string>
     <string name="opds_feeds_explore_entry_content">Explore new series from your sources</string>
@@ -56,6 +56,8 @@
 
     <string name="opds_facetgroup_sort_order">Sort Order</string>
     <string name="opds_facetgroup_read_status">Read Status</string>
+    <string name="opds_facetgroup_filter_status">Filter by Status</string>
+    <string name="opds_facetgroup_filter_content">Filter by Content</string>
 
     <string name="opds_facet_sort_oldest_first">Oldest First</string>
     <string name="opds_facet_sort_newest_first">Newest First</string>
@@ -63,10 +65,20 @@
     <string name="opds_facet_sort_date_desc">Date descending</string>
     <string name="opds_facet_sort_popular">Popular</string>
     <string name="opds_facet_sort_latest">Latest</string>
+    <string name="opds_facet_sort_alpha_asc">Alphabetical A-Z</string>
+    <string name="opds_facet_sort_alpha_desc">Alphabetical Z-A</string>
+    <string name="opds_facet_sort_last_read_desc">Last Read</string>
+    <string name="opds_facet_sort_latest_chapter_desc">Latest Chapter</string>
+    <string name="opds_facet_sort_date_added_desc">Date Added</string>
+    <string name="opds_facet_sort_unread_desc">Unread chapters</string>
 
+    <string name="opds_facet_filter_all">All</string>
     <string name="opds_facet_filter_all_chapters">All Chapters</string>
-    <string name="opds_facet_filter_unread_only">Unread Only</string>
-    <string name="opds_facet_filter_read_only">Read Only</string>
+    <string name="opds_facet_filter_unread_only">Unread</string>
+    <string name="opds_facet_filter_read_only">Read</string>
+    <string name="opds_facet_filter_downloaded">Downloaded</string>
+    <string name="opds_facet_filter_ongoing">Ongoing</string>
+    <string name="opds_facet_filter_completed">Completed</string>
 
     <string name="opds_linktitle_view_chapter_details">View Chapter Details &amp; Get Pages</string>
     <string name="opds_linktitle_download_cbz">Download CBZ</string>

--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -1,31 +1,43 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
     <string name="opds_search_shortname">Suwayomi OPDS Search</string>
-    <string name="opds_search_description">Search manga in the catalog</string>
+    <string name="opds_search_description">Search series in the catalog</string>
 
     <string name="opds_feeds_root">Suwayomi OPDS Catalog</string>
     <string name="opds_feeds_manga_chapters">%1$s Chapters</string>
     <string name="opds_feeds_chapter_details">%1$s | %2$s | Details</string>
 
-    <string name="opds_feeds_all_manga_title">All Manga</string>
-    <string name="opds_feeds_all_manga_entry_content">Browse all manga in your library</string>
+    <string name="opds_feeds_library_title">Library</string>
+    <string name="opds_feeds_library_entry_content">Browse all series saved in your library</string>
+
+    <string name="opds_feeds_explore_title">Explore</string>
+    <string name="opds_feeds_explore_entry_content">Explore new series from your sources</string>
+
+    <string name="opds_feeds_history_title">History</string>
+    <string name="opds_feeds_history_entry_content">Recently read chapters</string>
+
+    <string name="opds_feeds_all_series_in_library_title">All Series</string>
+    <string name="opds_feeds_all_series_in_library_entry_content">Browse all series saved in your library</string>
 
     <string name="opds_feeds_search_results">Search Results</string>
 
-    <string name="opds_feeds_sources_title">Sources</string>
-    <string name="opds_feeds_sources_entry_content">Browse manga by source</string>
+    <string name="opds_feeds_sources_title">All Sources</string>
+    <string name="opds_feeds_sources_entry_content">Browse series by source</string>
+
+    <string name="opds_feeds_library_sources_title">Sources</string>
+    <string name="opds_feeds_library_sources_entry_content">Browse series in your library filtered by source</string>
 
     <string name="opds_feeds_categories_title">Categories</string>
-    <string name="opds_feeds_categories_entry_content">Browse manga organized by categories</string>
+    <string name="opds_feeds_categories_entry_content">Browse series organized by categories</string>
 
     <string name="opds_feeds_genres_title">Genres</string>
-    <string name="opds_feeds_genres_entry_content">Browse manga by genre tags</string>
+    <string name="opds_feeds_genres_entry_content">Browse series by genre tags</string>
 
     <string name="opds_feeds_status_title">Status</string>
-    <string name="opds_feeds_status_entry_content">Browse manga by publication status</string>
+    <string name="opds_feeds_status_entry_content">Browse series by publication status</string>
 
     <string name="opds_feeds_languages_title">Languages</string>
-    <string name="opds_feeds_languages_entry_content">Browse manga by content language</string>
+    <string name="opds_feeds_languages_entry_content">Browse series by content language</string>
 
     <string name="opds_feeds_library_updates_title">Library Update History</string>
     <string name="opds_feeds_library_updates_entry_content">Recently updated chapters from your library</string>
@@ -35,8 +47,11 @@
     <string name="opds_feeds_status_specific_title">Status: %1$s</string>
     <string name="opds_feeds_language_specific_title">Language: %1$s</string>
     <string name="opds_feeds_source_specific_title">Source: %1$s</string>
-    
-    <string name="opds_error_manga_not_found">Manga with ID %1$d not found</string>
+    <string name="opds_feeds_library_source_specific_title">Library - Source: %1$s</string>
+    <string name="opds_feeds_source_specific_popular_title">Source: %1$s - Popular</string>
+    <string name="opds_feeds_source_specific_latest_title">Source: %1$s - Latest</string>
+
+    <string name="opds_error_manga_not_found">Series with ID %1$d not found</string>
     <string name="opds_error_chapter_not_found">Chapter with index %1$d not found</string>
 
     <string name="opds_facetgroup_sort_order">Sort Order</string>
@@ -46,6 +61,8 @@
     <string name="opds_facet_sort_newest_first">Newest First</string>
     <string name="opds_facet_sort_date_asc">Date ascending</string>
     <string name="opds_facet_sort_date_desc">Date descending</string>
+    <string name="opds_facet_sort_popular">Popular</string>
+    <string name="opds_facet_sort_latest">Latest</string>
 
     <string name="opds_facet_filter_all_chapters">All Chapters</string>
     <string name="opds_facet_filter_unread_only">Unread Only</string>

--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <resources>
-    <string name="opds_search_shortname">Suwayomi OPDS Search</string>
-    <string name="opds_search_description">Search series in the catalog</string>
-
+    <!-- OPDS feed titles and descriptions -->
     <string name="opds_feeds_root">Suwayomi OPDS Catalog</string>
     <string name="opds_feeds_manga_chapters">%1$s Chapters</string>
     <string name="opds_feeds_chapter_details">%1$s | %2$s | Details</string>
@@ -15,11 +13,6 @@
 
     <string name="opds_feeds_all_series_in_library_title">All Series</string>
     <string name="opds_feeds_all_series_in_library_entry_content">Browse all series saved in your library</string>
-
-    <string name="opds_feeds_search_results">Search Results</string>
-
-    <string name="opds_feeds_sources_title">All Sources</string>
-    <string name="opds_feeds_sources_entry_content">Browse series by source</string>
 
     <string name="opds_feeds_library_sources_title">Sources</string>
     <string name="opds_feeds_library_sources_entry_content">Browse series in your library filtered by source</string>
@@ -39,6 +32,8 @@
     <string name="opds_feeds_library_updates_title">Library Update History</string>
     <string name="opds_feeds_library_updates_entry_content">Recently updated chapters from your library</string>
 
+    <string name="opds_feeds_search_results_title">Search Results</string>
+    <string name="opds_feeds_sources_title">All Sources</string>
     <string name="opds_feeds_category_specific_title">Category: %1$s</string>
     <string name="opds_feeds_genre_specific_title">Genre: %1$s</string>
     <string name="opds_feeds_status_specific_title">Status: %1$s</string>
@@ -48,13 +43,23 @@
     <string name="opds_feeds_source_specific_popular_title">Source: %1$s - Popular</string>
     <string name="opds_feeds_source_specific_latest_title">Source: %1$s - Latest</string>
 
-    <string name="opds_error_manga_not_found">Series with ID %1$d not found</string>
-    <string name="opds_error_chapter_not_found">Chapter with index %1$d not found</string>
+    <!-- OPDS search texts -->
+    <string name="opds_search_shortname">Suwayomi OPDS Search</string>
+    <string name="opds_search_description">Search for series in the catalog.</string>
 
+    <!-- OPDS errors -->
+    <string name="opds_error_manga_not_found">Series with ID %1$d not found.</string>
+    <string name="opds_error_chapter_not_found">Chapter with index %1$d not found.</string>
+
+    <!-- OPDS facets (Filters and Sorting) -->
     <string name="opds_facetgroup_sort_order">Sort Order</string>
-    <string name="opds_facetgroup_read_status">Read Status</string>
+    <string name="opds_facetgroup_filter_read_status">Filter by Read Status</string>
+    <string name="opds_facetgroup_filter_content">Filter Content</string>
+    <string name="opds_facetgroup_filter_source">Filter by Source</string>
+    <string name="opds_facetgroup_filter_category">Filter by Category</string>
     <string name="opds_facetgroup_filter_status">Filter by Status</string>
-    <string name="opds_facetgroup_filter_content">Filter by Content</string>
+    <string name="opds_facetgroup_filter_language">Filter by Language</string>
+    <string name="opds_facetgroup_filter_genre">Filter by Genre</string>
 
     <string name="opds_facet_sort_oldest_first">Oldest First</string>
     <string name="opds_facet_sort_newest_first">Newest First</string>
@@ -77,23 +82,29 @@
     <string name="opds_facet_filter_ongoing">Ongoing</string>
     <string name="opds_facet_filter_completed">Completed</string>
 
-    <string name="opds_linktitle_view_chapter_details">View Chapter Details &amp; Get Pages</string>
-    <string name="opds_linktitle_download_cbz">Download CBZ</string>
-    <string name="opds_linktitle_stream_pages">View Pages (Streaming)</string>
-    <string name="opds_linktitle_chapter_cover">Chapter Cover</string>
-    <string name="opds_linktitle_current_page">Current Page</string>
+    <string name="opds_facet_all_sources">All Sources</string>
+    <string name="opds_facet_all_categories">All Categories</string>
+    <string name="opds_facet_all_statuses">All Statuses</string>
+    <string name="opds_facet_all_languages">All Languages</string>
+    <string name="opds_facet_all_genres">All Genres</string>
+
+    <!-- OPDS link texts -->
     <string name="opds_linktitle_catalog_root">Catalog Root</string>
     <string name="opds_linktitle_search_catalog">Search Catalog</string>
     <string name="opds_linktitle_previous_page">Previous Page</string>
     <string name="opds_linktitle_next_page">Next Page</string>
     <string name="opds_linktitle_self_feed">Current Feed</string>
+    <string name="opds_linktitle_view_on_web">View on Web</string>
+    <string name="opds_linktitle_stream_pages">View Pages (Streaming)</string>
+    <string name="opds_linktitle_download_cbz">Download CBZ</string>
+    <string name="opds_linktitle_chapter_cover">Chapter Cover</string>
+    <string name="opds_linktitle_view_chapter_details">View Chapter Details &amp; Get Pages</string>
 
-    <string name="opds_chapter_status_downloaded">⬇️ </string>
+    <!-- OPDS summary and details -->
     <string name="opds_chapter_status_read">✅ </string>
     <string name="opds_chapter_status_in_progress">⌛ </string>
-    <string name="opds_chapter_status_error">⚠️ </string>
-    <string name="opds_chapter_status_unknown">❔ </string>
     <string name="opds_chapter_status_unread">⭕ </string>
+    <string name="opds_chapter_status_downloaded">⬇️ </string>
 
     <string name="opds_chapter_details_base">%1$s | %2$s</string>
     <string name="opds_chapter_details_scanlator"> | By %1$s</string>
@@ -102,15 +113,15 @@
     <string name="opds_manga_summary_status">Status: %1$s</string>
     <string name="opds_manga_summary_source">Source: %1$s</string>
     <string name="opds_manga_summary_language">Language: %1$s</string>
-    <string name="opds_linktitle_view_on_web">View on web</string>
 
-    <string name="manga_status_unknown">Unknown</string>
+    <!-- Serie status labels -->
     <string name="manga_status_ongoing">Ongoing</string>
     <string name="manga_status_completed">Completed</string>
     <string name="manga_status_licensed">Licensed</string>
     <string name="manga_status_publishing_finished">Publishing Finished</string>
     <string name="manga_status_cancelled">Cancelled</string>
     <string name="manga_status_on_hiatus">On Hiatus</string>
+    <string name="manga_status_unknown">Unknown</string>
 
     <string name="label_error">Error</string>
     <string name="label_version">Version <xliff:g id="version" example="v2.0.1833">%1$s</xliff:g></string>

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -29,13 +29,13 @@ object OpdsAPI {
 
             // --- Library-Specific Feeds ---
             path("library") {
-                // All Mangas in Library / Search Results Feed (Acquisition)
-                get("mangas", OpdsV1Controller.mangasFeed)
+                // All Series in Library / Search Results Feed (Acquisition)
+                get("series", OpdsV1Controller.seriesFeed)
 
                 // Library Sources Navigation Feed
                 get("sources", OpdsV1Controller.librarySourcesFeed)
 
-                // Library Source-Specific Manga Acquisition Feed
+                // Library Source-Specific Series Acquisition Feed
                 path("source/{sourceId}") {
                     get(OpdsV1Controller.librarySourceFeed)
                 }
@@ -58,39 +58,39 @@ object OpdsAPI {
             // All Sources Navigation Feed (Explore)
             get("sources", OpdsV1Controller.exploreSourcesFeed)
 
-            // Source-Specific Manga Acquisition Feed (Explore)
+            // Source-Specific Series Acquisition Feed (Explore)
             path("source/{sourceId}") {
                 get(OpdsV1Controller.exploreSourceFeed)
             }
 
             // --- Item-Specific Feeds (Apply to both Library and Explore contexts) ---
 
-            // Manga Chapters Acquisition Feed
-            path("manga/{mangaId}/chapters") {
-                get(OpdsV1Controller.mangaFeed)
+            // Series Chapters Acquisition Feed
+            path("series/{seriesId}/chapters") {
+                get(OpdsV1Controller.seriesChaptersFeed)
             }
 
             // Chapter Metadata Acquisition Feed
-            path("manga/{mangaId}/chapter/{chapterIndex}/metadata") {
+            path("series/{seriesId}/chapter/{chapterIndex}/metadata") {
                 get(OpdsV1Controller.chapterMetadataFeed)
             }
 
-            // Category-Specific Manga Acquisition Feed (Library)
+            // Category-Specific Series Acquisition Feed (Library)
             path("category/{categoryId}") {
                 get(OpdsV1Controller.categoryFeed)
             }
 
-            // Genre-Specific Manga Acquisition Feed (Library)
+            // Genre-Specific Series Acquisition Feed (Library)
             path("genre/{genre}") {
                 get(OpdsV1Controller.genreFeed)
             }
 
-            // Status-Specific Manga Acquisition Feed (Library)
+            // Status-Specific Series Acquisition Feed (Library)
             path("status/{statusId}") {
                 get(OpdsV1Controller.statusMangaFeed)
             }
 
-            // Language-Specific Manga Acquisition Feed (Library)
+            // Language-Specific Series Acquisition Feed (Library)
             path("language/{langCode}") {
                 get(OpdsV1Controller.languageFeed)
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -15,9 +15,6 @@ object OpdsAPI {
 
             // --- Main Navigation Feeds ---
 
-            // Library Navigation Feed
-            get("library", OpdsV1Controller.libraryFeed)
-
             // Explore Navigation Feed
             get("explore", OpdsV1Controller.exploreSourcesFeed)
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -44,7 +44,7 @@ object OpdsAPI {
                 get("genres", OpdsV1Controller.genresFeed)
 
                 // Library Status Navigation Feed
-                get("status", OpdsV1Controller.statusFeed)
+                get("statuses", OpdsV1Controller.statusesFeed)
 
                 // Library Content Languages Navigation Feed
                 get("languages", OpdsV1Controller.languagesFeed)

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/OpdsAPI.kt
@@ -13,33 +13,57 @@ object OpdsAPI {
             // OPDS Search Description Feed
             get("search", OpdsV1Controller.searchFeed)
 
-            // Complete feed for crawlers
-            // get("complete", OpdsV1Controller.completeFeed)
+            // --- Main Navigation Feeds ---
 
-            // --- Main Navigation & Broad Acquisition Feeds ---
+            // Library Navigation Feed
+            get("library", OpdsV1Controller.libraryFeed)
 
-            // All Mangas / Search Results Feed (Acquisition)
-            get("mangas", OpdsV1Controller.mangasFeed)
+            // Explore Navigation Feed
+            get("explore", OpdsV1Controller.exploreSourcesFeed)
 
-            // Sources Navigation Feed
-            get("sources", OpdsV1Controller.sourcesFeed)
-
-            // Categories Navigation Feed
-            get("categories", OpdsV1Controller.categoriesFeed)
-
-            // Genres Navigation Feed
-            get("genres", OpdsV1Controller.genresFeed)
-
-            // Status Navigation Feed
-            get("status", OpdsV1Controller.statusFeed)
-
-            // Content Languages Navigation Feed
-            get("languages", OpdsV1Controller.languagesFeed)
+            // Reading History Acquisition Feed
+            get("history", OpdsV1Controller.historyFeed)
 
             // Library Updates Acquisition Feed
             get("library-updates", OpdsV1Controller.libraryUpdatesFeed)
 
-            // --- Filtered & Item-Specific Acquisition Feeds ---
+            // --- Library-Specific Feeds ---
+            path("library") {
+                // All Mangas in Library / Search Results Feed (Acquisition)
+                get("mangas", OpdsV1Controller.mangasFeed)
+
+                // Library Sources Navigation Feed
+                get("sources", OpdsV1Controller.librarySourcesFeed)
+
+                // Library Source-Specific Manga Acquisition Feed
+                path("source/{sourceId}") {
+                    get(OpdsV1Controller.librarySourceFeed)
+                }
+
+                // Library Categories Navigation Feed
+                get("categories", OpdsV1Controller.categoriesFeed)
+
+                // Library Genres Navigation Feed
+                get("genres", OpdsV1Controller.genresFeed)
+
+                // Library Status Navigation Feed
+                get("status", OpdsV1Controller.statusFeed)
+
+                // Library Content Languages Navigation Feed
+                get("languages", OpdsV1Controller.languagesFeed)
+            }
+
+            // --- Explore-Specific Feeds ---
+
+            // All Sources Navigation Feed (Explore)
+            get("sources", OpdsV1Controller.exploreSourcesFeed)
+
+            // Source-Specific Manga Acquisition Feed (Explore)
+            path("source/{sourceId}") {
+                get(OpdsV1Controller.exploreSourceFeed)
+            }
+
+            // --- Item-Specific Feeds (Apply to both Library and Explore contexts) ---
 
             // Manga Chapters Acquisition Feed
             path("manga/{mangaId}/chapters") {
@@ -51,27 +75,22 @@ object OpdsAPI {
                 get(OpdsV1Controller.chapterMetadataFeed)
             }
 
-            // Source-Specific Manga Acquisition Feed
-            path("source/{sourceId}") {
-                get(OpdsV1Controller.sourceFeed)
-            }
-
-            // Category-Specific Manga Acquisition Feed
+            // Category-Specific Manga Acquisition Feed (Library)
             path("category/{categoryId}") {
                 get(OpdsV1Controller.categoryFeed)
             }
 
-            // Genre-Specific Manga Acquisition Feed
+            // Genre-Specific Manga Acquisition Feed (Library)
             path("genre/{genre}") {
                 get(OpdsV1Controller.genreFeed)
             }
 
-            // Status-Specific Manga Acquisition Feed
+            // Status-Specific Manga Acquisition Feed (Library)
             path("status/{statusId}") {
                 get(OpdsV1Controller.statusMangaFeed)
             }
 
-            // Language-Specific Manga Acquisition Feed
+            // Language-Specific Manga Acquisition Feed (Library)
             path("language/{langCode}") {
                 get(OpdsV1Controller.languageFeed)
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/constants/OpdsConstants.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/constants/OpdsConstants.kt
@@ -29,6 +29,8 @@ object OpdsConstants {
     const val LINK_REL_NEXT = "next"
     const val LINK_REL_PSE_STREAM = "http://vaemendis.net/opds-pse/stream"
     const val LINK_REL_CRAWLABLE = "http://opds-spec.org/crawlable"
+    const val LINK_REL_SORT_NEW = "http://opds-spec.org/sort/new"
+    const val LINK_REL_SORT_POPULAR = "http://opds-spec.org/sort/popular"
 
     // Media Types
     const val TYPE_ATOM_XML_FEED_NAVIGATION = "application/atom+xml;profile=opds-catalog;kind=navigation"

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
@@ -36,23 +36,6 @@ object OpdsV1Controller {
 
     // --- Main Navigation Feeds ---
 
-    // Library Navigation Feed
-    val libraryFeed =
-        handler(
-            queryParam<String?>("lang"),
-            documentWith = {
-                withOperation {
-                    summary("OPDS Library Navigation Feed")
-                    description("Navigation feed for accessing library content.")
-                }
-            },
-            behaviorOf = { ctx, lang ->
-                val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
-                ctx.contentType(OPDS_MIME).result(OpdsFeedBuilder.getLibraryFeed(BASE_URL, locale))
-            },
-            withResults = { httpCode(HttpStatus.OK) },
-        )
-
     // History Acquisition Feed
     val historyFeed =
         handler(

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsCategoryNavEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsCategoryNavEntry.kt
@@ -3,4 +3,5 @@ package suwayomi.tachidesk.opds.dto
 data class OpdsCategoryNavEntry(
     val id: Int,
     val name: String,
+    val mangaCount: Long,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsChapterListAcqEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsChapterListAcqEntry.kt
@@ -9,6 +9,7 @@ data class OpdsChapterListAcqEntry(
     val scanlator: String?,
     val read: Boolean,
     val lastPageRead: Int,
+    val lastReadAt: Long,
     val sourceOrder: Int,
     val pageCount: Int, // Can be -1 if not known
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsChapterMetadataAcqEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsChapterMetadataAcqEntry.kt
@@ -12,4 +12,5 @@ data class OpdsChapterMetadataAcqEntry(
     val sourceOrder: Int,
     val downloaded: Boolean,
     val pageCount: Int,
+    val url: String?,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsGenreNavEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsGenreNavEntry.kt
@@ -3,4 +3,5 @@ package suwayomi.tachidesk.opds.dto
 data class OpdsGenreNavEntry(
     val id: String, // Name encoded for OPDS URL (e.g., "Action%20Adventure")
     val title: String, // e.g., "Action & Adventure"
+    val mangaCount: Long,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsHistoryAcqEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsHistoryAcqEntry.kt
@@ -1,0 +1,10 @@
+package suwayomi.tachidesk.opds.dto
+
+data class OpdsHistoryAcqEntry(
+    val chapter: OpdsChapterListAcqEntry,
+    val mangaTitle: String,
+    val mangaAuthor: String?,
+    val mangaId: Int,
+    val mangaSourceLang: String?,
+    val mangaThumbnailUrl: String?,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsLanguageNavEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsLanguageNavEntry.kt
@@ -3,4 +3,5 @@ package suwayomi.tachidesk.opds.dto
 data class OpdsLanguageNavEntry(
     val id: String, // langCode (e.g., "en")
     val title: String, // Localized (e.g., "English")
+    val mangaCount: Long,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsLibraryFeedResult.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsLibraryFeedResult.kt
@@ -1,0 +1,14 @@
+package suwayomi.tachidesk.opds.dto
+
+/**
+ * DTO to encapsulate the results of a library feed query.
+ *
+ * @property mangaEntries The list of manga entries for the current page.
+ * @property totalCount The total number of mangas that match the filter criteria.
+ * @property feedTitleComponent The specific name of the applied filter (e.g., the name of a category or source).
+ */
+data class OpdsLibraryFeedResult(
+    val mangaEntries: List<OpdsMangaAcqEntry>,
+    val totalCount: Long,
+    val feedTitleComponent: String?,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsMangaAcqEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsMangaAcqEntry.kt
@@ -3,10 +3,14 @@ package suwayomi.tachidesk.opds.dto
 data class OpdsMangaAcqEntry(
     val id: Int,
     val title: String,
-    val author: String?,
-    val genres: List<String>, // Raw genres, will be processed in builder
-    val description: String?,
-    val thumbnailUrl: String?, // Raw thumbnail URL from DB
-    val sourceLang: String?,
+    val thumbnailUrl: String?,
+    val lastFetchedAt: Long,
     val inLibrary: Boolean,
+    val author: String?,
+    val genres: List<String>,
+    val description: String?,
+    val status: Int,
+    val sourceName: String,
+    val sourceLang: String,
+    val url: String?,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsMangaFilter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsMangaFilter.kt
@@ -1,0 +1,72 @@
+package suwayomi.tachidesk.opds.dto
+
+import suwayomi.tachidesk.opds.util.OpdsStringUtil.encodeForOpdsURL
+
+/**
+ * Enum to represent the primary filter type of a feed, usually determined by the URL path.
+ */
+enum class PrimaryFilterType {
+    NONE,
+    SOURCE,
+    CATEGORY,
+    GENRE,
+    STATUS,
+    LANGUAGE,
+}
+
+/**
+ * Data class to hold all possible filter parameters for library feeds.
+ */
+data class OpdsMangaFilter(
+    val sourceId: Long? = null,
+    val categoryId: Int? = null,
+    val statusId: Int? = null,
+    val langCode: String? = null,
+    val genre: String? = null,
+    val sort: String? = null,
+    val filter: String? = null,
+    val pageNumber: Int? = null,
+    val primaryFilter: PrimaryFilterType = PrimaryFilterType.NONE,
+) {
+    /**
+     * Creates a query parameter string from the active cross-filters (source, category, etc.).
+     * Excludes sort and regular filter parameters.
+     */
+    fun toCrossFilterQueryParameters(): String =
+        buildList {
+            sourceId?.let { add("source_id=$it") }
+            categoryId?.let { add("category_id=$it") }
+            statusId?.let { add("status_id=$it") }
+            langCode?.let { add("lang_code=${it.encodeForOpdsURL()}") }
+            genre?.let { add("genre=${it.encodeForOpdsURL()}") }
+        }.joinToString("&")
+
+    /**
+     * Creates a new filter set by removing a filter. Used for "None" links.
+     */
+    fun without(key: String): OpdsMangaFilter =
+        when (key) {
+            "source_id" -> this.copy(sourceId = null)
+            "category_id" -> this.copy(categoryId = null)
+            "status_id" -> this.copy(statusId = null)
+            "lang_code" -> this.copy(langCode = null)
+            "genre" -> this.copy(genre = null)
+            else -> this
+        }
+
+    /**
+     * Creates a new filter set by adding or replacing a filter.
+     */
+    fun with(
+        key: String,
+        value: String,
+    ): OpdsMangaFilter =
+        when (key) {
+            "source_id" -> this.copy(sourceId = value.toLongOrNull())
+            "category_id" -> this.copy(categoryId = value.toIntOrNull())
+            "status_id" -> this.copy(statusId = value.toIntOrNull())
+            "lang_code" -> this.copy(langCode = value)
+            "genre" -> this.copy(genre = value)
+            else -> this
+        }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsSourceNavEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsSourceNavEntry.kt
@@ -4,4 +4,5 @@ data class OpdsSourceNavEntry(
     val id: Long,
     val name: String, // Not localized
     val iconUrl: String?,
+    val mangaCount: Long?,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsStatusNavEntry.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/dto/OpdsStatusNavEntry.kt
@@ -3,4 +3,5 @@ package suwayomi.tachidesk.opds.dto
 data class OpdsStatusNavEntry(
     val id: Int,
     val title: String, // Localized
+    val mangaCount: Long,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/FeedBuilderInternal.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/FeedBuilderInternal.kt
@@ -1,0 +1,129 @@
+package suwayomi.tachidesk.opds.impl
+
+import suwayomi.tachidesk.i18n.MR
+import suwayomi.tachidesk.opds.constants.OpdsConstants
+import suwayomi.tachidesk.opds.model.OpdsAuthorXml
+import suwayomi.tachidesk.opds.model.OpdsEntryXml
+import suwayomi.tachidesk.opds.model.OpdsFeedXml
+import suwayomi.tachidesk.opds.model.OpdsLinkXml
+import suwayomi.tachidesk.opds.util.OpdsDateUtil
+import suwayomi.tachidesk.server.serverConfig
+import java.util.Locale
+
+/**
+ * Clase de ayuda para construir un OpdsFeedXml.
+ */
+class FeedBuilderInternal(
+    val baseUrl: String,
+    val idPath: String,
+    val title: String,
+    val locale: Locale,
+    val feedType: String,
+    var pageNum: Int? = 1,
+    var explicitQueryParams: String? = null,
+    val currentSort: String? = null,
+    val currentFilter: String? = null,
+) {
+    private val opdsItemsPerPageBounded: Int
+        get() = serverConfig.opdsItemsPerPage.value.coerceIn(10, 5000)
+
+    private val feedAuthor = OpdsAuthorXml("Suwayomi", "https://suwayomi.org/")
+    private val feedGeneratedAt: String = OpdsDateUtil.formatCurrentInstantForOpds()
+
+    var totalResults: Long = 0
+    var icon: String? = null
+    val links = mutableListOf<OpdsLinkXml>()
+    val entries = mutableListOf<OpdsEntryXml>()
+
+    private fun buildUrlWithParams(
+        baseHrefPath: String,
+        page: Int?,
+    ): String {
+        val sb = StringBuilder("$baseUrl/$baseHrefPath")
+        val queryParamsList = mutableListOf<String>()
+
+        explicitQueryParams?.takeIf { it.isNotBlank() }?.let { queryParamsList.add(it) }
+        page?.let { queryParamsList.add("pageNumber=$it") }
+        currentSort?.let { queryParamsList.add("sort=$it") }
+        currentFilter?.let { queryParamsList.add("filter=$it") }
+        queryParamsList.add("lang=${locale.toLanguageTag()}")
+
+        if (queryParamsList.isNotEmpty()) {
+            sb.append("?").append(queryParamsList.joinToString("&"))
+        }
+        return sb.toString()
+    }
+
+    fun build(): OpdsFeedXml {
+        val actualPageNum = pageNum ?: 1
+        val selfLinkHref = buildUrlWithParams(idPath, if (pageNum != null) actualPageNum else null)
+        val feedLinks = mutableListOf<OpdsLinkXml>()
+        feedLinks.addAll(this.links)
+
+        feedLinks.add(
+            OpdsLinkXml(OpdsConstants.LINK_REL_SELF, selfLinkHref, feedType, MR.strings.opds_linktitle_self_feed.localized(locale)),
+        )
+        feedLinks.add(
+            OpdsLinkXml(
+                OpdsConstants.LINK_REL_START,
+                "$baseUrl?lang=${locale.toLanguageTag()}",
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                MR.strings.opds_linktitle_catalog_root.localized(locale),
+            ),
+        )
+        feedLinks.add(
+            OpdsLinkXml(
+                OpdsConstants.LINK_REL_SEARCH,
+                "$baseUrl/search?lang=${locale.toLanguageTag()}",
+                OpdsConstants.TYPE_OPENSEARCH_DESCRIPTION,
+                MR.strings.opds_linktitle_search_catalog.localized(locale),
+            ),
+        )
+
+        if (pageNum != null) {
+            if (actualPageNum > 1) {
+                feedLinks.add(
+                    OpdsLinkXml(
+                        OpdsConstants.LINK_REL_PREV,
+                        buildUrlWithParams(idPath, actualPageNum - 1),
+                        feedType,
+                        MR.strings.opds_linktitle_previous_page.localized(locale),
+                    ),
+                )
+            }
+            if (totalResults > actualPageNum * opdsItemsPerPageBounded) {
+                feedLinks.add(
+                    OpdsLinkXml(
+                        OpdsConstants.LINK_REL_NEXT,
+                        buildUrlWithParams(idPath, actualPageNum + 1),
+                        feedType,
+                        MR.strings.opds_linktitle_next_page.localized(locale),
+                    ),
+                )
+            }
+        }
+
+        val urnParams = mutableListOf<String>()
+        urnParams.add(locale.toLanguageTag())
+        pageNum?.let { urnParams.add("page$it") }
+        explicitQueryParams?.let { urnParams.add(it.replace("&", ":").replace("=", "_")) }
+        currentSort?.let { urnParams.add("sort_$it") }
+        currentFilter?.let { urnParams.add("filter_$it") }
+        val urnSuffix = if (urnParams.isNotEmpty()) ":${urnParams.joinToString(":")}" else ""
+
+        val showPaginationFields = pageNum != null && totalResults > 0
+
+        return OpdsFeedXml(
+            id = "urn:suwayomi:feed:${idPath.replace('/',':')}$urnSuffix",
+            title = title,
+            updated = feedGeneratedAt,
+            icon = icon,
+            author = feedAuthor,
+            links = feedLinks,
+            entries = entries,
+            totalResults = totalResults.takeIf { showPaginationFields },
+            itemsPerPage = if (showPaginationFields) opdsItemsPerPageBounded else null,
+            startIndex = if (showPaginationFields) ((actualPageNum - 1) * opdsItemsPerPageBounded + 1) else null,
+        )
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
@@ -1,0 +1,289 @@
+package suwayomi.tachidesk.opds.impl
+
+import dev.icerock.moko.resources.StringResource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import suwayomi.tachidesk.i18n.MR
+import suwayomi.tachidesk.manga.impl.ChapterDownloadHelper
+import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
+import suwayomi.tachidesk.opds.constants.OpdsConstants
+import suwayomi.tachidesk.opds.dto.OpdsChapterListAcqEntry
+import suwayomi.tachidesk.opds.dto.OpdsChapterMetadataAcqEntry
+import suwayomi.tachidesk.opds.dto.OpdsMangaAcqEntry
+import suwayomi.tachidesk.opds.dto.OpdsMangaDetails
+import suwayomi.tachidesk.opds.model.OpdsAuthorXml
+import suwayomi.tachidesk.opds.model.OpdsCategoryXml
+import suwayomi.tachidesk.opds.model.OpdsEntryXml
+import suwayomi.tachidesk.opds.model.OpdsLinkXml
+import suwayomi.tachidesk.opds.model.OpdsSummaryXml
+import suwayomi.tachidesk.opds.util.OpdsDateUtil
+import suwayomi.tachidesk.opds.util.OpdsStringUtil.formatFileSizeForOpds
+import suwayomi.tachidesk.server.serverConfig
+import java.util.Locale
+
+object OpdsEntryBuilder {
+    private fun currentFormattedTime() = OpdsDateUtil.formatCurrentInstantForOpds()
+
+    fun mangaAcqEntryToEntry(
+        entry: OpdsMangaAcqEntry,
+        baseUrl: String,
+        locale: Locale,
+    ): OpdsEntryXml {
+        val displayThumbnailUrl = entry.thumbnailUrl?.let { proxyThumbnailUrl(entry.id) }
+        val categoryScheme = if (entry.inLibrary) "$baseUrl/library/genres" else "$baseUrl/genres"
+
+        return OpdsEntryXml(
+            id = "urn:suwayomi:manga:${entry.id}",
+            title = entry.title,
+            updated = currentFormattedTime(),
+            authors = entry.author?.let { listOf(OpdsAuthorXml(name = it)) },
+            categories =
+                entry.genres.filter { it.isNotBlank() }.map { genre ->
+                    OpdsCategoryXml(
+                        term = genre.lowercase().replace(" ", "_"),
+                        label = genre,
+                        scheme = categoryScheme,
+                    )
+                },
+            summary = entry.description?.let { OpdsSummaryXml(value = it) },
+            link =
+                listOfNotNull(
+                    OpdsLinkXml(
+                        OpdsConstants.LINK_REL_SUBSECTION,
+                        "$baseUrl/manga/${entry.id}/chapters?lang=${locale.toLanguageTag()}",
+                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                        entry.title,
+                    ),
+                    displayThumbnailUrl?.let { OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE, it, OpdsConstants.TYPE_IMAGE_JPEG) },
+                    displayThumbnailUrl?.let { OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE_THUMBNAIL, it, OpdsConstants.TYPE_IMAGE_JPEG) },
+                ),
+            language = entry.sourceLang,
+        )
+    }
+
+    fun createChapterListEntry(
+        chapter: OpdsChapterListAcqEntry,
+        manga: OpdsMangaDetails,
+        baseUrl: String,
+        addMangaTitle: Boolean,
+        locale: Locale,
+    ): OpdsEntryXml {
+        val statusKey =
+            when {
+                chapter.read -> MR.strings.opds_chapter_status_read
+                chapter.lastPageRead > 0 -> MR.strings.opds_chapter_status_in_progress
+                else -> MR.strings.opds_chapter_status_unread
+            }
+        val titlePrefix = statusKey.localized(locale)
+        val entryTitle = titlePrefix + (if (addMangaTitle) " ${manga.title}:" else "") + " ${chapter.name}"
+
+        val details =
+            buildString {
+                append(MR.strings.opds_chapter_details_base.localized(locale, manga.title, chapter.name))
+                chapter.scanlator?.takeIf { it.isNotBlank() }?.let {
+                    append(MR.strings.opds_chapter_details_scanlator.localized(locale, it))
+                }
+                if (chapter.pageCount > 0) {
+                    append(MR.strings.opds_chapter_details_progress.localized(locale, chapter.lastPageRead, chapter.pageCount))
+                }
+            }
+
+        return OpdsEntryXml(
+            id = "urn:suwayomi:chapter:${chapter.id}",
+            title = entryTitle,
+            updated = OpdsDateUtil.formatEpochMillisForOpds(chapter.uploadDate),
+            authors =
+                listOfNotNull(
+                    manga.author?.let { OpdsAuthorXml(name = it) },
+                    chapter.scanlator?.takeIf { it.isNotBlank() }?.let { OpdsAuthorXml(name = it) },
+                ),
+            summary = OpdsSummaryXml(value = details),
+            link =
+                listOf(
+                    OpdsLinkXml(
+                        rel = OpdsConstants.LINK_REL_SUBSECTION,
+                        href = "$baseUrl/manga/${manga.id}/chapter/${chapter.sourceOrder}/metadata?lang=${locale.toLanguageTag()}",
+                        type = OpdsConstants.TYPE_ATOM_XML_ENTRY_PROFILE_OPDS,
+                        title = MR.strings.opds_linktitle_view_chapter_details.localized(locale),
+                    ),
+                ),
+        )
+    }
+
+    suspend fun createChapterMetadataEntry(
+        chapter: OpdsChapterMetadataAcqEntry,
+        manga: OpdsMangaDetails,
+        baseUrl: String,
+        locale: Locale,
+    ): OpdsEntryXml {
+        val statusKey =
+            when {
+                chapter.downloaded -> MR.strings.opds_chapter_status_downloaded
+                chapter.read -> MR.strings.opds_chapter_status_read
+                chapter.lastPageRead > 0 -> MR.strings.opds_chapter_status_in_progress
+                else -> MR.strings.opds_chapter_status_unread
+            }
+        val titlePrefix = statusKey.localized(locale)
+        val entryTitle = "$titlePrefix ${chapter.name}"
+
+        val details =
+            buildString {
+                append(MR.strings.opds_chapter_details_base.localized(locale, manga.title, chapter.name))
+                chapter.scanlator?.takeIf { it.isNotBlank() }?.let {
+                    append(MR.strings.opds_chapter_details_scanlator.localized(locale, it))
+                }
+                val pageCountDisplay = chapter.pageCount.takeIf { it > 0 } ?: "?"
+                append(MR.strings.opds_chapter_details_progress.localized(locale, chapter.lastPageRead, pageCountDisplay))
+            }
+
+        val links = mutableListOf<OpdsLinkXml>()
+        var cbzFileSize: Long? = null
+
+        if (chapter.downloaded) {
+            val cbzStreamPair =
+                withContext(
+                    Dispatchers.IO,
+                ) { runCatching { ChapterDownloadHelper.getArchiveStreamWithSize(manga.id, chapter.id) }.getOrNull() }
+            cbzFileSize = cbzStreamPair?.second
+            cbzStreamPair?.let {
+                links.add(
+                    OpdsLinkXml(
+                        OpdsConstants.LINK_REL_ACQUISITION_OPEN_ACCESS,
+                        "/api/v1/chapter/${chapter.id}/download?markAsRead=${serverConfig.opdsMarkAsReadOnDownload.value}",
+                        OpdsConstants.TYPE_CBZ,
+                        MR.strings.opds_linktitle_download_cbz.localized(locale),
+                    ),
+                )
+            }
+        }
+
+        if (chapter.pageCount > 0) {
+            links.add(
+                OpdsLinkXml(
+                    OpdsConstants.LINK_REL_PSE_STREAM,
+                    "/api/v1/manga/${manga.id}/chapter/${chapter.sourceOrder}/page/{pageNumber}?updateProgress=${serverConfig.opdsEnablePageReadProgress.value}",
+                    OpdsConstants.TYPE_IMAGE_JPEG,
+                    MR.strings.opds_linktitle_stream_pages.localized(locale),
+                    pseCount = chapter.pageCount,
+                    pseLastRead = chapter.lastPageRead.takeIf { it > 0 },
+                    pseLastReadDate = chapter.lastReadAt.takeIf { it > 0 }?.let { OpdsDateUtil.formatEpochMillisForOpds(it * 1000) },
+                ),
+            )
+            links.add(
+                OpdsLinkXml(
+                    OpdsConstants.LINK_REL_IMAGE,
+                    "/api/v1/manga/${manga.id}/chapter/${chapter.sourceOrder}/page/0",
+                    OpdsConstants.TYPE_IMAGE_JPEG,
+                    MR.strings.opds_linktitle_chapter_cover.localized(locale),
+                ),
+            )
+        }
+
+        return OpdsEntryXml(
+            id = "urn:suwayomi:chapter:${chapter.id}:metadata",
+            title = entryTitle,
+            updated = OpdsDateUtil.formatEpochMillisForOpds(chapter.uploadDate),
+            authors =
+                listOfNotNull(
+                    manga.author?.let { OpdsAuthorXml(name = it) },
+                    chapter.scanlator?.takeIf { it.isNotBlank() }?.let { OpdsAuthorXml(name = it) },
+                ),
+            summary = OpdsSummaryXml(value = details),
+            link = links,
+            extent = cbzFileSize?.let { formatFileSizeForOpds(it) },
+            format = if (cbzFileSize != null) "CBZ" else null,
+        )
+    }
+
+    fun addSourceSortFacets(
+        feedBuilder: FeedBuilderInternal,
+        baseSourceUrl: String,
+        currentSort: String,
+        locale: Locale,
+    ) {
+        val sortGroup = MR.strings.opds_facetgroup_sort_order.localized(locale)
+        val addFacet = { href: String, titleKey: StringResource, isActive: Boolean ->
+            feedBuilder.links.add(
+                OpdsLinkXml(
+                    OpdsConstants.LINK_REL_FACET,
+                    href,
+                    OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                    titleKey.localized(locale),
+                    facetGroup = sortGroup,
+                    activeFacet = isActive,
+                ),
+            )
+        }
+
+        addFacet("$baseSourceUrl?sort=popular&lang=${locale.toLanguageTag()}", MR.strings.opds_facet_sort_popular, currentSort == "popular")
+        addFacet("$baseSourceUrl?sort=latest&lang=${locale.toLanguageTag()}", MR.strings.opds_facet_sort_latest, currentSort == "latest")
+    }
+
+    fun addChapterSortAndFilterFacets(
+        feedBuilder: FeedBuilderInternal,
+        baseMangaUrl: String,
+        currentSort: String,
+        currentFilter: String,
+        locale: Locale,
+    ) {
+        val sortGroup = MR.strings.opds_facetgroup_sort_order.localized(locale)
+        val filterGroup = MR.strings.opds_facetgroup_read_status.localized(locale)
+
+        val addFacet = { href: String, titleKey: StringResource, group: String, isActive: Boolean ->
+            feedBuilder.links.add(
+                OpdsLinkXml(
+                    OpdsConstants.LINK_REL_FACET,
+                    href,
+                    OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                    titleKey.localized(locale),
+                    facetGroup = group,
+                    activeFacet = isActive,
+                ),
+            )
+        }
+
+        addFacet(
+            "$baseMangaUrl?sort=number_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_sort_oldest_first,
+            sortGroup,
+            currentSort == "number_asc",
+        )
+        addFacet(
+            "$baseMangaUrl?sort=number_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_sort_newest_first,
+            sortGroup,
+            currentSort == "number_desc",
+        )
+        addFacet(
+            "$baseMangaUrl?sort=date_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_sort_date_asc,
+            sortGroup,
+            currentSort == "date_asc",
+        )
+        addFacet(
+            "$baseMangaUrl?sort=date_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_sort_date_desc,
+            sortGroup,
+            currentSort == "date_desc",
+        )
+
+        addFacet(
+            "$baseMangaUrl?filter=all&sort=$currentSort&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_filter_all_chapters,
+            filterGroup,
+            currentFilter == "all",
+        )
+        addFacet(
+            "$baseMangaUrl?filter=unread&sort=$currentSort&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_filter_unread_only,
+            filterGroup,
+            currentFilter == "unread",
+        )
+        addFacet(
+            "$baseMangaUrl?filter=read&sort=$currentSort&lang=${locale.toLanguageTag()}",
+            MR.strings.opds_facet_filter_read_only,
+            filterGroup,
+            currentFilter == "read",
+        )
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
@@ -50,7 +50,7 @@ object OpdsEntryBuilder {
                 listOfNotNull(
                     OpdsLinkXml(
                         OpdsConstants.LINK_REL_SUBSECTION,
-                        "$baseUrl/manga/${entry.id}/chapters?lang=${locale.toLanguageTag()}",
+                        "$baseUrl/series/${entry.id}/chapters?lang=${locale.toLanguageTag()}",
                         OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                         entry.title,
                     ),
@@ -102,7 +102,7 @@ object OpdsEntryBuilder {
                 listOf(
                     OpdsLinkXml(
                         rel = OpdsConstants.LINK_REL_SUBSECTION,
-                        href = "$baseUrl/manga/${manga.id}/chapter/${chapter.sourceOrder}/metadata?lang=${locale.toLanguageTag()}",
+                        href = "$baseUrl/series/${manga.id}/chapter/${chapter.sourceOrder}/metadata?lang=${locale.toLanguageTag()}",
                         type = OpdsConstants.TYPE_ATOM_XML_ENTRY_PROFILE_OPDS,
                         title = MR.strings.opds_linktitle_view_chapter_details.localized(locale),
                     ),
@@ -197,7 +197,7 @@ object OpdsEntryBuilder {
 
     fun addSourceSortFacets(
         feedBuilder: FeedBuilderInternal,
-        baseSourceUrl: String,
+        baseUrl: String,
         currentSort: String,
         locale: Locale,
     ) {
@@ -215,13 +215,13 @@ object OpdsEntryBuilder {
             )
         }
 
-        addFacet("$baseSourceUrl?sort=popular&lang=${locale.toLanguageTag()}", MR.strings.opds_facet_sort_popular, currentSort == "popular")
-        addFacet("$baseSourceUrl?sort=latest&lang=${locale.toLanguageTag()}", MR.strings.opds_facet_sort_latest, currentSort == "latest")
+        addFacet("$baseUrl?sort=popular&lang=${locale.toLanguageTag()}", MR.strings.opds_facet_sort_popular, currentSort == "popular")
+        addFacet("$baseUrl?sort=latest&lang=${locale.toLanguageTag()}", MR.strings.opds_facet_sort_latest, currentSort == "latest")
     }
 
     fun addChapterSortAndFilterFacets(
         feedBuilder: FeedBuilderInternal,
-        baseMangaUrl: String,
+        baseUrl: String,
         currentSort: String,
         currentFilter: String,
         locale: Locale,
@@ -243,47 +243,131 @@ object OpdsEntryBuilder {
         }
 
         addFacet(
-            "$baseMangaUrl?sort=number_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            "$baseUrl?sort=number_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_sort_oldest_first,
             sortGroup,
             currentSort == "number_asc",
         )
         addFacet(
-            "$baseMangaUrl?sort=number_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            "$baseUrl?sort=number_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_sort_newest_first,
             sortGroup,
             currentSort == "number_desc",
         )
         addFacet(
-            "$baseMangaUrl?sort=date_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            "$baseUrl?sort=date_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_sort_date_asc,
             sortGroup,
             currentSort == "date_asc",
         )
         addFacet(
-            "$baseMangaUrl?sort=date_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
+            "$baseUrl?sort=date_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_sort_date_desc,
             sortGroup,
             currentSort == "date_desc",
         )
 
         addFacet(
-            "$baseMangaUrl?filter=all&sort=$currentSort&lang=${locale.toLanguageTag()}",
+            "$baseUrl?filter=all&sort=$currentSort&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_filter_all_chapters,
             filterGroup,
             currentFilter == "all",
         )
         addFacet(
-            "$baseMangaUrl?filter=unread&sort=$currentSort&lang=${locale.toLanguageTag()}",
+            "$baseUrl?filter=unread&sort=$currentSort&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_filter_unread_only,
             filterGroup,
             currentFilter == "unread",
         )
         addFacet(
-            "$baseMangaUrl?filter=read&sort=$currentSort&lang=${locale.toLanguageTag()}",
+            "$baseUrl?filter=read&sort=$currentSort&lang=${locale.toLanguageTag()}",
             MR.strings.opds_facet_filter_read_only,
             filterGroup,
             currentFilter == "read",
+        )
+    }
+
+    fun addLibraryMangaSortAndFilterFacets(
+        feedBuilder: FeedBuilderInternal,
+        baseUrl: String,
+        currentSort: String,
+        currentFilter: String,
+        locale: Locale,
+    ) {
+        val sortGroup = MR.strings.opds_facetgroup_sort_order.localized(locale)
+        val filterGroup = MR.strings.opds_facetgroup_filter_content.localized(locale)
+
+        val addFacet = { href: String, titleKey: StringResource, group: String, isActive: Boolean ->
+            feedBuilder.links.add(
+                OpdsLinkXml(
+                    OpdsConstants.LINK_REL_FACET,
+                    href,
+                    OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                    titleKey.localized(locale),
+                    facetGroup = group,
+                    activeFacet = isActive,
+                ),
+            )
+        }
+
+        // Sorting Facets
+        addFacet(
+            "$baseUrl?sort=alpha_asc&filter=$currentFilter",
+            MR.strings.opds_facet_sort_alpha_asc,
+            sortGroup,
+            currentSort == "alpha_asc",
+        )
+        addFacet(
+            "$baseUrl?sort=alpha_desc&filter=$currentFilter",
+            MR.strings.opds_facet_sort_alpha_desc,
+            sortGroup,
+            currentSort == "alpha_desc",
+        )
+        addFacet(
+            "$baseUrl?sort=last_read_desc&filter=$currentFilter",
+            MR.strings.opds_facet_sort_last_read_desc,
+            sortGroup,
+            currentSort == "last_read_desc",
+        )
+        addFacet(
+            "$baseUrl?sort=latest_chapter_desc&filter=$currentFilter",
+            MR.strings.opds_facet_sort_latest_chapter_desc,
+            sortGroup,
+            currentSort == "latest_chapter_desc",
+        )
+        addFacet(
+            "$baseUrl?sort=date_added_desc&filter=$currentFilter",
+            MR.strings.opds_facet_sort_date_added_desc,
+            sortGroup,
+            currentSort == "date_added_desc",
+        )
+        addFacet(
+            "$baseUrl?sort=unread_desc&filter=$currentFilter",
+            MR.strings.opds_facet_sort_unread_desc,
+            sortGroup,
+            currentSort == "unread_desc",
+        )
+
+        // Filtering Facets
+        addFacet("$baseUrl?filter=all&sort=$currentSort", MR.strings.opds_facet_filter_all, filterGroup, currentFilter == "all")
+        addFacet(
+            "$baseUrl?filter=unread&sort=$currentSort",
+            MR.strings.opds_facet_filter_unread_only,
+            filterGroup,
+            currentFilter == "unread",
+        )
+        addFacet(
+            "$baseUrl?filter=downloaded&sort=$currentSort",
+            MR.strings.opds_facet_filter_downloaded,
+            filterGroup,
+            currentFilter == "downloaded",
+        )
+        addFacet("$baseUrl?filter=ongoing&sort=$currentSort", MR.strings.opds_facet_filter_ongoing, filterGroup, currentFilter == "ongoing")
+        addFacet(
+            "$baseUrl?filter=completed&sort=$currentSort",
+            MR.strings.opds_facet_filter_completed,
+            filterGroup,
+            currentFilter == "completed",
         )
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
@@ -147,6 +147,7 @@ object OpdsFeedBuilder {
                 MR.strings.opds_feeds_all_series_in_library_title.localized(locale)
             }
 
+        val filterCounts = MangaRepository.getLibraryFilterCounts()
         val feedUrl = "library/series"
         val builder =
             FeedBuilderInternal(
@@ -160,7 +161,7 @@ object OpdsFeedBuilder {
                 currentFilter = currentFilter,
             )
         builder.totalResults = total
-        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale)
+        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale, filterCounts)
         builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
@@ -231,6 +232,7 @@ object OpdsFeedBuilder {
                                 "$baseUrl/library/source/${entry.id}?lang=${locale.toLanguageTag()}",
                                 OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                                 entry.name,
+                                thrCount = entry.mangaCount?.toInt(),
                             ),
                         ),
                 )
@@ -299,6 +301,7 @@ object OpdsFeedBuilder {
         val sourceNameOrId = sourceNavEntry?.name ?: sourceId.toString()
         val feedTitle = MR.strings.opds_feeds_library_source_specific_title.localized(locale, sourceNameOrId)
 
+        val filterCounts = MangaRepository.getLibraryFilterCounts()
         val feedUrl = "library/source/$sourceId"
         val builder =
             FeedBuilderInternal(
@@ -313,7 +316,7 @@ object OpdsFeedBuilder {
             )
         builder.totalResults = total
         builder.icon = sourceNavEntry?.iconUrl
-        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale)
+        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale, filterCounts)
         builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
@@ -347,6 +350,7 @@ object OpdsFeedBuilder {
                                 "$baseUrl/category/${entry.id}?lang=${locale.toLanguageTag()}",
                                 OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                                 entry.name,
+                                thrCount = entry.mangaCount.toInt(),
                             ),
                         ),
                 )
@@ -384,6 +388,7 @@ object OpdsFeedBuilder {
                                 "$baseUrl/genre/${entry.id}?lang=${locale.toLanguageTag()}",
                                 OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                                 entry.title,
+                                thrCount = entry.mangaCount.toInt(),
                             ),
                         ),
                 )
@@ -421,6 +426,7 @@ object OpdsFeedBuilder {
                                 "$baseUrl/status/${entry.id}?lang=${locale.toLanguageTag()}",
                                 OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                                 entry.title,
+                                thrCount = entry.mangaCount.toInt(),
                             ),
                         ),
                 )
@@ -457,6 +463,7 @@ object OpdsFeedBuilder {
                                 "$baseUrl/language/${entry.id}?lang=${uiLocale.toLanguageTag()}",
                                 OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                                 entry.title,
+                                thrCount = entry.mangaCount.toInt(),
                             ),
                         ),
                 )
@@ -503,6 +510,7 @@ object OpdsFeedBuilder {
         val (mangaEntries, total) = MangaRepository.getMangaByCategory(categoryId, pageNum, currentSort, currentFilter)
         val categoryNavEntry = NavigationRepository.getCategories(1).first.find { it.id == categoryId }
         val feedTitle = MR.strings.opds_feeds_category_specific_title.localized(locale, categoryNavEntry?.name ?: categoryId.toString())
+        val filterCounts = MangaRepository.getLibraryFilterCounts()
         val feedUrl = "category/$categoryId"
         val builder =
             FeedBuilderInternal(
@@ -516,7 +524,7 @@ object OpdsFeedBuilder {
                 currentFilter = currentFilter,
             )
         builder.totalResults = total
-        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale)
+        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale, filterCounts)
         builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
@@ -533,6 +541,7 @@ object OpdsFeedBuilder {
         val currentFilter = filter ?: "all"
         val (mangaEntries, total) = MangaRepository.getMangaByGenre(genre, pageNum, currentSort, currentFilter)
         val feedTitle = MR.strings.opds_feeds_genre_specific_title.localized(locale, genre)
+        val filterCounts = MangaRepository.getLibraryFilterCounts()
         val feedUrl = "genre/${genre.encodeForOpdsURL()}"
         val builder =
             FeedBuilderInternal(
@@ -546,7 +555,7 @@ object OpdsFeedBuilder {
                 currentFilter = currentFilter,
             )
         builder.totalResults = total
-        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale)
+        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale, filterCounts)
         builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
@@ -565,6 +574,7 @@ object OpdsFeedBuilder {
         val statusName = statusNavEntry?.title ?: statusDbId.toString()
         val (mangaEntries, total) = MangaRepository.getMangaByStatus(statusDbId.toInt(), pageNum, currentSort, currentFilter)
         val feedTitle = MR.strings.opds_feeds_status_specific_title.localized(locale, statusName)
+        val filterCounts = MangaRepository.getLibraryFilterCounts()
         val feedUrl = "status/$statusDbId"
         val builder =
             FeedBuilderInternal(
@@ -578,7 +588,7 @@ object OpdsFeedBuilder {
                 currentFilter = currentFilter,
             )
         builder.totalResults = total
-        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale)
+        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, locale, filterCounts)
         builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
@@ -596,6 +606,7 @@ object OpdsFeedBuilder {
         val (mangaEntries, total) = MangaRepository.getMangaByContentLanguage(contentLangCode, pageNum, currentSort, currentFilter)
         val contentLanguageDisplayName = Locale.forLanguageTag(contentLangCode).getDisplayName(uiLocale)
         val feedTitle = MR.strings.opds_feeds_language_specific_title.localized(uiLocale, contentLanguageDisplayName)
+        val filterCounts = MangaRepository.getLibraryFilterCounts()
         val feedUrl = "language/$contentLangCode"
         val builder =
             FeedBuilderInternal(
@@ -609,7 +620,14 @@ object OpdsFeedBuilder {
                 currentFilter = currentFilter,
             )
         builder.totalResults = total
-        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(builder, "$baseUrl/$feedUrl", currentSort, currentFilter, uiLocale)
+        OpdsEntryBuilder.addLibraryMangaSortAndFilterFacets(
+            builder,
+            "$baseUrl/$feedUrl",
+            currentSort,
+            currentFilter,
+            uiLocale,
+            filterCounts,
+        )
         builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, uiLocale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
@@ -653,6 +671,7 @@ object OpdsFeedBuilder {
                 val suffix = if (currentSortOrder == SortOrder.ASC) "asc" else "desc"
                 "${prefix}_$suffix"
             }
+        val filterCounts = ChapterRepository.getChapterFilterCounts(mangaId)
         val feedUrl = "series/$mangaId/chapters"
         val builder =
             FeedBuilderInternal(
@@ -677,6 +696,7 @@ object OpdsFeedBuilder {
             actualSortParamForLinks,
             currentFilter,
             locale,
+            filterCounts,
         )
         builder.entries.addAll(
             chapterEntries.map { chapter ->

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
@@ -400,7 +400,7 @@ object OpdsFeedBuilder {
                 }
                 addChapterSortAndFilterFacets(
                     this,
-                    "$baseUrl/manga/$mangaId",
+                    "$baseUrl/manga/$mangaId/chapters",
                     actualSortParamForLinks,
                     currentFilter,
                     locale,

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
@@ -1,51 +1,26 @@
 package suwayomi.tachidesk.opds.impl
 
-import dev.icerock.moko.resources.StringResource
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.sql.SortOrder
 import suwayomi.tachidesk.i18n.MR
-import suwayomi.tachidesk.manga.impl.ChapterDownloadHelper
 import suwayomi.tachidesk.manga.impl.MangaList.proxyThumbnailUrl
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.opds.constants.OpdsConstants
-import suwayomi.tachidesk.opds.dto.OpdsCategoryNavEntry
-import suwayomi.tachidesk.opds.dto.OpdsChapterListAcqEntry
-import suwayomi.tachidesk.opds.dto.OpdsChapterMetadataAcqEntry
-import suwayomi.tachidesk.opds.dto.OpdsGenreNavEntry
-import suwayomi.tachidesk.opds.dto.OpdsLanguageNavEntry
-import suwayomi.tachidesk.opds.dto.OpdsMangaAcqEntry
 import suwayomi.tachidesk.opds.dto.OpdsMangaDetails
-import suwayomi.tachidesk.opds.dto.OpdsRootNavEntry
 import suwayomi.tachidesk.opds.dto.OpdsSearchCriteria
-import suwayomi.tachidesk.opds.dto.OpdsSourceNavEntry
-import suwayomi.tachidesk.opds.dto.OpdsStatusNavEntry
-import suwayomi.tachidesk.opds.model.OpdsAuthorXml
-import suwayomi.tachidesk.opds.model.OpdsCategoryXml
 import suwayomi.tachidesk.opds.model.OpdsContentXml
 import suwayomi.tachidesk.opds.model.OpdsEntryXml
-import suwayomi.tachidesk.opds.model.OpdsFeedXml
 import suwayomi.tachidesk.opds.model.OpdsLinkXml
-import suwayomi.tachidesk.opds.model.OpdsSummaryXml
 import suwayomi.tachidesk.opds.repository.ChapterRepository
 import suwayomi.tachidesk.opds.repository.MangaRepository
 import suwayomi.tachidesk.opds.repository.NavigationRepository
 import suwayomi.tachidesk.opds.util.OpdsDateUtil
 import suwayomi.tachidesk.opds.util.OpdsStringUtil.encodeForOpdsURL
-import suwayomi.tachidesk.opds.util.OpdsStringUtil.formatFileSizeForOpds
 import suwayomi.tachidesk.opds.util.OpdsXmlUtil
 import suwayomi.tachidesk.server.serverConfig
 import java.util.Locale
 
 object OpdsFeedBuilder {
-    private val opdsItemsPerPageBounded: Int
-        get() = serverConfig.opdsItemsPerPage.value.coerceIn(10, 5000)
-
-    private val feedAuthor = OpdsAuthorXml("Suwayomi", "https://suwayomi.org/")
-
     private fun currentFormattedTime() = OpdsDateUtil.formatCurrentInstantForOpds()
-
-    // --- Main Feed Generators ---
 
     fun getRootFeed(
         baseUrl: String,
@@ -54,34 +29,96 @@ object OpdsFeedBuilder {
         val navItems = NavigationRepository.getRootNavigationItems(locale)
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "root",
-                title = MR.strings.opds_feeds_root.localized(locale),
-                locale = locale,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-                pageNum = null, // Root is never paginated
-            ).apply {
-                totalResults = navItems.size.toLong()
-                entries.addAll(
-                    navItems.map { item: OpdsRootNavEntry ->
-                        OpdsEntryXml(
-                            id = "urn:suwayomi:navigation:root:${item.id}",
-                            title = item.title,
-                            updated = currentFormattedTime(),
-                            link =
-                                listOf(
-                                    OpdsLinkXml(
-                                        rel = OpdsConstants.LINK_REL_SUBSECTION,
-                                        href = "$baseUrl/${item.id}?lang=${locale.toLanguageTag()}",
-                                        type = item.linkType,
-                                        title = item.title,
-                                    ),
-                                ),
-                            content = OpdsContentXml(type = "text", value = item.description),
-                        )
-                    },
+                baseUrl,
+                "root",
+                MR.strings.opds_feeds_root.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                null,
+            )
+        builder.totalResults = navItems.size.toLong()
+        builder.entries.addAll(
+            navItems.map { item ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:root:${item.id}",
+                    title = item.title,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                rel = OpdsConstants.LINK_REL_SUBSECTION,
+                                href = "$baseUrl/${item.id}?lang=${locale.toLanguageTag()}",
+                                type = item.linkType,
+                                title = item.title,
+                            ),
+                        ),
+                    content = OpdsContentXml(type = "text", value = item.description),
                 )
-            }
+            },
+        )
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getLibraryFeed(
+        baseUrl: String,
+        locale: Locale,
+    ): String {
+        val navItems = NavigationRepository.getLibraryNavigationItems(locale)
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "library",
+                MR.strings.opds_feeds_library_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                null,
+            )
+        builder.totalResults = navItems.size.toLong()
+        builder.entries.addAll(
+            navItems.map { item ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:library:${item.id}",
+                    title = item.title,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                rel = OpdsConstants.LINK_REL_SUBSECTION,
+                                href = "$baseUrl/library/${item.id}?lang=${locale.toLanguageTag()}",
+                                type = item.linkType,
+                                title = item.title,
+                            ),
+                        ),
+                    content = OpdsContentXml(type = "text", value = item.description),
+                )
+            },
+        )
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getHistoryFeed(
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val (historyItems, total) = ChapterRepository.getHistory(pageNum)
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "history",
+                MR.strings.opds_feeds_history_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(
+            historyItems.map { item ->
+                val mangaDetails =
+                    OpdsMangaDetails(item.mangaId, item.mangaTitle, item.mangaThumbnailUrl, item.mangaAuthor)
+                OpdsEntryBuilder.createChapterListEntry(item.chapter, mangaDetails, baseUrl, true, locale)
+            },
+        )
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
@@ -90,97 +127,173 @@ object OpdsFeedBuilder {
         baseUrl: String,
         pageNum: Int,
         locale: Locale,
-    ): String =
-        if (criteria != null) {
-            getMangaSearchResultsFeed(criteria, baseUrl, locale)
-        } else {
-            getAllMangasFeed(baseUrl, pageNum, locale)
-        }
+    ): String {
+        val (mangaEntries, total) =
+            if (criteria !=
+                null
+            ) {
+                MangaRepository.findMangaByCriteria(criteria)
+            } else {
+                MangaRepository.getAllManga(pageNum)
+            }
+        val title =
+            if (criteria !=
+                null
+            ) {
+                MR.strings.opds_feeds_search_results.localized(locale)
+            } else {
+                MR.strings.opds_feeds_all_series_in_library_title.localized(locale)
+            }
 
-    private fun getAllMangasFeed(
+        val builder = FeedBuilderInternal(baseUrl, "library/mangas", title, locale, OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION, pageNum)
+        builder.totalResults = total
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getExploreSourcesFeed(
         baseUrl: String,
         pageNum: Int,
         locale: Locale,
     ): String {
-        val (mangaEntries, total) = MangaRepository.getAllManga(pageNum)
+        val (sourceNavEntries, total) = NavigationRepository.getExploreSources(pageNum)
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "mangas",
-                title = MR.strings.opds_feeds_all_manga_title.localized(locale),
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, locale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    private fun getMangaSearchResultsFeed(
-        criteria: OpdsSearchCriteria,
-        baseUrl: String,
-        locale: Locale,
-    ): String {
-        val (mangaEntries, total) = MangaRepository.findMangaByCriteria(criteria)
-        val queryParams = mutableListOf<String>()
-        criteria.query?.let { queryParams.add("query=${it.encodeForOpdsURL()}") }
-        criteria.author?.let { queryParams.add("author=${it.encodeForOpdsURL()}") }
-        criteria.title?.let { queryParams.add("title=${it.encodeForOpdsURL()}") }
-
-        val builder =
-            FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "mangas",
-                title = MR.strings.opds_feeds_search_results.localized(locale),
-                locale = locale,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                explicitQueryParams = queryParams.joinToString("&").ifEmpty { null },
-                pageNum = 1, // Search results always start at page 1 for this link
-            ).apply {
-                totalResults = total
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, locale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getSourcesFeed(
-        baseUrl: String,
-        pageNum: Int,
-        locale: Locale,
-    ): String {
-        val (sourceNavEntries, total) = NavigationRepository.getSources(pageNum)
-        val builder =
-            FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "sources",
-                title = MR.strings.opds_feeds_sources_title.localized(locale),
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-            ).apply {
-                totalResults = total
-                entries.addAll(
-                    sourceNavEntries.map { entry: OpdsSourceNavEntry ->
-                        OpdsEntryXml(
-                            id = "urn:suwayomi:navigation:sources:${entry.id}",
-                            title = entry.name,
-                            updated = currentFormattedTime(),
-                            link =
-                                listOf(
-                                    OpdsLinkXml(
-                                        OpdsConstants.LINK_REL_SUBSECTION,
-                                        "$baseUrl/source/${entry.id}?lang=${locale.toLanguageTag()}",
-                                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                                        entry.name,
-                                    ),
-                                ),
-                            // Consider adding icon as artwork link if needed
-                        )
-                    },
+                baseUrl,
+                "sources",
+                MR.strings.opds_feeds_sources_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(
+            sourceNavEntries.map { entry ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:sources:${entry.id}",
+                    title = entry.name,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                OpdsConstants.LINK_REL_SUBSECTION,
+                                "$baseUrl/source/${entry.id}?lang=${locale.toLanguageTag()}",
+                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                                entry.name,
+                            ),
+                        ),
                 )
+            },
+        )
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getLibrarySourcesFeed(
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val (sourceNavEntries, total) = NavigationRepository.getLibrarySources(pageNum)
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "library/sources",
+                MR.strings.opds_feeds_library_sources_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(
+            sourceNavEntries.map { entry ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:library:sources:${entry.id}",
+                    title = entry.name,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                OpdsConstants.LINK_REL_SUBSECTION,
+                                "$baseUrl/library/source/${entry.id}?lang=${locale.toLanguageTag()}",
+                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                                entry.name,
+                            ),
+                        ),
+                )
+            },
+        )
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    suspend fun getExploreSourceFeed(
+        sourceId: Long,
+        baseUrl: String,
+        pageNum: Int,
+        sort: String,
+        locale: Locale,
+    ): String {
+        val (mangaEntries, hasNextPage) = MangaRepository.getMangaBySource(sourceId, pageNum, sort)
+        val sourceNavEntry = NavigationRepository.getExploreSources(1).first.find { it.id == sourceId }
+        val sourceNameOrId = sourceNavEntry?.name ?: sourceId.toString()
+        val titleRes =
+            if (sort ==
+                "latest"
+            ) {
+                MR.strings.opds_feeds_source_specific_latest_title
+            } else {
+                MR.strings.opds_feeds_source_specific_popular_title
             }
+        val feedTitle = titleRes.localized(locale, sourceNameOrId)
+
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "source/$sourceId",
+                feedTitle,
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
+                currentSort = sort,
+            )
+        builder.totalResults =
+            if (hasNextPage) {
+                (pageNum * serverConfig.opdsItemsPerPage.value + 1).toLong()
+            } else {
+                (
+                    (pageNum - 1) *
+                        serverConfig.opdsItemsPerPage.value +
+                        mangaEntries.size
+                ).toLong()
+            }
+        builder.icon = sourceNavEntry?.iconUrl
+        OpdsEntryBuilder.addSourceSortFacets(builder, "$baseUrl/source/$sourceId", sort, locale)
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getLibrarySourceFeed(
+        sourceId: Long,
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val (mangaEntries, total) = MangaRepository.getLibraryMangaBySource(sourceId, pageNum)
+        val sourceNavEntry = NavigationRepository.getLibrarySources(1).first.find { it.id == sourceId }
+        val sourceNameOrId = sourceNavEntry?.name ?: sourceId.toString()
+        val feedTitle = MR.strings.opds_feeds_library_source_specific_title.localized(locale, sourceNameOrId)
+
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "library/source/$sourceId",
+                feedTitle,
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.icon = sourceNavEntry?.iconUrl
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
@@ -192,33 +305,32 @@ object OpdsFeedBuilder {
         val (categoryNavEntries, total) = NavigationRepository.getCategories(pageNum)
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "categories",
-                title = MR.strings.opds_feeds_categories_title.localized(locale),
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-            ).apply {
-                totalResults = total
-                entries.addAll(
-                    categoryNavEntries.map { entry: OpdsCategoryNavEntry ->
-                        OpdsEntryXml(
-                            id = "urn:suwayomi:navigation:categories:${entry.id}",
-                            title = entry.name,
-                            updated = currentFormattedTime(),
-                            link =
-                                listOf(
-                                    OpdsLinkXml(
-                                        OpdsConstants.LINK_REL_SUBSECTION,
-                                        "$baseUrl/category/${entry.id}?lang=${locale.toLanguageTag()}",
-                                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                                        entry.name,
-                                    ),
-                                ),
-                        )
-                    },
+                baseUrl,
+                "library/categories",
+                MR.strings.opds_feeds_categories_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(
+            categoryNavEntries.map { entry ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:categories:${entry.id}",
+                    title = entry.name,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                OpdsConstants.LINK_REL_SUBSECTION,
+                                "$baseUrl/category/${entry.id}?lang=${locale.toLanguageTag()}",
+                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                                entry.name,
+                            ),
+                        ),
                 )
-            }
+            },
+        )
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
@@ -230,37 +342,35 @@ object OpdsFeedBuilder {
         val (genreNavEntries, total) = NavigationRepository.getGenres(pageNum, locale)
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "genres",
-                title = MR.strings.opds_feeds_genres_title.localized(locale),
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-            ).apply {
-                totalResults = total
-                entries.addAll(
-                    genreNavEntries.map { entry: OpdsGenreNavEntry ->
-                        OpdsEntryXml(
-                            id = "urn:suwayomi:navigation:genres:${entry.id}", // Already encoded
-                            title = entry.title,
-                            updated = currentFormattedTime(),
-                            link =
-                                listOf(
-                                    OpdsLinkXml(
-                                        OpdsConstants.LINK_REL_SUBSECTION,
-                                        "$baseUrl/genre/${entry.id}?lang=${locale.toLanguageTag()}",
-                                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                                        entry.title,
-                                    ),
-                                ),
-                        )
-                    },
+                baseUrl,
+                "library/genres",
+                MR.strings.opds_feeds_genres_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(
+            genreNavEntries.map { entry ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:genres:${entry.id}",
+                    title = entry.title,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                OpdsConstants.LINK_REL_SUBSECTION,
+                                "$baseUrl/genre/${entry.id}?lang=${locale.toLanguageTag()}",
+                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                                entry.title,
+                            ),
+                        ),
                 )
-            }
+            },
+        )
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
-    // `pageNum` is ignored, always fetches all, and sets pageNum = null in builder.
     fun getStatusFeed(
         baseUrl: String,
         @Suppress("UNUSED_PARAMETER") pageNum: Int,
@@ -269,33 +379,32 @@ object OpdsFeedBuilder {
         val statuses = NavigationRepository.getStatuses(locale)
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "status",
-                title = MR.strings.opds_feeds_status_title.localized(locale),
-                locale = locale,
-                pageNum = null, // Status feed is not paginated
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-            ).apply {
-                totalResults = statuses.size.toLong()
-                entries.addAll(
-                    statuses.map { entry: OpdsStatusNavEntry ->
-                        OpdsEntryXml(
-                            id = "urn:suwayomi:navigation:status:${entry.id}",
-                            title = entry.title,
-                            updated = currentFormattedTime(),
-                            link =
-                                listOf(
-                                    OpdsLinkXml(
-                                        OpdsConstants.LINK_REL_SUBSECTION,
-                                        "$baseUrl/status/${entry.id}?lang=${locale.toLanguageTag()}",
-                                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                                        entry.title,
-                                    ),
-                                ),
-                        )
-                    },
+                baseUrl,
+                "library/status",
+                MR.strings.opds_feeds_status_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                null,
+            )
+        builder.totalResults = statuses.size.toLong()
+        builder.entries.addAll(
+            statuses.map { entry ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:status:${entry.id}",
+                    title = entry.title,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                OpdsConstants.LINK_REL_SUBSECTION,
+                                "$baseUrl/status/${entry.id}?lang=${locale.toLanguageTag()}",
+                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                                entry.title,
+                            ),
+                        ),
                 )
-            }
+            },
+        )
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
@@ -306,37 +415,137 @@ object OpdsFeedBuilder {
         val languages = NavigationRepository.getContentLanguages(uiLocale)
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "languages",
-                title = MR.strings.opds_feeds_languages_title.localized(uiLocale),
-                locale = uiLocale,
-                pageNum = null, // Language feed is not paginated
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-            ).apply {
-                totalResults = languages.size.toLong()
-                entries.addAll(
-                    languages.map { entry: OpdsLanguageNavEntry ->
-                        OpdsEntryXml(
-                            id = "urn:suwayomi:navigation:language:${entry.id}",
-                            title = entry.title,
-                            updated = currentFormattedTime(),
-                            link =
-                                listOf(
-                                    OpdsLinkXml(
-                                        OpdsConstants.LINK_REL_SUBSECTION,
-                                        "$baseUrl/language/${entry.id}?lang=${uiLocale.toLanguageTag()}",
-                                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                                        entry.title,
-                                    ),
-                                ),
-                        )
-                    },
+                baseUrl,
+                "library/languages",
+                MR.strings.opds_feeds_languages_title.localized(uiLocale),
+                uiLocale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
+                null,
+            )
+        builder.totalResults = languages.size.toLong()
+        builder.entries.addAll(
+            languages.map { entry ->
+                OpdsEntryXml(
+                    id = "urn:suwayomi:navigation:language:${entry.id}",
+                    title = entry.title,
+                    updated = currentFormattedTime(),
+                    link =
+                        listOf(
+                            OpdsLinkXml(
+                                OpdsConstants.LINK_REL_SUBSECTION,
+                                "$baseUrl/language/${entry.id}?lang=${uiLocale.toLanguageTag()}",
+                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                                entry.title,
+                            ),
+                        ),
                 )
-            }
+            },
+        )
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
-    // --- Specific Acquisition Feed Generators ---
+    fun getLibraryUpdatesFeed(
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val (updateItems, total) = ChapterRepository.getLibraryUpdates(pageNum)
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "library-updates",
+                MR.strings.opds_feeds_library_updates_title.localized(locale),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(
+            updateItems.map { item ->
+                val mangaDetails = OpdsMangaDetails(item.mangaId, item.mangaTitle, item.mangaThumbnailUrl, item.mangaAuthor)
+                OpdsEntryBuilder.createChapterListEntry(item.chapter, mangaDetails, baseUrl, true, locale)
+            },
+        )
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getCategoryFeed(
+        categoryId: Int,
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val (mangaEntries, total) = MangaRepository.getMangaByCategory(categoryId, pageNum)
+        val categoryNavEntry = NavigationRepository.getCategories(1).first.find { it.id == categoryId }
+        val feedTitle = MR.strings.opds_feeds_category_specific_title.localized(locale, categoryNavEntry?.name ?: categoryId.toString())
+        val builder =
+            FeedBuilderInternal(baseUrl, "category/$categoryId", feedTitle, locale, OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION, pageNum)
+        builder.totalResults = total
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getGenreFeed(
+        genre: String,
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val (mangaEntries, total) = MangaRepository.getMangaByGenre(genre, pageNum)
+        val feedTitle = MR.strings.opds_feeds_genre_specific_title.localized(locale, genre)
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "genre/${genre.encodeForOpdsURL()}",
+                feedTitle,
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getStatusMangaFeed(
+        statusDbId: Long,
+        baseUrl: String,
+        pageNum: Int,
+        locale: Locale,
+    ): String {
+        val statusNavEntry = NavigationRepository.getStatuses(locale).find { it.id == statusDbId.toInt() }
+        val statusName = statusNavEntry?.title ?: statusDbId.toString()
+        val (mangaEntries, total) = MangaRepository.getMangaByStatus(statusDbId.toInt(), pageNum)
+        val feedTitle = MR.strings.opds_feeds_status_specific_title.localized(locale, statusName)
+        val builder =
+            FeedBuilderInternal(baseUrl, "status/$statusDbId", feedTitle, locale, OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION, pageNum)
+        builder.totalResults = total
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, locale) })
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
+
+    fun getLanguageFeed(
+        contentLangCode: String,
+        baseUrl: String,
+        pageNum: Int,
+        uiLocale: Locale,
+    ): String {
+        val (mangaEntries, total) = MangaRepository.getMangaByContentLanguage(contentLangCode, pageNum)
+        val contentLanguageDisplayName = Locale.forLanguageTag(contentLangCode).getDisplayName(uiLocale)
+        val feedTitle = MR.strings.opds_feeds_language_specific_title.localized(uiLocale, contentLanguageDisplayName)
+        val builder =
+            FeedBuilderInternal(
+                baseUrl,
+                "language/$contentLangCode",
+                feedTitle,
+                uiLocale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
+            )
+        builder.totalResults = total
+        builder.entries.addAll(mangaEntries.map { OpdsEntryBuilder.mangaAcqEntryToEntry(it, baseUrl, uiLocale) })
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
+    }
 
     fun getMangaFeed(
         mangaId: Int,
@@ -350,11 +559,10 @@ object OpdsFeedBuilder {
             MangaRepository.getMangaDetails(mangaId)
                 ?: return buildNotFoundFeed(
                     baseUrl,
-                    "manga/$mangaId",
+                    "manga/$mangaId/chapters",
                     MR.strings.opds_error_manga_not_found.localized(locale, mangaId),
                     locale,
                 )
-
         val (sortColumn, currentSortOrder) =
             when (sortParam?.lowercase()) {
                 "asc", "number_asc" -> ChapterTable.sourceOrder to SortOrder.ASC
@@ -364,7 +572,6 @@ object OpdsFeedBuilder {
                 else -> ChapterTable.sourceOrder to (serverConfig.opdsChapterSortOrder.value ?: SortOrder.ASC)
             }
         val currentFilter = filterParam?.lowercase() ?: if (serverConfig.opdsShowOnlyUnreadChapters.value) "unread" else "all"
-
         val (chapterEntries, totalChapters) =
             ChapterRepository.getChaptersForManga(
                 mangaId,
@@ -373,42 +580,41 @@ object OpdsFeedBuilder {
                 currentSortOrder,
                 currentFilter,
             )
-
         val actualSortParamForLinks =
             sortParam ?: run {
                 val prefix = if (sortColumn == ChapterTable.sourceOrder) "number" else "date"
                 val suffix = if (currentSortOrder == SortOrder.ASC) "asc" else "desc"
                 "${prefix}_$suffix"
             }
-
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "manga/$mangaId/chapters",
-                title = MR.strings.opds_feeds_manga_chapters.localized(locale, mangaDetails.title),
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                baseUrl,
+                "manga/$mangaId/chapters",
+                MR.strings.opds_feeds_manga_chapters.localized(locale, mangaDetails.title),
+                locale,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                pageNum,
                 currentSort = actualSortParamForLinks,
                 currentFilter = currentFilter,
-            ).apply {
-                totalResults = totalChapters
-                icon = mangaDetails.thumbnailUrl?.let { proxyThumbnailUrl(mangaDetails.id) }
-                icon?.let {
-                    links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE, it, OpdsConstants.TYPE_IMAGE_JPEG))
-                    links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE_THUMBNAIL, it, OpdsConstants.TYPE_IMAGE_JPEG))
-                }
-                addChapterSortAndFilterFacets(
-                    this,
-                    "$baseUrl/manga/$mangaId/chapters",
-                    actualSortParamForLinks,
-                    currentFilter,
-                    locale,
-                    sortColumn,
-                    currentSortOrder,
-                )
-                entries.addAll(chapterEntries.map { chapter -> createChapterListEntry(chapter, mangaDetails, baseUrl, false, locale) })
-            }
+            )
+        builder.totalResults = totalChapters
+        mangaDetails.thumbnailUrl?.let { proxyThumbnailUrl(mangaDetails.id) }?.also {
+            builder.icon = it
+            builder.links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE, it, OpdsConstants.TYPE_IMAGE_JPEG))
+            builder.links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE_THUMBNAIL, it, OpdsConstants.TYPE_IMAGE_JPEG))
+        }
+        OpdsEntryBuilder.addChapterSortAndFilterFacets(
+            builder,
+            "$baseUrl/manga/$mangaId/chapters",
+            actualSortParamForLinks,
+            currentFilter,
+            locale,
+        )
+        builder.entries.addAll(
+            chapterEntries.map { chapter ->
+                OpdsEntryBuilder.createChapterListEntry(chapter, mangaDetails, baseUrl, false, locale)
+            },
+        )
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
@@ -426,7 +632,6 @@ object OpdsFeedBuilder {
                     MR.strings.opds_error_manga_not_found.localized(locale, mangaId),
                     locale,
                 )
-
         val chapterMetadata =
             ChapterRepository.getChapterDetailsForMetadataFeed(mangaId, chapterSourceOrder)
                 ?: return buildNotFoundFeed(
@@ -435,453 +640,26 @@ object OpdsFeedBuilder {
                     MR.strings.opds_error_chapter_not_found.localized(locale, chapterSourceOrder),
                     locale,
                 )
-
         val builder =
             FeedBuilderInternal(
-                baseUrl = baseUrl,
-                idPath = "manga/$mangaId/chapter/${chapterMetadata.sourceOrder}/metadata",
-                title = MR.strings.opds_feeds_chapter_details.localized(locale, mangaDetails.title, chapterMetadata.name),
-                locale = locale,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                pageNum = null, // Metadata feed is single entry, not paginated
-            ).apply {
-                totalResults = 1
-                icon = mangaDetails.thumbnailUrl?.let { proxyThumbnailUrl(mangaDetails.id) }
-                icon?.let {
-                    links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE, it, OpdsConstants.TYPE_IMAGE_JPEG))
-                    links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE_THUMBNAIL, it, OpdsConstants.TYPE_IMAGE_JPEG))
-                }
-                entries.add(createChapterMetadataEntry(chapterMetadata, mangaDetails, locale))
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getSourceFeed(
-        sourceId: Long,
-        baseUrl: String,
-        pageNum: Int,
-        locale: Locale,
-    ): String {
-        val (mangaEntries, total) = MangaRepository.getMangaBySource(sourceId, pageNum)
-        val sourceNavEntry = NavigationRepository.getSources(1).first.find { it.id == sourceId }
-        val sourceNameOrId = sourceNavEntry?.name ?: sourceId.toString()
-        val feedTitle =
-            MR.strings.opds_feeds_source_specific_title.localized(
+                baseUrl,
+                "manga/$mangaId/chapter/${chapterMetadata.sourceOrder}/metadata",
+                MR.strings.opds_feeds_chapter_details.localized(locale, mangaDetails.title, chapterMetadata.name),
                 locale,
-                sourceNameOrId,
+                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+                null,
             )
-
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "source/$sourceId",
-                feedTitle,
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                icon = sourceNavEntry?.iconUrl
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, locale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getCategoryFeed(
-        categoryId: Int,
-        baseUrl: String,
-        pageNum: Int,
-        locale: Locale,
-    ): String {
-        val (mangaEntries, total) = MangaRepository.getMangaByCategory(categoryId, pageNum)
-        val categoryNavEntry = NavigationRepository.getCategories(1).first.find { it.id == categoryId }
-        val feedTitle = MR.strings.opds_feeds_category_specific_title.localized(locale, categoryNavEntry?.name ?: categoryId.toString())
-
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "category/$categoryId",
-                feedTitle,
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, locale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getGenreFeed(
-        genre: String,
-        baseUrl: String,
-        pageNum: Int,
-        locale: Locale,
-    ): String {
-        val (mangaEntries, total) = MangaRepository.getMangaByGenre(genre, pageNum)
-        val feedTitle = MR.strings.opds_feeds_genre_specific_title.localized(locale, genre)
-
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "genre/${genre.encodeForOpdsURL()}",
-                feedTitle,
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, locale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getStatusMangaFeed(
-        statusDbId: Long,
-        baseUrl: String,
-        pageNum: Int,
-        locale: Locale,
-    ): String {
-        val statusNavEntry = NavigationRepository.getStatuses(locale).find { it.id == statusDbId.toInt() }
-        val statusName = statusNavEntry?.title ?: statusDbId.toString()
-        val (mangaEntries, total) = MangaRepository.getMangaByStatus(statusDbId.toInt(), pageNum)
-        val feedTitle = MR.strings.opds_feeds_status_specific_title.localized(locale, statusName)
-
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "status/$statusDbId",
-                feedTitle,
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, locale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getLanguageFeed(
-        contentLangCode: String,
-        baseUrl: String,
-        pageNum: Int,
-        uiLocale: Locale,
-    ): String {
-        val (mangaEntries, total) = MangaRepository.getMangaByContentLanguage(contentLangCode, pageNum)
-        val contentLanguageDisplayName = Locale.forLanguageTag(contentLangCode).getDisplayName(uiLocale)
-        val feedTitle = MR.strings.opds_feeds_language_specific_title.localized(uiLocale, contentLanguageDisplayName)
-
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "language/$contentLangCode",
-                feedTitle,
-                locale = uiLocale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                entries.addAll(mangaEntries.map { mangaAcqEntryToEntry(it, baseUrl, uiLocale) })
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    fun getLibraryUpdatesFeed(
-        baseUrl: String,
-        pageNum: Int,
-        locale: Locale,
-    ): String {
-        val (updateItems, total) = ChapterRepository.getLibraryUpdates(pageNum)
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "library-updates",
-                MR.strings.opds_feeds_library_updates_title.localized(locale),
-                locale = locale,
-                pageNum = pageNum,
-                feedType = OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-            ).apply {
-                totalResults = total
-                entries.addAll(
-                    updateItems.map { item ->
-                        val mangaDetails = OpdsMangaDetails(item.mangaId, item.mangaTitle, item.mangaThumbnailUrl, item.mangaAuthor)
-                        createChapterListEntry(item.chapter, mangaDetails, baseUrl, true, locale)
-                    },
-                )
-            }
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
-    // --- Entry Creation Helpers ---
-
-    private fun mangaAcqEntryToEntry(
-        entry: OpdsMangaAcqEntry,
-        baseUrl: String,
-        locale: Locale,
-    ): OpdsEntryXml {
-        val displayThumbnailUrl = entry.thumbnailUrl?.let { proxyThumbnailUrl(entry.id) }
-        return OpdsEntryXml(
-            id = "urn:suwayomi:manga:${entry.id}",
-            title = entry.title,
-            updated = currentFormattedTime(),
-            authors = entry.author?.let { listOf(OpdsAuthorXml(name = it)) },
-            categories =
-                entry.genres.filter { it.isNotBlank() }.map { genre ->
-                    OpdsCategoryXml(
-                        term = genre.lowercase().replace(" ", "_"),
-                        label = genre,
-                        scheme = "$baseUrl/genres",
-                    )
-                },
-            summary = entry.description?.let { OpdsSummaryXml(value = it) },
-            link =
-                listOfNotNull(
-                    OpdsLinkXml(
-                        OpdsConstants.LINK_REL_SUBSECTION,
-                        "$baseUrl/manga/${entry.id}/chapters?lang=${locale.toLanguageTag()}",
-                        OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                        entry.title,
-                    ),
-                    displayThumbnailUrl?.let { OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE, it, OpdsConstants.TYPE_IMAGE_JPEG) },
-                    displayThumbnailUrl?.let { OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE_THUMBNAIL, it, OpdsConstants.TYPE_IMAGE_JPEG) },
-                ),
-            language = entry.sourceLang,
-        )
-    }
-
-    private fun createChapterListEntry(
-        chapter: OpdsChapterListAcqEntry,
-        manga: OpdsMangaDetails,
-        baseUrl: String,
-        addMangaTitle: Boolean,
-        locale: Locale,
-    ): OpdsEntryXml {
-        val statusKey =
-            when {
-                chapter.read -> MR.strings.opds_chapter_status_read
-                chapter.lastPageRead > 0 -> MR.strings.opds_chapter_status_in_progress
-                else -> MR.strings.opds_chapter_status_unread
-            }
-        val titlePrefix = statusKey.localized(locale)
-        val entryTitle = titlePrefix + (if (addMangaTitle) " ${manga.title}:" else "") + " ${chapter.name}"
-
-        val details =
-            buildString {
-                append(MR.strings.opds_chapter_details_base.localized(locale, manga.title, chapter.name))
-                chapter.scanlator?.takeIf { it.isNotBlank() }?.let {
-                    append(
-                        MR.strings.opds_chapter_details_scanlator.localized(locale, it),
-                    )
-                }
-                if (chapter.pageCount > 0) {
-                    append(
-                        MR.strings.opds_chapter_details_progress.localized(
-                            locale,
-                            chapter.lastPageRead,
-                            chapter.pageCount,
-                        ),
-                    )
-                }
-            }
-
-        return OpdsEntryXml(
-            id = "urn:suwayomi:chapter:${chapter.id}",
-            title = entryTitle,
-            updated = OpdsDateUtil.formatEpochMillisForOpds(chapter.uploadDate),
-            authors =
-                listOfNotNull(
-                    manga.author?.let { OpdsAuthorXml(name = it) },
-                    chapter.scanlator?.takeIf { it.isNotBlank() }?.let { OpdsAuthorXml(name = it) },
-                ),
-            summary = OpdsSummaryXml(value = details),
-            link =
-                listOf(
-                    OpdsLinkXml(
-                        rel = OpdsConstants.LINK_REL_SUBSECTION,
-                        href = "$baseUrl/manga/${manga.id}/chapter/${chapter.sourceOrder}/metadata?lang=${locale.toLanguageTag()}",
-                        type = OpdsConstants.TYPE_ATOM_XML_ENTRY_PROFILE_OPDS,
-                        title = MR.strings.opds_linktitle_view_chapter_details.localized(locale),
-                    ),
-                ),
-        )
-    }
-
-    private suspend fun createChapterMetadataEntry(
-        chapter: OpdsChapterMetadataAcqEntry,
-        manga: OpdsMangaDetails,
-        locale: Locale,
-    ): OpdsEntryXml {
-        val statusKey =
-            when {
-                chapter.downloaded -> MR.strings.opds_chapter_status_downloaded
-                chapter.read -> MR.strings.opds_chapter_status_read
-                chapter.lastPageRead > 0 -> MR.strings.opds_chapter_status_in_progress
-                else -> MR.strings.opds_chapter_status_unread
-            }
-        val titlePrefix = statusKey.localized(locale)
-        val entryTitle = "$titlePrefix ${chapter.name}"
-
-        val details =
-            buildString {
-                append(MR.strings.opds_chapter_details_base.localized(locale, manga.title, chapter.name))
-                chapter.scanlator?.takeIf { it.isNotBlank() }?.let {
-                    append(
-                        MR.strings.opds_chapter_details_scanlator.localized(locale, it),
-                    )
-                }
-                val pageCountDisplay = chapter.pageCount.takeIf { it > 0 } ?: "?"
-                append(
-                    MR.strings.opds_chapter_details_progress.localized(
-                        locale,
-                        chapter.lastPageRead,
-                        pageCountDisplay,
-                    ),
-                )
-            }
-
-        val links = mutableListOf<OpdsLinkXml>()
-        var cbzFileSize: Long? = null
-
-        if (chapter.downloaded) {
-            val cbzStreamPair =
-                withContext(
-                    Dispatchers.IO,
-                ) { runCatching { ChapterDownloadHelper.getArchiveStreamWithSize(manga.id, chapter.id) }.getOrNull() }
-            cbzFileSize = cbzStreamPair?.second
-            cbzStreamPair?.let {
-                links.add(
-                    OpdsLinkXml(
-                        OpdsConstants.LINK_REL_ACQUISITION_OPEN_ACCESS,
-                        "/api/v1/chapter/${chapter.id}/download?markAsRead=${serverConfig.opdsMarkAsReadOnDownload.value}",
-                        OpdsConstants.TYPE_CBZ,
-                        MR.strings.opds_linktitle_download_cbz.localized(locale),
-                    ),
-                )
-            }
+        builder.totalResults = 1
+        mangaDetails.thumbnailUrl?.let { proxyThumbnailUrl(mangaDetails.id) }?.also {
+            builder.icon = it
+            builder.links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE, it, OpdsConstants.TYPE_IMAGE_JPEG))
+            builder.links.add(OpdsLinkXml(OpdsConstants.LINK_REL_IMAGE_THUMBNAIL, it, OpdsConstants.TYPE_IMAGE_JPEG))
         }
-
-        if (chapter.pageCount > 0) {
-            links.add(
-                OpdsLinkXml(
-                    OpdsConstants.LINK_REL_PSE_STREAM,
-                    "/api/v1/manga/${manga.id}/chapter/${chapter.sourceOrder}/page/{pageNumber}?updateProgress=${serverConfig.opdsEnablePageReadProgress.value}",
-                    OpdsConstants.TYPE_IMAGE_JPEG,
-                    MR.strings.opds_linktitle_stream_pages.localized(locale),
-                    pseCount = chapter.pageCount,
-                    pseLastRead =
-                        chapter.lastPageRead.takeIf {
-                            it > 0
-                        },
-                    pseLastReadDate = chapter.lastReadAt.takeIf { it > 0 }?.let { OpdsDateUtil.formatEpochMillisForOpds(it * 1000) },
-                ),
-            )
-            links.add(
-                OpdsLinkXml(
-                    OpdsConstants.LINK_REL_IMAGE,
-                    "/api/v1/manga/${manga.id}/chapter/${chapter.sourceOrder}/page/0",
-                    OpdsConstants.TYPE_IMAGE_JPEG,
-                    MR.strings.opds_linktitle_chapter_cover.localized(locale),
-                ),
-            )
-        }
-
-        return OpdsEntryXml(
-            id = "urn:suwayomi:chapter:${chapter.id}:metadata",
-            title = entryTitle,
-            updated = OpdsDateUtil.formatEpochMillisForOpds(chapter.uploadDate),
-            authors =
-                listOfNotNull(
-                    manga.author?.let { OpdsAuthorXml(name = it) },
-                    chapter.scanlator?.takeIf { it.isNotBlank() }?.let { OpdsAuthorXml(name = it) },
-                ),
-            summary = OpdsSummaryXml(value = details),
-            link = links,
-            extent = cbzFileSize?.let { formatFileSizeForOpds(it) },
-            format = if (cbzFileSize != null) "CBZ" else null,
-        )
+        builder.entries.add(OpdsEntryBuilder.createChapterMetadataEntry(chapterMetadata, mangaDetails, baseUrl, locale))
+        return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
-    // --- Helpers & Internal Builder ---
-
-    private fun addChapterSortAndFilterFacets(
-        feedBuilder: FeedBuilderInternal,
-        baseMangaUrl: String,
-        currentSort: String,
-        currentFilter: String,
-        locale: Locale,
-        sortColumn: org.jetbrains.exposed.sql.Column<*>,
-        currentSortOrder: SortOrder,
-    ) {
-        val sortGroup = MR.strings.opds_facetgroup_sort_order.localized(locale)
-        val filterGroup = MR.strings.opds_facetgroup_read_status.localized(locale)
-
-        val addFacet = { rel: String, href: String, titleKey: StringResource, group: String, isActive: Boolean ->
-            feedBuilder.links.add(
-                OpdsLinkXml(
-                    rel,
-                    href,
-                    OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                    titleKey.localized(locale),
-                    facetGroup = group,
-                    activeFacet = isActive,
-                ),
-            )
-        }
-
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?sort=number_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_sort_oldest_first,
-            sortGroup,
-            sortColumn == ChapterTable.sourceOrder && currentSortOrder == SortOrder.ASC,
-        )
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?sort=number_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_sort_newest_first,
-            sortGroup,
-            sortColumn == ChapterTable.sourceOrder && currentSortOrder == SortOrder.DESC,
-        )
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?sort=date_asc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_sort_date_asc,
-            sortGroup,
-            sortColumn == ChapterTable.date_upload && currentSortOrder == SortOrder.ASC,
-        )
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?sort=date_desc&filter=$currentFilter&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_sort_date_desc,
-            sortGroup,
-            sortColumn == ChapterTable.date_upload && currentSortOrder == SortOrder.DESC,
-        )
-
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?filter=all&sort=$currentSort&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_filter_all_chapters,
-            filterGroup,
-            currentFilter == "all",
-        )
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?filter=unread&sort=$currentSort&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_filter_unread_only,
-            filterGroup,
-            currentFilter == "unread",
-        )
-        addFacet(
-            OpdsConstants.LINK_REL_FACET,
-            "$baseMangaUrl?filter=read&sort=$currentSort&lang=${locale.toLanguageTag()}",
-            MR.strings.opds_facet_filter_read_only,
-            filterGroup,
-            currentFilter == "read",
-        )
-    }
-
-    private fun buildNotFoundFeed(
+    fun buildNotFoundFeed(
         baseUrl: String,
         idPath: String,
         title: String,
@@ -891,127 +669,4 @@ object OpdsFeedBuilder {
             .apply { totalResults = 0L }
             .build()
             .let(OpdsXmlUtil::serializeFeedToString)
-
-    private class FeedBuilderInternal(
-        val baseUrl: String,
-        val idPath: String,
-        val title: String,
-        val locale: Locale,
-        val feedType: String,
-        var pageNum: Int? = 1, // Nullable, default to 1 if needed, null means no pagination
-        var explicitQueryParams: String? = null,
-        val currentSort: String? = null,
-        val currentFilter: String? = null,
-    ) {
-        val feedGeneratedAt: String = currentFormattedTime()
-        var totalResults: Long = 0
-        var icon: String? = null
-        val links = mutableListOf<OpdsLinkXml>()
-        val entries = mutableListOf<OpdsEntryXml>()
-
-        private fun buildUrlWithParams(
-            baseHrefPath: String,
-            page: Int?,
-        ): String {
-            val sb = StringBuilder("$baseUrl/$baseHrefPath")
-            val queryParamsList = mutableListOf<String>()
-
-            explicitQueryParams?.takeIf { it.isNotBlank() }?.let {
-                queryParamsList.add(it)
-            }
-            // Only add pageNumber if pagination is active (pageNum is not null)
-            page?.let {
-                queryParamsList.add("pageNumber=$it")
-            }
-
-            currentSort?.let { queryParamsList.add("sort=$it") }
-            currentFilter?.let { queryParamsList.add("filter=$it") }
-            queryParamsList.add("lang=${locale.toLanguageTag()}")
-
-            if (queryParamsList.isNotEmpty()) {
-                sb.append("?").append(queryParamsList.joinToString("&"))
-            }
-            return sb.toString()
-        }
-
-        fun build(): OpdsFeedXml {
-            val actualPageNum = pageNum ?: 1
-            // val needsPagination = pageNum != null && totalResults > opdsItemsPerPageBounded
-
-            val selfLinkHref = buildUrlWithParams(idPath, if (pageNum != null) actualPageNum else null)
-            val feedLinks = mutableListOf<OpdsLinkXml>()
-            feedLinks.addAll(this.links)
-
-            feedLinks.add(
-                OpdsLinkXml(
-                    OpdsConstants.LINK_REL_SELF,
-                    selfLinkHref,
-                    feedType,
-                    MR.strings.opds_linktitle_self_feed.localized(locale),
-                ),
-            )
-            feedLinks.add(
-                OpdsLinkXml(
-                    OpdsConstants.LINK_REL_START,
-                    "$baseUrl?lang=${locale.toLanguageTag()}",
-                    OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-                    MR.strings.opds_linktitle_catalog_root.localized(locale),
-                ),
-            )
-            feedLinks.add(
-                OpdsLinkXml(
-                    OpdsConstants.LINK_REL_SEARCH,
-                    "$baseUrl/search?lang=${locale.toLanguageTag()}",
-                    OpdsConstants.TYPE_OPENSEARCH_DESCRIPTION,
-                    MR.strings.opds_linktitle_search_catalog.localized(locale),
-                ),
-            )
-
-            if (pageNum != null) { // Only add pagination links if pageNum was provided (meaning it's paginatable)
-                if (actualPageNum > 1) {
-                    feedLinks.add(
-                        OpdsLinkXml(
-                            OpdsConstants.LINK_REL_PREV,
-                            buildUrlWithParams(idPath, actualPageNum - 1),
-                            feedType,
-                            MR.strings.opds_linktitle_previous_page.localized(locale),
-                        ),
-                    )
-                }
-                if (totalResults > actualPageNum * opdsItemsPerPageBounded) {
-                    feedLinks.add(
-                        OpdsLinkXml(
-                            OpdsConstants.LINK_REL_NEXT,
-                            buildUrlWithParams(idPath, actualPageNum + 1),
-                            feedType,
-                            MR.strings.opds_linktitle_next_page.localized(locale),
-                        ),
-                    )
-                }
-            }
-
-            val urnParams = mutableListOf<String>()
-            urnParams.add(locale.toLanguageTag())
-            pageNum?.let { urnParams.add("page$it") }
-            explicitQueryParams?.let { urnParams.add(it.replace("&", ":").replace("=", "_")) }
-            currentSort?.let { urnParams.add("sort_$it") }
-            currentFilter?.let { urnParams.add("filter_$it") }
-            val urnSuffix = if (urnParams.isNotEmpty()) ":${urnParams.joinToString(":")}" else ""
-
-            val showPaginationFields = pageNum != null && totalResults > 0
-
-            return OpdsFeedXml(
-                id = "urn:suwayomi:feed:${idPath.replace('/',':')}$urnSuffix",
-                title = title,
-                updated = feedGeneratedAt,
-                icon = icon,
-                author = feedAuthor,
-                links = feedLinks,
-                entries = entries,
-                totalResults = totalResults.takeIf { showPaginationFields },
-                itemsPerPage = if (showPaginationFields) opdsItemsPerPageBounded else null,
-                startIndex = if (showPaginationFields) ((actualPageNum - 1) * opdsItemsPerPageBounded + 1) else null,
-            )
-        }
-    }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
@@ -59,43 +59,6 @@ object OpdsFeedBuilder {
         return OpdsXmlUtil.serializeFeedToString(builder.build())
     }
 
-    fun getLibraryFeed(
-        baseUrl: String,
-        locale: Locale,
-    ): String {
-        val navItems = NavigationRepository.getLibraryNavigationItems(locale)
-        val builder =
-            FeedBuilderInternal(
-                baseUrl,
-                "library",
-                MR.strings.opds_feeds_library_title.localized(locale),
-                locale,
-                OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-                null,
-            )
-        builder.totalResults = navItems.size.toLong()
-        builder.entries.addAll(
-            navItems.map { item ->
-                OpdsEntryXml(
-                    id = "urn:suwayomi:navigation:library:${item.id}",
-                    title = item.title,
-                    updated = currentFormattedTime(),
-                    link =
-                        listOf(
-                            OpdsLinkXml(
-                                rel = OpdsConstants.LINK_REL_SUBSECTION,
-                                href = "$baseUrl/library/${item.id}?lang=${locale.toLanguageTag()}",
-                                type = item.linkType,
-                                title = item.title,
-                            ),
-                        ),
-                    content = OpdsContentXml(type = "text", value = item.description),
-                )
-            },
-        )
-        return OpdsXmlUtil.serializeFeedToString(builder.build())
-    }
-
     fun getHistoryFeed(
         baseUrl: String,
         pageNum: Int,

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsFeedBuilder.kt
@@ -155,10 +155,16 @@ object OpdsFeedBuilder {
                         listOf(
                             OpdsLinkXml(
                                 OpdsConstants.LINK_REL_SUBSECTION,
-                                "$baseUrl/source/${entry.id}?lang=${locale.toLanguageTag()}",
+                                "$baseUrl/source/${entry.id}?sort=popular&lang=${locale.toLanguageTag()}",
                                 OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
-                                entry.name,
+//                                MR.strings.opds_facet_sort_popular.localized(locale),
                             ),
+//                            OpdsLinkXml(
+//                                OpdsConstants.LINK_REL_SORT_NEW,
+//                                "$baseUrl/source/${entry.id}?sort=latest&lang=${locale.toLanguageTag()}",
+//                                OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
+//                                MR.strings.opds_facet_sort_latest.localized(locale),
+//                            ),
                         ),
                 )
             },

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
@@ -94,6 +94,7 @@ object ChapterRepository {
                 sourceOrder = chapterDataClass.index,
                 downloaded = chapterDataClass.downloaded,
                 pageCount = chapterDataClass.pageCount,
+                url = chapterDataClass.realUrl,
             )
         } catch (e: Exception) {
             null

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
@@ -34,6 +34,7 @@ object ChapterRepository {
             scanlator = this[ChapterTable.scanlator],
             read = this[ChapterTable.isRead],
             lastPageRead = this[ChapterTable.lastPageRead],
+            lastReadAt = this[ChapterTable.lastReadAt],
             sourceOrder = this[ChapterTable.sourceOrder],
             pageCount = this[ChapterTable.pageCount],
         )

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.manga.impl.chapter.getChapterDownloadReady
 import suwayomi.tachidesk.manga.model.table.ChapterTable
@@ -158,5 +159,19 @@ object ChapterRepository {
                         )
                     }
             Pair(items, totalCount)
+        }
+
+    fun getChapterFilterCounts(mangaId: Int): Map<String, Long> =
+        transaction {
+            val baseQuery = ChapterTable.select(ChapterTable.id).where { ChapterTable.manga eq mangaId }
+            val readCount = baseQuery.copy().andWhere { ChapterTable.isRead eq true }.count()
+            val unreadCount = baseQuery.copy().andWhere { ChapterTable.isRead eq false }.count()
+            val allCount = baseQuery.copy().count()
+
+            mapOf(
+                "read" to readCount,
+                "unread" to unreadCount,
+                "all" to allCount,
+            )
         }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/ChapterRepository.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.transactions.transaction
 import suwayomi.tachidesk.manga.impl.chapter.getChapterDownloadReady
@@ -14,6 +15,7 @@ import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.SourceTable
 import suwayomi.tachidesk.opds.dto.OpdsChapterListAcqEntry
 import suwayomi.tachidesk.opds.dto.OpdsChapterMetadataAcqEntry
+import suwayomi.tachidesk.opds.dto.OpdsHistoryAcqEntry
 import suwayomi.tachidesk.opds.dto.OpdsLibraryUpdateAcqEntry
 import suwayomi.tachidesk.server.serverConfig
 
@@ -49,7 +51,6 @@ object ChapterRepository {
             when (filter) {
                 "unread" -> conditions.add(ChapterTable.isRead eq false)
                 "read" -> conditions.add(ChapterTable.isRead eq true)
-                // "all" -> no additional condition
             }
             if (serverConfig.opdsShowOnlyDownloadedChapters.value) {
                 conditions.add(ChapterTable.isDownloaded eq true)
@@ -117,7 +118,38 @@ object ChapterRepository {
                     .offset(((pageNum - 1) * opdsItemsPerPageBounded).toLong())
                     .map {
                         OpdsLibraryUpdateAcqEntry(
-                            chapter = it.toOpdsChapterListAcqEntry(), // This will work if ChapterTable columns do not collide
+                            chapter = it.toOpdsChapterListAcqEntry(),
+                            mangaTitle = it[MangaTable.title],
+                            mangaAuthor = it[MangaTable.author],
+                            mangaId = it[MangaTable.id].value,
+                            mangaSourceLang = it[SourceTable.lang],
+                            mangaThumbnailUrl = it[MangaTable.thumbnail_url],
+                        )
+                    }
+            Pair(items, totalCount)
+        }
+
+    fun getHistory(pageNum: Int): Pair<List<OpdsHistoryAcqEntry>, Long> =
+        transaction {
+            val query =
+                ChapterTable
+                    .join(MangaTable, JoinType.INNER, ChapterTable.manga, MangaTable.id)
+                    .join(SourceTable, JoinType.INNER, MangaTable.sourceReference, SourceTable.id)
+                    .select(
+                        ChapterTable.columns + MangaTable.title + MangaTable.author + MangaTable.thumbnail_url + MangaTable.id +
+                            SourceTable.lang,
+                    ).where { ChapterTable.lastReadAt greater 0L }
+
+            val totalCount = query.count()
+
+            val items =
+                query
+                    .orderBy(ChapterTable.lastReadAt to SortOrder.DESC)
+                    .limit(opdsItemsPerPageBounded)
+                    .offset(((pageNum - 1) * opdsItemsPerPageBounded).toLong())
+                    .map {
+                        OpdsHistoryAcqEntry(
+                            chapter = it.toOpdsChapterListAcqEntry(),
                             mangaTitle = it[MangaTable.title],
                             mangaAuthor = it[MangaTable.author],
                             mangaId = it[MangaTable.id].value,

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/MangaRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/MangaRepository.kt
@@ -22,21 +22,29 @@ import suwayomi.tachidesk.manga.impl.MangaList.insertOrUpdate
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource
 import suwayomi.tachidesk.manga.model.dataclass.toGenreList
 import suwayomi.tachidesk.manga.model.table.CategoryMangaTable
+import suwayomi.tachidesk.manga.model.table.CategoryTable
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.SourceTable
+import suwayomi.tachidesk.opds.dto.OpdsLibraryFeedResult
 import suwayomi.tachidesk.opds.dto.OpdsMangaAcqEntry
 import suwayomi.tachidesk.opds.dto.OpdsMangaDetails
+import suwayomi.tachidesk.opds.dto.OpdsMangaFilter
 import suwayomi.tachidesk.opds.dto.OpdsSearchCriteria
+import suwayomi.tachidesk.opds.dto.PrimaryFilterType
 import suwayomi.tachidesk.server.serverConfig
 
+/**
+ * Repository for fetching manga data tailored for OPDS feeds.
+ */
 object MangaRepository {
     private val opdsItemsPerPageBounded: Int
         get() = serverConfig.opdsItemsPerPage.value.coerceIn(10, 5000)
 
     /**
-     * Mapper for OPDS entries. Always includes all available fields from joined tables.
+     * Maps a database [ResultRow] to an [OpdsMangaAcqEntry] data transfer object.
+     * @return The mapped [OpdsMangaAcqEntry].
      */
     private fun ResultRow.toOpdsMangaAcqEntry(): OpdsMangaAcqEntry =
         OpdsMangaAcqEntry(
@@ -55,25 +63,72 @@ object MangaRepository {
         )
 
     /**
-     * Main dispatcher for all library manga queries.
+     * Centralized function to retrieve paginated, sorted, and filtered manga from the library.
+     * @param pageNum The page number for pagination.
+     * @param sort The sorting parameter.
+     * @param filter The filtering parameter.
+     * @param criteria Additional filtering criteria for categories, sources, etc.
+     * @return An [OpdsLibraryFeedResult] containing the list of manga, total count, and the specific filter name.
      */
-    private fun getLibraryManga(
+    fun getLibraryManga(
         pageNum: Int,
         sort: String?,
         filter: String?,
-        baseCondition: Op<Boolean> = Op.TRUE,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> =
+        criteria: OpdsMangaFilter,
+    ): OpdsLibraryFeedResult =
         transaction {
             val unreadCountExpr = Case().When(ChapterTable.isRead eq false, intLiteral(1)).Else(intLiteral(0)).sum()
             val unreadCount = unreadCountExpr.alias("unread_count")
 
+            // Base query with necessary joins for filtering and sorting
             val query =
                 MangaTable
                     .join(SourceTable, JoinType.INNER, MangaTable.sourceReference, SourceTable.id)
                     .join(ChapterTable, JoinType.LEFT, MangaTable.id, ChapterTable.manga)
+                    .join(CategoryMangaTable, JoinType.LEFT, MangaTable.id, CategoryMangaTable.manga)
                     .select(MangaTable.columns + SourceTable.lang + SourceTable.name + unreadCount)
-                    .where { (MangaTable.inLibrary eq true) and baseCondition }
+                    .where { MangaTable.inLibrary eq true }
                     .groupBy(MangaTable.id, SourceTable.lang, SourceTable.name)
+
+            // Apply specific filters from criteria
+            criteria.sourceId?.let { query.andWhere { MangaTable.sourceReference eq it } }
+            criteria.categoryId?.let { query.andWhere { CategoryMangaTable.category eq it } }
+            criteria.statusId?.let { query.andWhere { MangaTable.status eq it } }
+            criteria.langCode?.let { query.andWhere { SourceTable.lang eq it } }
+            criteria.genre?.let { genre ->
+                val genreTrimmed = genre.trim()
+                val genreCondition =
+                    (MangaTable.genre like "%, $genreTrimmed, %") or
+                        (MangaTable.genre like "$genreTrimmed, %") or
+                        (MangaTable.genre like "%, $genreTrimmed") or
+                        (MangaTable.genre eq genreTrimmed)
+                query.andWhere { genreCondition }
+            }
+
+            // Efficiently get the name of the primary filter item
+            val specificFilterName =
+                when (criteria.primaryFilter) {
+                    PrimaryFilterType.SOURCE ->
+                        criteria.sourceId?.let {
+                            SourceTable
+                                .select(SourceTable.name)
+                                .where { SourceTable.id eq it }
+                                .firstOrNull()
+                                ?.get(SourceTable.name)
+                        }
+                    PrimaryFilterType.CATEGORY ->
+                        criteria.categoryId?.let {
+                            CategoryTable
+                                .select(CategoryTable.name)
+                                .where { CategoryTable.id eq it }
+                                .firstOrNull()
+                                ?.get(CategoryTable.name)
+                        }
+                    PrimaryFilterType.GENRE -> criteria.genre
+                    PrimaryFilterType.STATUS -> criteria.statusId.toString() // Controller will map this to a localized string
+                    PrimaryFilterType.LANGUAGE -> criteria.langCode // Controller will map this to a display name
+                    else -> null
+                }
 
             applyMangaLibrarySortAndFilter(query, sort, filter)
 
@@ -83,101 +138,16 @@ object MangaRepository {
                     .limit(opdsItemsPerPageBounded)
                     .offset(((pageNum - 1) * opdsItemsPerPageBounded).toLong())
                     .map { it.toOpdsMangaAcqEntry() }
-            Pair(mangas, totalCount)
+
+            OpdsLibraryFeedResult(mangas, totalCount, specificFilterName)
         }
 
     /**
-     * Gets all manga from the user's library with optional sorting and filtering.
-     */
-    fun getAllManga(
-        pageNum: Int,
-        sort: String?,
-        filter: String?,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> = getLibraryManga(pageNum, sort, filter)
-
-    /**
-     * Gets library manga from a specific source with optional sorting and filtering.
-     */
-    fun getLibraryMangaBySource(
-        sourceId: Long,
-        pageNum: Int,
-        sort: String?,
-        filter: String?,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> = getLibraryManga(pageNum, sort, filter, MangaTable.sourceReference eq sourceId)
-
-    /**
-     * Gets manga from a specific category with optional sorting and filtering.
-     */
-    fun getMangaByCategory(
-        categoryId: Int,
-        pageNum: Int,
-        sort: String?,
-        filter: String?,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> =
-        transaction {
-            val unreadCountExpr = Case().When(ChapterTable.isRead eq false, intLiteral(1)).Else(intLiteral(0)).sum()
-            val unreadCount = unreadCountExpr.alias("unread_count")
-
-            val query =
-                MangaTable
-                    .join(CategoryMangaTable, JoinType.INNER, MangaTable.id, CategoryMangaTable.manga)
-                    .join(SourceTable, JoinType.INNER, MangaTable.sourceReference, SourceTable.id)
-                    .join(ChapterTable, JoinType.LEFT, MangaTable.id, ChapterTable.manga)
-                    .select(MangaTable.columns + SourceTable.lang + SourceTable.name + unreadCount)
-                    .where { (CategoryMangaTable.category eq categoryId) and (MangaTable.inLibrary eq true) }
-                    .groupBy(MangaTable.id, SourceTable.lang, SourceTable.name)
-
-            applyMangaLibrarySortAndFilter(query, sort, filter)
-
-            val totalCount = query.count()
-            val mangas =
-                query
-                    .limit(opdsItemsPerPageBounded)
-                    .offset(((pageNum - 1) * opdsItemsPerPageBounded).toLong())
-                    .map { it.toOpdsMangaAcqEntry() }
-            Pair(mangas, totalCount)
-        }
-
-    /**
-     * Gets manga filtered by genre with optional sorting and filtering.
-     */
-    fun getMangaByGenre(
-        genre: String,
-        pageNum: Int,
-        sort: String?,
-        filter: String?,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> {
-        val genreTrimmed = genre.trim()
-        val genreCondition =
-            (MangaTable.genre like "%, $genreTrimmed, %") or
-                (MangaTable.genre like "$genreTrimmed, %") or
-                (MangaTable.genre like "%, $genreTrimmed") or
-                (MangaTable.genre eq genreTrimmed)
-        return getLibraryManga(pageNum, sort, filter, genreCondition)
-    }
-
-    /**
-     * Gets manga filtered by publication status with optional sorting and filtering.
-     */
-    fun getMangaByStatus(
-        statusId: Int,
-        pageNum: Int,
-        sort: String?,
-        filter: String?,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> = getLibraryManga(pageNum, sort, filter, MangaTable.status eq statusId)
-
-    /**
-     * Gets manga filtered by source language with optional sorting and filtering.
-     */
-    fun getMangaByContentLanguage(
-        langCode: String,
-        pageNum: Int,
-        sort: String?,
-        filter: String?,
-    ): Pair<List<OpdsMangaAcqEntry>, Long> = getLibraryManga(pageNum, sort, filter, SourceTable.lang eq langCode)
-
-    /**
-     * Gets manga from a specific source with pagination and sorting.
+     * Fetches a paginated list of manga from a specific source (for exploration).
+     * @param sourceId The ID of the source.
+     * @param pageNum The page number for pagination.
+     * @param sort The sorting parameter ('popular' or 'latest').
+     * @return A pair containing the list of [OpdsMangaAcqEntry] and a boolean indicating if there's a next page.
      */
     suspend fun getMangaBySource(
         sourceId: Long,
@@ -206,7 +176,9 @@ object MangaRepository {
     }
 
     /**
-     * Finds manga based on search criteria (title, author, genre).
+     * Finds manga in the library based on search criteria (query, author, title).
+     * @param criteria The search criteria.
+     * @return A pair containing the list of matching [OpdsMangaAcqEntry] and the total count.
      */
     fun findMangaByCriteria(criteria: OpdsSearchCriteria): Pair<List<OpdsMangaAcqEntry>, Long> =
         transaction {
@@ -247,7 +219,9 @@ object MangaRepository {
         }
 
     /**
-     * Gets basic manga details for OPDS metadata.
+     * Retrieves basic details for a single manga, used for populating chapter feed metadata.
+     * @param mangaId The ID of the manga.
+     * @return An [OpdsMangaDetails] object or null if not found.
      */
     fun getMangaDetails(mangaId: Int): OpdsMangaDetails? =
         transaction {
@@ -266,7 +240,10 @@ object MangaRepository {
         }
 
     /**
-     * Applies sorting and filtering to manga library queries.
+     * Applies sorting and filtering logic to a manga library query.
+     * @param query The Exposed SQL query to modify.
+     * @param sort The sorting parameter.
+     * @param filter The filtering parameter.
      */
     private fun applyMangaLibrarySortAndFilter(
         query: Query,
@@ -278,7 +255,7 @@ object MangaRepository {
         val lastReadAtExpr = ChapterTable.lastReadAt.max()
         val latestChapterDateExpr = ChapterTable.date_upload.max()
 
-        // Apply filtering using HAVING clause for aggregate functions
+        // Apply filtering using HAVING for aggregate functions or WHERE for direct columns
         when (filter) {
             "unread" -> query.having { unreadCountExpr greater 0 }
             "downloaded" -> query.having { downloadedCountExpr greater 0 }
@@ -299,7 +276,8 @@ object MangaRepository {
     }
 
     /**
-     * Gets counts for different library filters (unread, downloaded, ongoing, completed).
+     * Calculates the count of manga for various library filter facets.
+     * @return A map where keys are filter names and values are the counts.
      */
     fun getLibraryFilterCounts(): Map<String, Long> =
         transaction {

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/NavigationRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/NavigationRepository.kt
@@ -58,7 +58,7 @@ object NavigationRepository {
 
     val librarySectionDetails: Map<String, Triple<String, StringResource, StringResource>> =
         mapOf(
-            "mangas" to
+            "series" to
                 Triple(
                     OpdsConstants.TYPE_ATOM_XML_FEED_ACQUISITION,
                     MR.strings.opds_feeds_all_series_in_library_title,

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/NavigationRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/NavigationRepository.kt
@@ -32,12 +32,6 @@ object NavigationRepository {
 
     private val rootSectionDetails: Map<String, Triple<String, StringResource, StringResource>> =
         mapOf(
-            "library" to
-                Triple(
-                    OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
-                    MR.strings.opds_feeds_library_title,
-                    MR.strings.opds_feeds_library_entry_content,
-                ),
             "explore" to
                 Triple(
                     OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
@@ -98,16 +92,31 @@ object NavigationRepository {
                 ),
         )
 
-    fun getRootNavigationItems(locale: Locale): List<OpdsRootNavEntry> =
-        rootSectionDetails.map { (id, details) ->
-            val (linkType, titleRes, descriptionRes) = details
-            OpdsRootNavEntry(
-                id = id,
-                title = titleRes.localized(locale),
-                description = descriptionRes.localized(locale),
-                linkType = linkType,
-            )
-        }
+    fun getRootNavigationItems(locale: Locale): List<OpdsRootNavEntry> {
+        val libraryItems =
+            librarySectionDetails.map { (id, details) ->
+                val (linkType, titleRes, descriptionRes) = details
+                OpdsRootNavEntry(
+                    id = "library/$id",
+                    title = titleRes.localized(locale),
+                    description = descriptionRes.localized(locale),
+                    linkType = linkType,
+                )
+            }
+
+        val otherRootItems =
+            rootSectionDetails.map { (id, details) ->
+                val (linkType, titleRes, descriptionRes) = details
+                OpdsRootNavEntry(
+                    id = id,
+                    title = titleRes.localized(locale),
+                    description = descriptionRes.localized(locale),
+                    linkType = linkType,
+                )
+            }
+
+        return libraryItems + otherRootItems
+    }
 
     fun getLibraryNavigationItems(locale: Locale): List<OpdsRootNavEntry> =
         librarySectionDetails.map { (id, details) ->
@@ -120,6 +129,7 @@ object NavigationRepository {
             )
         }
 
+    // ... (El resto del archivo permanece sin cambios)
     fun getExploreSources(pageNum: Int): Pair<List<OpdsSourceNavEntry>, Long> =
         transaction {
             val query =

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/NavigationRepository.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/repository/NavigationRepository.kt
@@ -78,7 +78,7 @@ object NavigationRepository {
                     MR.strings.opds_feeds_genres_title,
                     MR.strings.opds_feeds_genres_entry_content,
                 ),
-            "status" to
+            "statuses" to
                 Triple(
                     OpdsConstants.TYPE_ATOM_XML_FEED_NAVIGATION,
                     MR.strings.opds_feeds_status_title,


### PR DESCRIPTION
This pull request completely refactors the OPDS v1.2 implementation to align it more closely with the WebUI experience, enabling more intuitive content discovery in addition to library management.

#### Key Changes:

*   **Root Feed Restructuring:** The root feed now directly presents the main sections, including "Explore," "History," "Updates," and all methods for browsing the library (by series, sources, categories, etc.), offering faster and more direct access to content.

*   **New "Explore" Section:** An "Explore" section has been introduced, allowing users to browse all available sources (not just those with series in the library), with the ability to sort by "Popular" and "Latest," mirroring the WebUI.

*   **New "History" Feed:** A "History" feed has been added to the root to display recently read chapters.

*   **Advanced Library Filtering and Sorting:**
    *   All library feeds (`All Series`, `By Source`, `By Category`, etc.) now include OPDS facets for **sorting** by:
        *   Title (A-Z, Z-A)
        *   Last Read
        *   Latest Chapter
        *   Date Added
        *   Unread Chapters
    *   Facets have also been added for **filtering** by content: Unread, Downloaded, Ongoing, and Completed.
    *   **Cross-Filtering:** All library feeds now support combining multiple filters (e.g., by source, category, and status simultaneously) using OPDS facets for powerful, targeted browsing.

*   **Enhanced Chapter Feeds**: Chapter feeds now provide direct links for streaming (OPDS-PSE) and CBZ downloads when page counts are known, falling back to a metadata feed otherwise. This significantly speeds up access to content.

*   **User Experience Enhancements:**
    *   Item counts (`thr:count`) have been added to navigation and facet links, providing OPDS clients with a clear indication of the amount of content in each section.
    *   The term "manga" has been standardized to "series" across all user-facing OPDS titles and descriptions to maintain consistency with the WebUI.

*   **Code Refactoring & Fixes:**
    *   The controller and feed building logic have been centralized using a new `getLibraryFeed` helper and an `OpdsMangaFilter` DTO, improving maintainability and standardizing feed generation.
    *   Repository queries have been updated to efficiently support the new filters and item counts.
    *   Fixed bugs related to fetching chapters for non-library series and resolved async issues in feed generation.

---
#### **BREAKING CHANGE ⚠️**

*   The API structure has changed. OPDS clients must update their routes to discover library sections directly from the root feed (`/api/opds/v1.2`). The `/api/opds/v1.2/library` endpoint has been removed.
*   Endpoints that previously used `manga` now use `series` for consistency. For example, `/api/opds/v1.2/manga/{id}/chapters` is now `/api/opds/v1.2/series/{id}/chapters`.