### PR TITLE
FEAT: Configurable session cookie max-age (0 = session-only)

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -75,20 +75,12 @@ object JavalinSetup {
                 }
 
                 var connectorAdded = false
-                // Configure Jetty session cookie. If optional server.sessionCookieMaxAgeMinutes is present,
-                // set persistent cookie max-age accordingly; otherwise, leave Jetty defaults.
+                // Configure Jetty session cookie: 0 = default behavior, >0 = persistent Max-Age in minutes
                 config.jetty.modifyServletContextHandler { context ->
                     val sessionHandler = context.sessionHandler ?: SessionHandler()
                     sessionHandler.sessionCookieConfig.apply {
-                        val cookieMaxAgeMinutes: Int? = try {
-                            val cfg = GlobalConfigManager.config
-                            if (cfg.hasPath("server.sessionCookieMaxAgeMinutes")) cfg.getInt("server.sessionCookieMaxAgeMinutes") else null
-                        } catch (_: Exception) {
-                            null
-                        }
-                        if (cookieMaxAgeMinutes != null) {
-                            maxAge = (cookieMaxAgeMinutes * 60)
-                        }
+                        val cookieMaxAgeMinutes: Int = serverConfig.sessionCookieMaxAgeMinutes.value
+                        if (cookieMaxAgeMinutes > 0) maxAge = (cookieMaxAgeMinutes * 60)
                         isHttpOnly = true
                         // Keep defaults for name/path; JSESSIONID and "/" are used by default
                     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.runBlocking
 import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.session.SessionHandler
 import suwayomi.tachidesk.global.GlobalAPI
 import suwayomi.tachidesk.graphql.GraphQL
 import suwayomi.tachidesk.graphql.types.AuthMode
@@ -40,6 +41,7 @@ import java.util.Locale
 import java.util.concurrent.CompletableFuture
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.days
+import xyz.nulldev.ts.config.GlobalConfigManager
 
 object JavalinSetup {
     private val logger = KotlinLogging.logger {}
@@ -73,6 +75,25 @@ object JavalinSetup {
                 }
 
                 var connectorAdded = false
+                // Configure Jetty session cookie. If optional server.sessionCookieMaxAgeMinutes is present,
+                // set persistent cookie max-age accordingly; otherwise, leave Jetty defaults.
+                config.jetty.modifyServletContextHandler { context ->
+                    val sessionHandler = context.sessionHandler ?: SessionHandler()
+                    sessionHandler.sessionCookieConfig.apply {
+                        val cookieMaxAgeMinutes: Int? = try {
+                            val cfg = GlobalConfigManager.config
+                            if (cfg.hasPath("server.sessionCookieMaxAgeMinutes")) cfg.getInt("server.sessionCookieMaxAgeMinutes") else null
+                        } catch (_: Exception) {
+                            null
+                        }
+                        if (cookieMaxAgeMinutes != null) {
+                            maxAge = (cookieMaxAgeMinutes * 60)
+                        }
+                        isHttpOnly = true
+                        // Keep defaults for name/path; JSESSIONID and "/" are used by default
+                    }
+                    context.sessionHandler = sessionHandler
+                }
                 config.jetty.modifyServer { server ->
                     if (!connectorAdded) {
                         val connector =
@@ -102,7 +123,6 @@ object JavalinSetup {
                         connectorAdded = true
                     }
                 }
-
                 config.bundledPlugins.enableCors { cors ->
                     cors.addRule {
                         it.allowCredentials = true
@@ -146,11 +166,12 @@ object JavalinSetup {
 
             if (isValid) {
                 val redirect = ctx.queryParam("redirect") ?: "/"
-                // NOTE: We currently have no session handler attached.
-                // Thus, all sessions are stored in memory and not persisted.
-                // Furthermore, default session timeout appears to be 30m
+                // NOTE: We currently have no session persistence configured.
+                // Sessions are in-memory; server-side inactivity timeout is extended below.
                 ctx.header("Location", redirect)
                 ctx.sessionAttribute("logged-in", username)
+                // Extend server-side session inactivity timeout from ~30 minutes to 30 days
+                ctx.req().session.maxInactiveInterval = 30.days.inWholeSeconds.toInt()
                 throw RedirectResponse(HttpStatus.SEE_OTHER)
             }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -150,6 +150,8 @@ class ServerConfig(
     val authMode: MutableStateFlow<AuthMode> by OverrideConfigValue()
     val authUsername: MutableStateFlow<String> by OverrideConfigValue()
     val authPassword: MutableStateFlow<String> by OverrideConfigValue()
+    // Sessions
+    val sessionCookieMaxAgeMinutes: MutableStateFlow<Int> by OverrideConfigValue()
     val basicAuthEnabled: MutableStateFlow<Boolean> by MigratedConfigValue({
         authMode.value == AuthMode.BASIC_AUTH
     }) {

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -53,10 +53,9 @@ server.authMode = "none" # none, basic_auth or simple_login
 server.authUsername = ""
 server.authPassword = ""
 
-# Sessions (optional)
-# If set, Jetty will issue a persistent JSESSIONID cookie with this max-age (in minutes).
-# If not set, default session cookie behavior applies (session cookie without persistent max-age).
-# server.sessionCookieMaxAgeMinutes = 43200 # 30 days
+# Sessions
+# 0 = default session cookie behavior (no persistent Max-Age); >0 = persistent JSESSIONID with given max-age in minutes
+server.sessionCookieMaxAgeMinutes = 0
 
 # misc
 server.debugLogsEnabled = false

--- a/server/src/main/resources/server-reference.conf
+++ b/server/src/main/resources/server-reference.conf
@@ -53,6 +53,11 @@ server.authMode = "none" # none, basic_auth or simple_login
 server.authUsername = ""
 server.authPassword = ""
 
+# Sessions (optional)
+# If set, Jetty will issue a persistent JSESSIONID cookie with this max-age (in minutes).
+# If not set, default session cookie behavior applies (session cookie without persistent max-age).
+# server.sessionCookieMaxAgeMinutes = 43200 # 30 days
+
 # misc
 server.debugLogsEnabled = false
 server.systemTrayEnabled = true


### PR DESCRIPTION
## Session cookie persistence

### Overview
- `server.sessionCookieMaxAgeMinutes` controls the browser persistence of the `JSESSIONID` cookie.
- **Default is 0** → session-only cookie (no persistent Max-Age) [Currently is working like this].
- Set to a positive number (minutes) to make the cookie persistent.

### Configure
Edit your `server.conf`:

```conf
server.sessionCookieMaxAgeMinutes = 0
```

- Keep at `0` for session-only cookies.
- Example for 30 days persistence:

```conf
server.sessionCookieMaxAgeMinutes = 43200
```

Restart the server to apply changes.

### What changes
- When > 0: Jetty issues `Set-Cookie: JSESSIONID; Max-Age=<minutes*60>; HttpOnly`.
- When 0: No `Max-Age` is set (session cookie).
- Server-side session inactivity timeout after login remains 30 days; this setting only affects browser persistence.

### Verify
1) Set desired value in `server.conf`, restart.
2) Login via WebUI.
3) Check response headers or browser devtools:
   - With `0`: `Set-Cookie: JSESSIONID` has no `Max-Age`.
   - With `5`: header includes `Max-Age=300`.
 
### Notes
- Use session-only (0) for stricter security/privacy.
- Use persistence for convenience on trusted devices/hosts.