### PR TITLE
Restore server settings first

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupImport.kt
@@ -197,22 +197,22 @@ object ProtoBackupImport : ProtoBackupBase() {
         val getRestoreAmount = { size: Int -> size + restoreCategories + restoreMeta + restoreSettings }
         val restoreAmount = getRestoreAmount(backup.backupManga.size)
 
-        updateRestoreState(id, BackupRestoreState.RestoringCategories(restoreCategories, restoreAmount))
+        updateRestoreState(
+            id,
+            BackupRestoreState.RestoringSettings(restoreSettings, restoreAmount),
+        )
+
+        BackupSettingsHandler.restore(backup.serverSettings)
+
+        updateRestoreState(id, BackupRestoreState.RestoringCategories(restoreSettings + restoreCategories, restoreAmount))
 
         val categoryMapping = restoreCategories(backup.backupCategories)
 
-        updateRestoreState(id, BackupRestoreState.RestoringMeta(restoreCategories + restoreMeta, restoreAmount))
+        updateRestoreState(id, BackupRestoreState.RestoringMeta(restoreSettings + restoreCategories + restoreMeta, restoreAmount))
 
         restoreGlobalMeta(backup.meta)
 
         restoreSourceMeta(backup.backupSources)
-
-        updateRestoreState(
-            id,
-            BackupRestoreState.RestoringSettings(restoreCategories + restoreMeta + restoreSettings, restoreAmount),
-        )
-
-        BackupSettingsHandler.restore(backup.serverSettings)
 
         // Store source mapping for error messages
         val sourceMapping = backup.getSourceMap()


### PR DESCRIPTION
The imported server settings might cause the active database to change. In case this happens, the backup was restored into the wrong database.