### PR TITLE
Fix handling of too long page image urls migration

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0050_FixHandlingOfTooLongPageImageUrls.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0050_FixHandlingOfTooLongPageImageUrls.kt
@@ -20,7 +20,7 @@ class M0050_FixHandlingOfTooLongPageImageUrls : SQLMigration() {
             GROUP BY INDEX, CHAPTER
         );
             
-        ALTER TABLE PAGE DROP CONSTRAINT UC_PAGE;
+        ALTER TABLE PAGE DROP CONSTRAINT IF EXISTS UC_PAGE;
         ALTER TABLE PAGE ADD CONSTRAINT UC_PAGE UNIQUE (INDEX, CHAPTER);
         
         ALTER TABLE PAGE ALTER COLUMN IMAGE_URL VARCHAR; -- the default length is `Integer.MAX_VALUE`

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0050_FixHandlingOfTooLongPageImageUrls.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0050_FixHandlingOfTooLongPageImageUrls.kt
@@ -13,6 +13,13 @@ import de.neonew.exposed.migrations.helpers.SQLMigration
 class M0050_FixHandlingOfTooLongPageImageUrls : SQLMigration() {
     override val sql: String =
         """
+        DELETE FROM PAGE
+        WHERE ID NOT IN (
+            SELECT MIN(ID)
+            FROM PAGE
+            GROUP BY INDEX, CHAPTER
+        );
+            
         ALTER TABLE PAGE DROP CONSTRAINT UC_PAGE;
         ALTER TABLE PAGE ADD CONSTRAINT UC_PAGE UNIQUE (INDEX, CHAPTER);
         


### PR DESCRIPTION
In case duplicated rows based on the condition for the updated unique constraint existed, the new constraint could not be added and caused the migration to fail

fixes #1546