### PR TITLE
[#1563] Return default if no matching locale found

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/i18n/LocalizationHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/i18n/LocalizationHelper.kt
@@ -39,7 +39,7 @@ object LocalizationHelper {
         return if (headerLang == null || headerLang.isEmpty()) {
             Locale.getDefault()
         } else {
-            Locale.lookup(Locale.LanguageRange.parse(headerLang), supportedLocales)
+            Locale.lookup(Locale.LanguageRange.parse(headerLang), supportedLocales) ?: Locale.getDefault()
         }
     }
 }


### PR DESCRIPTION
Fixes #1563

Not sure why Kotlin didn't complain that `Locale.parse` can return `null`, but it does so when the browser sends only languages we don't support (e.g. browser says I only speak Catalan, but we don't support Catalan), return the default locale in that case as well