### PR TITLE
Handle too long page image urls

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -112,14 +112,11 @@ object Page {
 
         if (pageEntry[PageTable.imageUrl] == null) {
             val trueImageUrl = getTrueImageUrl(tachiyomiPage, source)
-            if (trueImageUrl.length <= 2048) {
-                transaction {
-                    PageTable.update({ (PageTable.chapter eq chapterId) and (PageTable.index eq index) }) {
-                        it[imageUrl] = trueImageUrl
-                    }
+            transaction {
+                PageTable.update({ (PageTable.chapter eq chapterId) and (PageTable.index eq index) }) {
+                    it[imageUrl] = trueImageUrl
                 }
             }
-            tachiyomiPage.imageUrl = trueImageUrl
         }
 
         val fileName = getPageName(index, chapterEntry[ChapterTable.pageCount])

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/chapter/ChapterForDownload.kt
@@ -182,13 +182,7 @@ private class ChapterForDownload(
             PageTable.batchInsert(pageList) { page ->
                 this[PageTable.index] = page.index
                 this[PageTable.url] = page.url
-                // Only store imageUrl if it's not too long to prevent database constraint violations
-                this[PageTable.imageUrl] =
-                    if (page.imageUrl != null && page.imageUrl!!.length <= 2048) {
-                        page.imageUrl
-                    } else {
-                        null
-                    }
+                this[PageTable.imageUrl] = page.imageUrl
                 this[PageTable.chapter] = chapterId
             }
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/PageTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/PageTable.kt
@@ -13,7 +13,7 @@ import org.jetbrains.exposed.sql.ReferenceOption
 object PageTable : IntIdTable() {
     val index = integer("index")
     val url = varchar("url", 2048)
-    val imageUrl = varchar("image_url", 2048).nullable()
+    val imageUrl = varchar("image_url", Integer.MAX_VALUE).nullable()
 
     val chapter = reference("chapter", ChapterTable, ReferenceOption.CASCADE)
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0050_FixHandlingOfTooLongPageImageUrls.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0050_FixHandlingOfTooLongPageImageUrls.kt
@@ -1,0 +1,21 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+
+@Suppress("ClassName", "unused")
+class M0050_FixHandlingOfTooLongPageImageUrls : SQLMigration() {
+    override val sql: String =
+        """
+        ALTER TABLE PAGE DROP CONSTRAINT UC_PAGE;
+        ALTER TABLE PAGE ADD CONSTRAINT UC_PAGE UNIQUE (INDEX, CHAPTER);
+        
+        ALTER TABLE PAGE ALTER COLUMN IMAGE_URL VARCHAR; -- the default length is `Integer.MAX_VALUE`
+        """.trimIndent()
+}


### PR DESCRIPTION
Attempted fix of 3ff29aa38a447f3eba93bf72c090fab3b774509f might not work, because there is no guarantee that the extension supports retrieving a specific page.