### PR TITLE
feat(opds): Enhance KOSync Conflict Handling and Reliability

### DIFF
--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -110,6 +110,7 @@
     <string name="opds_chapter_status_in_progress">⌛ </string>
     <string name="opds_chapter_status_unread">⭕ </string>
     <string name="opds_chapter_status_downloaded">⬇️ </string>
+    <string name="opds_chapter_status_synced">☁️ </string>
 
     <string name="opds_chapter_details_base">Series: %1$s | %2$s</string>
     <string name="opds_chapter_details_scanlator"> | By %1$s</string>

--- a/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
+++ b/server/i18n/src/commonMain/moko-resources/values/base/strings.xml
@@ -110,7 +110,7 @@
     <string name="opds_chapter_status_in_progress">⌛ </string>
     <string name="opds_chapter_status_unread">⭕ </string>
     <string name="opds_chapter_status_downloaded">⬇️ </string>
-    <string name="opds_chapter_status_synced">☁️ </string>
+    <string name="opds_chapter_status_synced">🌐 </string>
 
     <string name="opds_chapter_details_base">Series: %1$s | %2$s</string>
     <string name="opds_chapter_details_scanlator"> | By %1$s</string>

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
@@ -325,7 +325,6 @@ object OpdsEntryBuilder {
             }
         }
 
-        // Integrated `buildChapterSummary` logic here
         val details =
             buildString {
                 append(MR.strings.opds_chapter_details_base.localized(locale, manga.title, chapter.name))
@@ -338,7 +337,6 @@ object OpdsEntryBuilder {
 
         val entryTitle = "$titlePrefix ${chapter.name}"
 
-        // Integrated `buildChapterLinks` logic here
         val links = mutableListOf<OpdsLinkXml>()
         chapter.url?.let {
             links.add(


### PR DESCRIPTION
This pull request overhauls the Koreader Sync (KOSync) integration within the OPDS feed to correctly handle synchronization conflicts and improve overall stability.

#### Problem
When a KOSync conflict occurred (i.e., local and remote reading progress for the same chapter differed), the server would generate an invalid OPDS entry. It would incorrectly include multiple `opds-pse/stream` links within a single `<entry>`, one for each progress point.

This approach violates the implicit design of the OPDS-PSE specification, which expects only one stream link per entry. As a result, OPDS clients like KOReader would exhibit inconsistent behavior, often only recognizing the last link and preventing the user from choosing which progress to resume from.

Additionally, two underlying issues were discovered during investigation:
1.  A JSON deserialization error caused the remote progress timestamp (`updated_at`) to be ignored.
2.  Network instability during KOSync API calls sometimes led to `unexpected end of stream` errors due to connection reuse.

#### Solution
This PR addresses these issues with the following changes:

*   **feat(opds): Correct Conflict Handling with Separate Entries**
    *   When a sync conflict is detected, the OPDS feed now generates **two distinct `<entry>` elements** for the same chapter.
    *   One entry represents the **local progress** and retains the original, stable ID (`urn:suwayomi:chapter:{id}:metadata`).
    *   The second entry represents the **remote progress**, is visually distinguished by a icon (**🌐**) prefix, and is given a unique ID with a `:remote` suffix to avoid collisions.
    *   This ensures each entry has only one `opds-pse/stream` link, making the feed compliant and allowing clients to present a clear choice to the user.

*   **fix(sync): Fix Progress Timestamp Deserialization**
    *   The `KoreaderProgressResponse` data class has been corrected to map the server's `updated_at` field to our internal `timestamp` property, ensuring remote timestamps are now correctly processed.

*   **fix(sync): Improve Network Reliability**
    *   A `Connection: close` header has been added to all KOSync API requests to prevent connection reuse issues and improve the stability of sync operations.

*   **chore(sync): Enhance Debuggability**
    *   Detailed debug logging has been added to the KOSync service for both `GET` and `PUT` requests, making it easier to troubleshoot future synchronization issues.