### PR TITLE
Fix GraphQL authentication after #1613

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/user/UserType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/user/UserType.kt
@@ -34,6 +34,10 @@ fun UserType.requireUserWithBasicFallback(ctx: Context): Int =
     }
 
 fun getUserFromToken(token: String?): UserType {
+    if (serverConfig.authMode.value != AuthMode.UI_LOGIN) {
+        return UserType.Admin(1)
+    }
+
     if (token.isNullOrBlank()) {
         return UserType.Visitor
     }


### PR DESCRIPTION
GraphQL directly uses `getUserFromToken` and expects a valid user for other authentication methods, so re-introduce that check