### PR TITLE
feat(kosync): Implement On-the-Fly Deterministic Hashing for KOReader Sync

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
@@ -20,6 +20,7 @@ import suwayomi.tachidesk.server.ApplicationDirs
 import uy.kohesive.injekt.injectLazy
 import java.io.File
 import java.io.InputStream
+import java.util.zip.Deflater
 
 private val applicationDirs: ApplicationDirs by injectLazy()
 
@@ -61,9 +62,12 @@ class ArchiveProvider(
         }
 
         ZipArchiveOutputStream(outputFile.outputStream()).use { zipOut ->
+            zipOut.setMethod(ZipArchiveOutputStream.DEFLATED)
+            zipOut.setLevel(Deflater.DEFAULT_COMPRESSION)
             if (chapterCacheFolder.isDirectory) {
                 chapterCacheFolder.listFiles()?.sortedBy { it.name }?.forEach {
                     val entry = ZipArchiveEntry(it.name)
+                    entry.time = 0L
                     try {
                         zipOut.putArchiveEntry(entry)
                         it.inputStream().use { inputStream ->

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/sync/KoreaderSyncService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/sync/KoreaderSyncService.kt
@@ -121,7 +121,7 @@ object KoreaderSyncService {
                         try {
                             // This generates a deterministic CBZ stream from either a folder or an existing CBZ file.
                             // If it fails, it means the chapter is not available for hashing.
-                            val (stream, _) = ChapterDownloadHelper.getAsArchiveStream(mangaId, chapterId)
+                            val (stream, _) = ChapterDownloadHelper.getArchiveStreamWithSize(mangaId, chapterId)
                             stream.use {
                                 Hash.md5(it.readBytes())
                             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/sync/KoreaderSyncService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/sync/KoreaderSyncService.kt
@@ -17,13 +17,11 @@ import org.jetbrains.exposed.sql.update
 import suwayomi.tachidesk.graphql.types.KoSyncStatusPayload
 import suwayomi.tachidesk.graphql.types.KoreaderSyncChecksumMethod
 import suwayomi.tachidesk.graphql.types.KoreaderSyncStrategy
-import suwayomi.tachidesk.manga.impl.util.KoreaderHelper
-import suwayomi.tachidesk.manga.impl.util.getChapterCbzPath
+import suwayomi.tachidesk.manga.impl.ChapterDownloadHelper
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.server.serverConfig
 import uy.kohesive.injekt.injectLazy
-import java.io.File
 import java.util.UUID
 import kotlin.math.abs
 
@@ -102,35 +100,35 @@ object KoreaderSyncService {
 
     private fun getOrGenerateChapterHash(chapterId: Int): String? {
         return transaction {
-            val existingHash =
+            val chapterRow =
                 ChapterTable
-                    .select(ChapterTable.koreaderHash)
+                    .select(ChapterTable.koreaderHash, ChapterTable.manga, ChapterTable.isDownloaded)
                     .where { ChapterTable.id eq chapterId }
-                    .firstOrNull()
-                    ?.get(ChapterTable.koreaderHash)
+                    .firstOrNull() ?: return@transaction null
 
+            val existingHash = chapterRow[ChapterTable.koreaderHash]
             if (!existingHash.isNullOrBlank()) {
                 return@transaction existingHash
             }
 
+            val mangaId = chapterRow[ChapterTable.manga].value
             val checksumMethod = serverConfig.koreaderSyncChecksumMethod.value
+
             val newHash =
                 when (checksumMethod) {
                     KoreaderSyncChecksumMethod.BINARY -> {
-                        logger.info { "[KOSYNC HASH] No hash for chapterId=$chapterId. Generating from CBZ content." }
-                        val mangaId =
-                            ChapterTable
-                                .select(ChapterTable.manga)
-                                .where { ChapterTable.id eq chapterId }
-                                .firstOrNull()
-                                ?.get(ChapterTable.manga)
-                                ?.value ?: return@transaction null
-                        val cbzFile = File(getChapterCbzPath(mangaId, chapterId))
-                        if (!cbzFile.exists()) {
-                            logger.info { "[KOSYNC HASH] Could not generate hash for chapterId=$chapterId. CBZ not found." }
-                            return@transaction null
+                        logger.info { "[KOSYNC HASH] No hash for chapterId=$chapterId. Generating from downloaded content." }
+                        try {
+                            // This generates a deterministic CBZ stream from either a folder or an existing CBZ file.
+                            // If it fails, it means the chapter is not available for hashing.
+                            val (stream, _) = ChapterDownloadHelper.getAsArchiveStream(mangaId, chapterId)
+                            stream.use {
+                                Hash.md5(it.readBytes())
+                            }
+                        } catch (e: Exception) {
+                            logger.warn(e) { "[KOSYNC HASH] Failed to generate archive stream for chapterId=$chapterId." }
+                            null
                         }
-                        KoreaderHelper.hashContents(cbzFile)
                     }
                     KoreaderSyncChecksumMethod.FILENAME -> {
                         logger.info { "[KOSYNC HASH] No hash for chapterId=$chapterId. Generating from filename." }


### PR DESCRIPTION
This PR builds upon the work to make CBZ generation deterministic by implementing a lazy hash generation and caching mechanism for KOReader Sync. This resolves two key issues: it extends sync compatibility to chapters downloaded as folders and makes the entire process more robust and efficient.

#### The Problem

KOReader Sync's "binary" mode is the most reliable way to sync progress, but it depends on a consistent content hash. Previously, Suwayomi-Server had two limitations:
1.  **Inconsistent Hashes:** CBZ files generated on-the-fly had different hashes than those downloaded directly, breaking sync consistency.
2.  **Limited Compatibility:** The sync service could only provide a hash for chapters that were *already* downloaded as CBZ files. Chapters downloaded as plain folders were excluded from this feature, forcing users to either not use binary sync or manually manage their download formats.

The first issue was addressed by unifying the CBZ creation logic to use Apache Commons Compress, ensuring deterministic output. This PR tackles the second issue by leveraging that new determinism.

#### The Solution

This PR refactors and enhances the `KoreaderSyncService` to generate and cache a deterministic CBZ hash on-the-fly for *any* downloaded chapter, right when it's needed for synchronization.

**Key Changes:**

*   **Lazy Hash Generation:** The hash for a chapter is now calculated only the first time it's requested for a sync operation (`push` or `pull`).
*   **Unified Hashing Logic:** The service now uses `ChapterDownloadHelper.getAsArchiveStream()` to get the CBZ content as an in-memory stream. This method deterministically creates a CBZ from a folder if one doesn't already exist, ensuring the resulting hash is identical whether the source is a folder or a pre-existing CBZ file.
*   **Database Caching:** Once generated, the hash is saved to the `koreader_hash` column in the `Chapter` table. Subsequent sync requests for the same chapter will use this cached hash, avoiding repeated and expensive calculations.
*   **Robustness:** The logic no longer relies on the `isDownloaded` database flag. Instead, it directly checks if the archive stream can be created, making the filesystem the single source of truth and gracefully handling any potential desynchronization with the database.

#### Benefits

*   **Seamless Syncing:** All downloaded chapters are now compatible with KOReader Sync's binary mode, regardless of their storage format.
*   **Improved User Experience:** Users no longer need to manually manage download formats to enable reliable progress syncing.
*   **Efficient:** Hashing is performed only once per download and then cached, minimizing performance impact.
*   **Cleaner Code:** The logic is now simpler and more robust by removing redundant checks.