### PR TITLE
feat(kosync): Add mutations for manual progress push and pull

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/KoreaderSyncMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/KoreaderSyncMutation.kt
@@ -1,14 +1,21 @@
 package suwayomi.tachidesk.graphql.mutations
 
+import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import suwayomi.tachidesk.graphql.asDataFetcherResult
 import suwayomi.tachidesk.graphql.server.getAttribute
+import suwayomi.tachidesk.graphql.types.ChapterType
 import suwayomi.tachidesk.graphql.types.KoSyncConnectPayload
 import suwayomi.tachidesk.graphql.types.LogoutKoSyncAccountPayload
 import suwayomi.tachidesk.graphql.types.SettingsType
+import suwayomi.tachidesk.graphql.types.SyncConflictInfoType
 import suwayomi.tachidesk.manga.impl.sync.KoreaderSyncService
+import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.future
-import suwayomi.tachidesk.server.JavalinSetup.getAttribute
 import suwayomi.tachidesk.server.user.requireUser
 import java.util.concurrent.CompletableFuture
 
@@ -52,5 +59,101 @@ class KoreaderSyncMutation {
                 success = true,
                 settings = SettingsType(),
             )
+        }
+
+    data class PushKoSyncProgressInput(
+        val clientMutationId: String? = null,
+        val chapterId: Int,
+    )
+
+    data class PushKoSyncProgressPayload(
+        val clientMutationId: String?,
+        val success: Boolean,
+        val chapter: ChapterType?,
+    )
+
+    fun pushKoSyncProgress(
+        dataFetchingEnvironment: DataFetchingEnvironment,
+        input: PushKoSyncProgressInput,
+    ): CompletableFuture<DataFetcherResult<PushKoSyncProgressPayload?>> =
+        future {
+            asDataFetcherResult {
+                dataFetchingEnvironment.getAttribute(Attribute.TachideskUser).requireUser()
+
+                KoreaderSyncService.pushProgress(input.chapterId)
+
+                val chapter =
+                    transaction {
+                        ChapterTable
+                            .selectAll()
+                            .where { ChapterTable.id eq input.chapterId }
+                            .firstOrNull()
+                            ?.let { ChapterType(it) }
+                    }
+
+                PushKoSyncProgressPayload(
+                    clientMutationId = input.clientMutationId,
+                    success = true,
+                    chapter = chapter,
+                )
+            }
+        }
+
+    data class PullKoSyncProgressInput(
+        val clientMutationId: String? = null,
+        val chapterId: Int,
+    )
+
+    data class PullKoSyncProgressPayload(
+        val clientMutationId: String?,
+        val chapter: ChapterType?,
+        val syncConflict: SyncConflictInfoType?,
+    )
+
+    fun pullKoSyncProgress(
+        dataFetchingEnvironment: DataFetchingEnvironment,
+        input: PullKoSyncProgressInput,
+    ): CompletableFuture<DataFetcherResult<PullKoSyncProgressPayload?>> =
+        future {
+            asDataFetcherResult {
+                dataFetchingEnvironment.getAttribute(Attribute.TachideskUser).requireUser()
+
+                val syncResult = KoreaderSyncService.checkAndPullProgress(input.chapterId)
+                var syncConflictInfo: SyncConflictInfoType? = null
+
+                if (syncResult != null) {
+                    if (syncResult.isConflict) {
+                        syncConflictInfo =
+                            SyncConflictInfoType(
+                                deviceName = syncResult.device,
+                                remotePage = syncResult.pageRead,
+                            )
+                    }
+
+                    if (syncResult.shouldUpdate) {
+                        transaction {
+                            ChapterTable.update({ ChapterTable.id eq input.chapterId }) {
+                                it[lastPageRead] = syncResult.pageRead
+                                it[lastReadAt] = syncResult.timestamp
+                            }
+                        }
+                    }
+                }
+
+                val chapter =
+                    transaction {
+                        ChapterTable
+                            .selectAll()
+                            .where { ChapterTable.id eq input.chapterId }
+                            .firstOrNull()
+                            ?.let { ChapterType(it) }
+                    }
+
+                PullKoSyncProgressPayload(
+                    clientMutationId = input.clientMutationId,
+                    chapter = chapter,
+                    syncConflict = syncConflictInfo,
+                )
+            }
         }
 }


### PR DESCRIPTION
This PR adds two new GraphQL mutations to manually trigger KOReader reading progress synchronization: `pushKoSyncProgress` and `pullKoSyncProgress`.

These mutations expose existing logic within the `KoreaderSyncService` to the GraphQL API, allowing any client to build UIs with manual sync controls.

-   **`pushKoSyncProgress(chapterId: Int!)`**: Triggers an immediate push of the local reading progress for a given chapter to the KOReader sync server.
-   **`pullKoSyncProgress(chapterId: Int!)`**: Fetches the latest progress from the sync server for a given chapter. It handles sync conflicts according to the user's settings and returns the updated chapter state.

### Motivation

This change is motivated by recent developments in client applications like **Readest** (as seen in commit `584f351`), which are moving KOReader Sync functionality into the reader view and adding manual triggers for a better user experience.

To support this and provide a richer, more interactive feature set across all clients, the Suwayomi-Server backend needs to expose this functionality. This aligns the server's capabilities with what is already possible in the official **KOReader `kosync` plugin** and empowers UI developers to give users more granular control over their data.

### How to Test

1.  Run the server with this branch.
2.  Navigate to the GraphiQL playground at `/api/graphql`.
3.  Ensure you have a chapter in your library and note its ID.
4.  Execute the `pushKoSyncProgress` mutation:
    ```graphql
    mutation PushProgress($chapterId: Int!) {
      pushKoSyncProgress(input: { chapterId: $chapterId }) {
        success
        chapter {
          id
          lastPageRead
        }
      }
    }
    ```
    *Variables:* `{ "chapterId": 1 }` (replace `1` with a valid chapter ID).
5.  Execute the `pullKoSyncProgress` mutation:
    ```graphql
    mutation PullProgress($chapterId: Int!) {
      pullKoSyncProgress(input: { chapterId: $chapterId }) {
        chapter {
          id
          lastPageRead
          lastReadAt
        }
        syncConflict {
          deviceName
          remotePage
        }
      }
    }
    ```
    *Variables:* `{ "chapterId": 1 }`
6.  Verify that both mutations execute successfully and return the expected payload.