### PR TITLE
[#1575] WebView: Disable Alt translation

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt
@@ -466,8 +466,9 @@ class KcefWebView {
         val clickY = msg.clickY
         val modifier =
             (
-                (if (msg.altKey == true) InputEvent.ALT_DOWN_MASK else 0) or
-                    (if (msg.ctrlKey == true) InputEvent.CTRL_DOWN_MASK else 0) or
+                // Alt support is removed, since browsers already translate, so this messes with translation, see #1575
+                // (if (msg.altKey == true) InputEvent.ALT_DOWN_MASK else 0) or
+                (if (msg.ctrlKey == true) InputEvent.CTRL_DOWN_MASK else 0) or
                     (if (msg.shiftKey == true) InputEvent.SHIFT_DOWN_MASK else 0) or
                     (if (msg.metaKey == true) InputEvent.META_DOWN_MASK else 0)
             )


### PR DESCRIPTION
Some keyboards (e.g. Finnish or German) use Alt for some characters. On Linux/Windows, these are activated by Alt-Gr and directly translated. On macOS, they are also translated, but Alt is still sent in the event. CEF now tries to translate a second time, which won't work. Since we don't support alt-based shortcuts anyways (no file menu etc), disabling this translation makes those keyboards work and should have no impact on other functionality.

Closes #1575