### PR TITLE
OPDS: Allow fallback to Basic Auth

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/global/controller/WebViewController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/controller/WebViewController.kt
@@ -14,14 +14,14 @@ import io.javalin.websocket.WsConfig
 import suwayomi.tachidesk.global.impl.WebView
 import suwayomi.tachidesk.graphql.types.AuthMode
 import suwayomi.tachidesk.i18n.LocalizationHelper
-import suwayomi.tachidesk.server.serverConfig
 import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.getAttribute
+import suwayomi.tachidesk.server.serverConfig
+import suwayomi.tachidesk.server.user.UnauthorizedException
 import suwayomi.tachidesk.server.user.requireUser
 import suwayomi.tachidesk.server.util.handler
 import suwayomi.tachidesk.server.util.queryParam
 import suwayomi.tachidesk.server.util.withOperation
-import suwayomi.tachidesk.server.user.UnauthorizedException
 import java.net.URLEncoder
 import java.util.Locale
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/controller/WebViewController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/controller/WebViewController.kt
@@ -9,15 +9,20 @@ package suwayomi.tachidesk.global.controller
 
 import io.javalin.http.ContentType
 import io.javalin.http.HttpStatus
+import io.javalin.http.RedirectResponse
 import io.javalin.websocket.WsConfig
 import suwayomi.tachidesk.global.impl.WebView
+import suwayomi.tachidesk.graphql.types.AuthMode
 import suwayomi.tachidesk.i18n.LocalizationHelper
+import suwayomi.tachidesk.server.serverConfig
 import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.getAttribute
 import suwayomi.tachidesk.server.user.requireUser
 import suwayomi.tachidesk.server.util.handler
 import suwayomi.tachidesk.server.util.queryParam
 import suwayomi.tachidesk.server.util.withOperation
+import suwayomi.tachidesk.server.user.UnauthorizedException
+import java.net.URLEncoder
 import java.util.Locale
 
 object WebViewController {
@@ -31,7 +36,18 @@ object WebViewController {
                 }
             },
             behaviorOf = { ctx, lang ->
-                // intentionally not user-protected, this pages handles login by itself
+                // intentionally not user-protected, this pages handles login by itself in UI_LOGIN mode
+                // for SIMPLE_LOGIN, we need to manually redirect to make this work
+                // for BASIC_AUTH, JavalinSetup already handles this
+                if (serverConfig.authMode.value == AuthMode.SIMPLE_LOGIN) {
+                    try {
+                        ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                    } catch (_: UnauthorizedException) {
+                        val url = "/login.html?redirect=" + URLEncoder.encode(ctx.fullUrl(), Charsets.UTF_8)
+                        ctx.header("Location", url)
+                        throw RedirectResponse(HttpStatus.SEE_OTHER)
+                    }
+                }
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.contentType(ContentType.TEXT_HTML)
                 ctx.render(

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
@@ -13,6 +13,7 @@ import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.future
 import suwayomi.tachidesk.server.JavalinSetup.getAttribute
 import suwayomi.tachidesk.server.user.requireUser
+import suwayomi.tachidesk.server.user.requireUserWithBasicFallback
 import suwayomi.tachidesk.server.util.handler
 import suwayomi.tachidesk.server.util.pathParam
 import suwayomi.tachidesk.server.util.queryParam
@@ -65,7 +66,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.contentType(OPDS_MIME).result(OpdsFeedBuilder.getRootFeed(BASE_URL, locale))
             },
@@ -88,7 +89,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, pageNumber, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -114,7 +115,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.contentType("application/opensearchdescription+xml").result(
                     """
@@ -142,7 +143,7 @@ object OpdsV1Controller {
         handler(
             documentWith = { withOperation { summary("OPDS Series in Library Feed") } },
             behaviorOf = { ctx ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val pageNumber = ctx.queryParam("pageNumber")?.toIntOrNull()
                 val query = ctx.queryParam("query")
                 val author = ctx.queryParam("author")
@@ -195,7 +196,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, pageNumber, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -222,7 +223,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, pageNumber, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -249,7 +250,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, pageNumber, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -276,7 +277,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, pageNumber, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -302,7 +303,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -328,7 +329,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -355,7 +356,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, pageNumber, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -384,7 +385,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, sourceId, pageNumber, sort, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -420,7 +421,7 @@ object OpdsV1Controller {
             pathParam<Long>("sourceId"),
             documentWith = { withOperation { summary("OPDS Library Source Specific Series Feed") } },
             behaviorOf = { ctx, sourceId ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val criteria = buildCriteriaFromContext(ctx, OpdsMangaFilter(sourceId = sourceId, primaryFilter = PrimaryFilterType.SOURCE))
                 getLibraryFeed(ctx, ctx.queryParam("pageNumber")?.toIntOrNull(), criteria)
             },
@@ -438,7 +439,7 @@ object OpdsV1Controller {
             pathParam<Int>("categoryId"),
             documentWith = { withOperation { summary("OPDS Category Specific Series Feed") } },
             behaviorOf = { ctx, categoryId ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val criteria =
                     buildCriteriaFromContext(ctx, OpdsMangaFilter(categoryId = categoryId, primaryFilter = PrimaryFilterType.CATEGORY))
                 getLibraryFeed(ctx, ctx.queryParam("pageNumber")?.toIntOrNull(), criteria)
@@ -457,7 +458,7 @@ object OpdsV1Controller {
             pathParam<String>("genre"),
             documentWith = { withOperation { summary("OPDS Genre Specific Series Feed") } },
             behaviorOf = { ctx, genre ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val criteria = buildCriteriaFromContext(ctx, OpdsMangaFilter(genre = genre, primaryFilter = PrimaryFilterType.GENRE))
                 getLibraryFeed(ctx, ctx.queryParam("pageNumber")?.toIntOrNull(), criteria)
             },
@@ -475,7 +476,7 @@ object OpdsV1Controller {
             pathParam<Int>("statusId"),
             documentWith = { withOperation { summary("OPDS Status Specific Series Feed") } },
             behaviorOf = { ctx, statusId ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val criteria = buildCriteriaFromContext(ctx, OpdsMangaFilter(statusId = statusId, primaryFilter = PrimaryFilterType.STATUS))
                 getLibraryFeed(ctx, ctx.queryParam("pageNumber")?.toIntOrNull(), criteria)
             },
@@ -498,7 +499,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, langCode ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val criteria =
                     buildCriteriaFromContext(ctx, OpdsMangaFilter(langCode = langCode, primaryFilter = PrimaryFilterType.LANGUAGE))
                 getLibraryFeed(ctx, ctx.queryParam("pageNumber")?.toIntOrNull(), criteria)
@@ -526,7 +527,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, seriesId, pageNumber, sort, filter, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {
@@ -557,7 +558,7 @@ object OpdsV1Controller {
                 }
             },
             behaviorOf = { ctx, seriesId, chapterIndex, lang ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
                 val locale: Locale = LocalizationHelper.ctxToLocale(ctx, lang)
                 ctx.future {
                     future {

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/controller/OpdsV1Controller.kt
@@ -12,7 +12,6 @@ import suwayomi.tachidesk.opds.impl.OpdsFeedBuilder
 import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.future
 import suwayomi.tachidesk.server.JavalinSetup.getAttribute
-import suwayomi.tachidesk.server.user.requireUser
 import suwayomi.tachidesk.server.user.requireUserWithBasicFallback
 import suwayomi.tachidesk.server.util.handler
 import suwayomi.tachidesk.server.util.pathParam

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -132,8 +132,9 @@ object JavalinSetup {
                         after { ctx ->
                             // If not matched, the request was for an invalid endpoint
                             // Return a 404 instead of redirecting to the UI for usability
-                            if (ctx.endpointHandlerPath() == "*")
+                            if (ctx.endpointHandlerPath() == "*") {
                                 throw NotFoundResponse()
+                            }
                         }
                     }
                 }
@@ -301,6 +302,7 @@ object JavalinSetup {
         val name: String,
     ) {
         data object TachideskUser : Attribute<UserType>("user")
+
         data object TachideskBasic : Attribute<Boolean>("basicAuthValid")
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -180,6 +180,7 @@ object JavalinSetup {
                     !ctx.path().substring(1).contains('/') &&
                     listOf(".png", ".jpg", ".ico").any { ctx.path().endsWith(it) }
             val isPreFlight = ctx.method() == HandlerType.OPTIONS
+            val isApi = ctx.path().startsWith("/api/")
 
             val requiresAuthentication = !isPreFlight && !isPageIcon && !isWebManifest
             if (!requiresAuthentication) {
@@ -200,11 +201,7 @@ object JavalinSetup {
                 return username == serverConfig.authUsername.value
             }
 
-            if (authMode == AuthMode.SIMPLE_LOGIN && !cookieValid() && ctx.path().startsWith("/api")) {
-                throw UnauthorizedResponse()
-            }
-
-            if (authMode == AuthMode.SIMPLE_LOGIN && !cookieValid()) {
+            if (authMode == AuthMode.SIMPLE_LOGIN && !cookieValid() && !isApi) {
                 val url = "/login.html?redirect=" + URLEncoder.encode(ctx.fullUrl(), Charsets.UTF_8)
                 ctx.header("Location", url)
                 throw RedirectResponse(HttpStatus.SEE_OTHER)

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -213,6 +213,7 @@ object JavalinSetup {
             }
 
             ctx.setAttribute(Attribute.TachideskUser, getUserFromContext(ctx))
+            ctx.setAttribute(Attribute.TachideskBasic, credentialsValid())
         }
 
         app.events { event ->
@@ -291,6 +292,7 @@ object JavalinSetup {
         val name: String,
     ) {
         data object TachideskUser : Attribute<UserType>("user")
+        data object TachideskBasic : Attribute<Boolean>("basicAuthValid")
     }
 
     private fun <T : Any> Context.setAttribute(

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -11,10 +11,12 @@ import gg.jte.ContentType
 import gg.jte.TemplateEngine
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.javalin.Javalin
+import io.javalin.apibuilder.ApiBuilder.after
 import io.javalin.apibuilder.ApiBuilder.path
 import io.javalin.http.Context
 import io.javalin.http.HandlerType
 import io.javalin.http.HttpStatus
+import io.javalin.http.NotFoundResponse
 import io.javalin.http.RedirectResponse
 import io.javalin.http.UnauthorizedResponse
 import io.javalin.http.staticfiles.Location
@@ -126,6 +128,13 @@ object JavalinSetup {
 
                         OpdsAPI.defineEndpoints()
                         GraphQL.defineEndpoints()
+
+                        after { ctx ->
+                            // If not matched, the request was for an invalid endpoint
+                            // Return a 404 instead of redirecting to the UI for usability
+                            if (ctx.endpointHandlerPath() == "*")
+                                throw NotFoundResponse()
+                        }
                     }
                 }
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/user/UserType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/user/UserType.kt
@@ -5,9 +5,9 @@ import io.javalin.http.Header
 import io.javalin.websocket.WsConnectContext
 import suwayomi.tachidesk.global.impl.util.Jwt
 import suwayomi.tachidesk.graphql.types.AuthMode
-import suwayomi.tachidesk.server.serverConfig
 import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.getAttribute
+import suwayomi.tachidesk.server.serverConfig
 
 sealed class UserType {
     class Admin(


### PR DESCRIPTION
As discussed in #1524 and discord

All OPDS endpoints now allow Basic Auth as fallback if other authentication methods are configured.
To implement this, SIMPLE_LOGIN verification for API endpoints has been moved to the context as with UI_LOGIN.

This also makes unmatched /api requests return a 404 instead of loading the UI like before. This is important, since SIMPLE_LOGIN now won't run for those endpoints, so the UI is loaded in a un-authorized state, with no way to authorize. It's also the more correct way to handle API requests :)

As a side-effect, Webview with SIMPLE_LOGIN now also presents a login page. Before, it simply shows "Unauthorized", since it was treated as any other API request.