### PR TITLE
refactor(kosync): introduce differentiated sync strategies

### DIFF
--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/graphql/types/KoreaderSyncTypes.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/graphql/types/KoreaderSyncTypes.kt
@@ -5,7 +5,27 @@ enum class KoreaderSyncChecksumMethod {
     FILENAME,
 }
 
-enum class KoreaderSyncStrategy {
+/**
+ * Defines the resolution strategy for synchronization conflicts.
+ * This is applied separately for when the remote progress is newer (Forward)
+ * or older (Backward) than the local progress.
+ */
+enum class KoreaderSyncConflictStrategy {
+    /** Ask the client application to prompt the user for a decision. */
+    PROMPT,
+    /** Always keep the local progress, ignoring the remote version. */
+    KEEP_LOCAL,
+    /** Always overwrite local progress with the remote version. */
+    KEEP_REMOTE,
+    /** Do not perform any sync action for this scenario. */
+    DISABLED,
+}
+
+/**
+ * Legacy enum for migrating the old, single sync strategy setting.
+ */
+@Deprecated("Used for migration purposes only. Use KoreaderSyncConflictStrategy instead.")
+enum class KoreaderSyncLegacyStrategy {
     PROMPT, // Ask on conflict
     SILENT, // Always use latest
     SEND, // Send changes only

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -654,26 +654,8 @@ class ServerConfig(
         },
     )
 
-    val koreaderSyncStrategyForward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
-        protoNumber = 65,
-        group = SettingGroup.KOREADER_SYNC,
-        defaultValue = KoreaderSyncConflictStrategy.PROMPT,
-        enumClass = KoreaderSyncConflictStrategy::class,
-        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
-        description = "Strategy to apply when remote progress is newer than local.",
-    )
-
-    val koreaderSyncStrategyBackward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
-        protoNumber = 66,
-        group = SettingGroup.KOREADER_SYNC,
-        defaultValue = KoreaderSyncConflictStrategy.DISABLED,
-        enumClass = KoreaderSyncConflictStrategy::class,
-        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
-        description = "Strategy to apply when remote progress is older than local.",
-    )
-
     val koreaderSyncPercentageTolerance: MutableStateFlow<Double> by DoubleSetting(
-        protoNumber = 67,
+        protoNumber = 65,
         group = SettingGroup.KOREADER_SYNC,
         defaultValue = 0.000000000000001,
         min = 0.000000000000001,
@@ -682,28 +664,28 @@ class ServerConfig(
     )
 
     val jwtTokenExpiry: MutableStateFlow<Duration> by DurationSetting(
-        protoNumber = 68,
+        protoNumber = 66,
         group = SettingGroup.AUTH,
         defaultValue = 5.minutes,
         min = 0.seconds,
     )
 
     val jwtRefreshExpiry: MutableStateFlow<Duration> by DurationSetting(
-        protoNumber = 69,
+        protoNumber = 67,
         group = SettingGroup.AUTH,
         defaultValue = 60.days,
         min = 0.seconds,
     )
 
     val webUIEnabled: MutableStateFlow<Boolean> by BooleanSetting(
-        protoNumber = 70,
+        protoNumber = 78,
         group = SettingGroup.WEB_UI,
         defaultValue = true,
         requiresRestart = true,
     )
 
     val databaseType: MutableStateFlow<DatabaseType> by EnumSetting(
-        protoNumber = 71,
+        protoNumber = 69,
         group = SettingGroup.DATABASE,
         defaultValue = DatabaseType.H2,
         enumClass = DatabaseType::class,
@@ -711,21 +693,39 @@ class ServerConfig(
     )
 
     val databaseUrl: MutableStateFlow<String> by StringSetting(
-        protoNumber = 72,
+        protoNumber = 70,
         group = SettingGroup.DATABASE,
         defaultValue = "postgresql://localhost:5432/suwayomi",
     )
 
     val databaseUsername: MutableStateFlow<String> by StringSetting(
-        protoNumber = 73,
+        protoNumber = 71,
         group = SettingGroup.DATABASE,
         defaultValue = "",
     )
 
     val databasePassword: MutableStateFlow<String> by StringSetting(
-        protoNumber = 74,
+        protoNumber = 72,
         group = SettingGroup.DATABASE,
         defaultValue = "",
+    )
+
+    val koreaderSyncStrategyForward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
+        protoNumber = 73,
+        group = SettingGroup.KOREADER_SYNC,
+        defaultValue = KoreaderSyncConflictStrategy.PROMPT,
+        enumClass = KoreaderSyncConflictStrategy::class,
+        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
+        description = "Strategy to apply when remote progress is newer than local.",
+    )
+
+    val koreaderSyncStrategyBackward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
+        protoNumber = 74,
+        group = SettingGroup.KOREADER_SYNC,
+        defaultValue = KoreaderSyncConflictStrategy.DISABLED,
+        enumClass = KoreaderSyncConflictStrategy::class,
+        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
+        description = "Strategy to apply when remote progress is older than local.",
     )
 
     /** ****************************************************************** **/

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -27,7 +27,8 @@ import suwayomi.tachidesk.graphql.types.AuthMode
 import suwayomi.tachidesk.graphql.types.DatabaseType
 import suwayomi.tachidesk.graphql.types.DownloadConversion
 import suwayomi.tachidesk.graphql.types.KoreaderSyncChecksumMethod
-import suwayomi.tachidesk.graphql.types.KoreaderSyncStrategy
+import suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy
+import suwayomi.tachidesk.graphql.types.KoreaderSyncLegacyStrategy
 import suwayomi.tachidesk.graphql.types.SettingsDownloadConversionType
 import suwayomi.tachidesk.graphql.types.WebUIChannel
 import suwayomi.tachidesk.graphql.types.WebUIFlavor
@@ -599,16 +600,80 @@ class ServerConfig(
         typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncChecksumMethod")),
     )
 
-    val koreaderSyncStrategy: MutableStateFlow<KoreaderSyncStrategy> by EnumSetting(
+    @Deprecated("Use koreaderSyncStrategyForward and koreaderSyncStrategyBackward instead")
+    val koreaderSyncStrategy: MutableStateFlow<KoreaderSyncLegacyStrategy> by MigratedConfigValue(
         protoNumber = 64,
+        defaultValue = KoreaderSyncLegacyStrategy.DISABLED,
         group = SettingGroup.KOREADER_SYNC,
-        defaultValue = KoreaderSyncStrategy.DISABLED,
-        enumClass = KoreaderSyncStrategy::class,
-        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncStrategy")),
+        typeInfo =
+            SettingsRegistry.PartialTypeInfo(
+                imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncLegacyStrategy"),
+            ),
+        deprecated =
+        SettingsRegistry.SettingDeprecated(
+            replaceWith = "koreaderSyncStrategyForward, koreaderSyncStrategyBackward",
+            message = "Replaced with koreaderSyncStrategyForward and koreaderSyncStrategyBackward",
+        ),
+        readMigrated = {
+            // This is a best-effort reverse mapping. It's not perfect but covers common cases.
+            when {
+                koreaderSyncStrategyForward.value == KoreaderSyncConflictStrategy.PROMPT &&
+                    koreaderSyncStrategyBackward.value == KoreaderSyncConflictStrategy.PROMPT -> KoreaderSyncLegacyStrategy.PROMPT
+                koreaderSyncStrategyForward.value == KoreaderSyncConflictStrategy.KEEP_REMOTE &&
+                    koreaderSyncStrategyBackward.value == KoreaderSyncConflictStrategy.KEEP_LOCAL -> KoreaderSyncLegacyStrategy.SILENT
+                koreaderSyncStrategyForward.value == KoreaderSyncConflictStrategy.KEEP_LOCAL &&
+                    koreaderSyncStrategyBackward.value == KoreaderSyncConflictStrategy.KEEP_LOCAL -> KoreaderSyncLegacyStrategy.SEND
+                koreaderSyncStrategyForward.value == KoreaderSyncConflictStrategy.KEEP_REMOTE &&
+                    koreaderSyncStrategyBackward.value == KoreaderSyncConflictStrategy.KEEP_REMOTE -> KoreaderSyncLegacyStrategy.RECEIVE
+                else -> KoreaderSyncLegacyStrategy.DISABLED
+            }
+        },
+        setMigrated = { value ->
+            when (value) {
+                KoreaderSyncLegacyStrategy.PROMPT -> {
+                    koreaderSyncStrategyForward.value = KoreaderSyncConflictStrategy.PROMPT
+                    koreaderSyncStrategyBackward.value = KoreaderSyncConflictStrategy.PROMPT
+                }
+                KoreaderSyncLegacyStrategy.SILENT -> {
+                    koreaderSyncStrategyForward.value = KoreaderSyncConflictStrategy.KEEP_REMOTE // Remote is newer
+                    koreaderSyncStrategyBackward.value = KoreaderSyncConflictStrategy.KEEP_LOCAL  // Local is newer
+                }
+                KoreaderSyncLegacyStrategy.SEND -> {
+                    koreaderSyncStrategyForward.value = KoreaderSyncConflictStrategy.KEEP_LOCAL
+                    koreaderSyncStrategyBackward.value = KoreaderSyncConflictStrategy.KEEP_LOCAL
+                }
+                KoreaderSyncLegacyStrategy.RECEIVE -> {
+                    koreaderSyncStrategyForward.value = KoreaderSyncConflictStrategy.KEEP_REMOTE
+                    koreaderSyncStrategyBackward.value = KoreaderSyncConflictStrategy.KEEP_REMOTE
+                }
+                KoreaderSyncLegacyStrategy.DISABLED -> {
+                    koreaderSyncStrategyForward.value = KoreaderSyncConflictStrategy.DISABLED
+                    koreaderSyncStrategyBackward.value = KoreaderSyncConflictStrategy.DISABLED
+                }
+            }
+        },
+    )
+
+    val koreaderSyncStrategyForward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
+        protoNumber = 65,
+        group = SettingGroup.KOREADER_SYNC,
+        defaultValue = KoreaderSyncConflictStrategy.PROMPT,
+        enumClass = KoreaderSyncConflictStrategy::class,
+        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
+        description = "Strategy to apply when remote progress is newer than local.",
+    )
+
+    val koreaderSyncStrategyBackward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
+        protoNumber = 66,
+        group = SettingGroup.KOREADER_SYNC,
+        defaultValue = KoreaderSyncConflictStrategy.DISABLED,
+        enumClass = KoreaderSyncConflictStrategy::class,
+        typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
+        description = "Strategy to apply when remote progress is older than local.",
     )
 
     val koreaderSyncPercentageTolerance: MutableStateFlow<Double> by DoubleSetting(
-        protoNumber = 65,
+        protoNumber = 67,
         group = SettingGroup.KOREADER_SYNC,
         defaultValue = 0.000000000000001,
         min = 0.000000000000001,
@@ -617,28 +682,28 @@ class ServerConfig(
     )
 
     val jwtTokenExpiry: MutableStateFlow<Duration> by DurationSetting(
-        protoNumber = 66,
+        protoNumber = 68,
         group = SettingGroup.AUTH,
         defaultValue = 5.minutes,
         min = 0.seconds,
     )
 
     val jwtRefreshExpiry: MutableStateFlow<Duration> by DurationSetting(
-        protoNumber = 67,
+        protoNumber = 69,
         group = SettingGroup.AUTH,
         defaultValue = 60.days,
         min = 0.seconds,
     )
 
     val webUIEnabled: MutableStateFlow<Boolean> by BooleanSetting(
-        protoNumber = 68,
+        protoNumber = 70,
         group = SettingGroup.WEB_UI,
         defaultValue = true,
         requiresRestart = true,
     )
 
     val databaseType: MutableStateFlow<DatabaseType> by EnumSetting(
-        protoNumber = 69,
+        protoNumber = 71,
         group = SettingGroup.DATABASE,
         defaultValue = DatabaseType.H2,
         enumClass = DatabaseType::class,
@@ -646,19 +711,19 @@ class ServerConfig(
     )
 
     val databaseUrl: MutableStateFlow<String> by StringSetting(
-        protoNumber = 70,
+        protoNumber = 72,
         group = SettingGroup.DATABASE,
         defaultValue = "postgresql://localhost:5432/suwayomi",
     )
 
     val databaseUsername: MutableStateFlow<String> by StringSetting(
-        protoNumber = 71,
+        protoNumber = 73,
         group = SettingGroup.DATABASE,
         defaultValue = "",
     )
 
     val databasePassword: MutableStateFlow<String> by StringSetting(
-        protoNumber = 72,
+        protoNumber = 74,
         group = SettingGroup.DATABASE,
         defaultValue = "",
     )

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -678,7 +678,7 @@ class ServerConfig(
     )
 
     val webUIEnabled: MutableStateFlow<Boolean> by BooleanSetting(
-        protoNumber = 78,
+        protoNumber = 68,
         group = SettingGroup.WEB_UI,
         defaultValue = true,
         requiresRestart = true,


### PR DESCRIPTION
This PR refactors the KOReader sync strategy to provide more granular control over conflict resolution.

Previously, a single strategy setting was applied universally. Now, users can define separate strategies for two distinct scenarios:
1.  **Forward Sync:** When the remote progress is newer than the local progress.
2.  **Backward Sync:** When the remote progress is older than the local progress.

This is achieved by deprecating the old `koreaderSyncStrategy` and introducing two new settings: `koreaderSyncStrategyForward` and `koreaderSyncStrategyBackward`.

The `SILENT` option has been removed from the strategy enum because its behavior is now implicitly defined by the user's choices. For example:
- Setting `Forward` to `KEEP_REMOTE` and `Backward` to `KEEP_LOCAL` perfectly replicates the old `SILENT` behavior (always sync to the most recent timestamp).

All previous functionalities are retained and new, more complex combinations are now possible, giving users greater customization. Existing user settings are automatically migrated to the new system for a smooth transition.