### PR TITLE
Add server-side subpath support for WebUI

### DIFF
--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -715,14 +715,6 @@ class ServerConfig(
         requiresRestart = true,
     )
 
-    val webUISubpath: MutableStateFlow<String> by StringSetting(
-        protoNumber = 75,
-        group = SettingGroup.WEB_UI,
-        defaultValue = "",
-        pattern = "^(/[a-zA-Z0-9._-]+)*$".toRegex(),
-        description = "Serve WebUI under a subpath (e.g., /manga). Leave empty for root path. Must start with / if specified.",
-    )
-
     val databaseType: MutableStateFlow<DatabaseType> by EnumSetting(
         protoNumber = 69,
         group = SettingGroup.DATABASE,
@@ -766,6 +758,16 @@ class ServerConfig(
         typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.KoreaderSyncConflictStrategy")),
         description = "Strategy to apply when remote progress is older than local.",
     )
+
+    val webUISubpath: MutableStateFlow<String> by StringSetting(
+        protoNumber = 75,
+        group = SettingGroup.WEB_UI,
+        defaultValue = "",
+        pattern = "^(/[a-zA-Z0-9._-]+)*$".toRegex(),
+        description = "Serve WebUI under a subpath (e.g., /manga). Leave empty for root path. Must start with / if specified.",
+        requiresRestart = true,
+    )
+
 
     /** ****************************************************************** **/
     /**                                                                    **/

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -715,6 +715,14 @@ class ServerConfig(
         requiresRestart = true,
     )
 
+    val webUISubpath: MutableStateFlow<String> by StringSetting(
+        protoNumber = 75,
+        group = SettingGroup.WEB_UI,
+        defaultValue = "",
+        pattern = "^(/[a-zA-Z0-9._-]+)*$".toRegex(),
+        description = "Serve WebUI under a subpath (e.g., /manga). Leave empty for root path. Must start with / if specified.",
+    )
+
     val databaseType: MutableStateFlow<DatabaseType> by EnumSetting(
         protoNumber = 69,
         group = SettingGroup.DATABASE,

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -7,12 +7,6 @@ package suwayomi.tachidesk.server
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import java.io.IOException
-import java.net.URLEncoder
-import java.util.*
-import java.util.concurrent.CompletableFuture
-import kotlin.concurrent.thread
-import kotlin.time.Duration.Companion.days
 import gg.jte.ContentType
 import gg.jte.TemplateEngine
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -49,6 +43,12 @@ import suwayomi.tachidesk.server.user.getUserFromWsContext
 import suwayomi.tachidesk.server.util.Browser
 import suwayomi.tachidesk.server.util.WebInterfaceManager
 import uy.kohesive.injekt.injectLazy
+import java.io.IOException
+import java.net.URLEncoder
+import java.util.Locale
+import java.util.concurrent.CompletableFuture
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.days
 
 object JavalinSetup {
     private val logger = KotlinLogging.logger {}
@@ -73,40 +73,43 @@ object JavalinSetup {
                     }
 
                     // Helper function to create a servable WebUI directory with subpath injection
-                    fun createServableWebUIRoot(): String = if (subpath.isNotBlank()) {
-                        val tempWebUIRoot = WebInterfaceManager.createServableWebUIDirectory()
+                    fun createServableWebUIRoot(): String =
+                        if (subpath.isNotBlank()) {
+                            val tempWebUIRoot = WebInterfaceManager.createServableWebUIDirectory()
 
-                        // Inject subpath configuration
-                        val indexHtmlPath = "$tempWebUIRoot/index.html"
-                        val indexHtmlFile = java.io.File(indexHtmlPath)
+                            // Inject subpath configuration
+                            val indexHtmlPath = "$tempWebUIRoot/index.html"
+                            val indexHtmlFile = java.io.File(indexHtmlPath)
 
-                        if (indexHtmlFile.exists()) {
-                            val originalIndexHtml = indexHtmlFile.readText()
+                            if (indexHtmlFile.exists()) {
+                                val originalIndexHtml = indexHtmlFile.readText()
 
-                            // Only inject if not already injected
-                            if (!originalIndexHtml.contains("window.__SUWAYOMI_CONFIG__")) {
-                                val configScript = """
-                                    <script>
-                                    window.__SUWAYOMI_CONFIG__ = {
-                                      webUISubpath: "$subpath"
-                                    };
-                                    </script>
-                                """.trimIndent()
+                                // Only inject if not already injected
+                                if (!originalIndexHtml.contains("window.__SUWAYOMI_CONFIG__")) {
+                                    val configScript =
+                                        """
+                                        <script>
+                                        window.__SUWAYOMI_CONFIG__ = {
+                                          webUISubpath: "$subpath"
+                                        };
+                                        </script>
+                                        """.trimIndent()
 
-                                val modifiedIndexHtml = originalIndexHtml.replace(
-                                    "</head>",
-                                    "$configScript</head>",
-                                )
+                                    val modifiedIndexHtml =
+                                        originalIndexHtml.replace(
+                                            "</head>",
+                                            "$configScript</head>",
+                                        )
 
-                                indexHtmlFile.writeText(modifiedIndexHtml)
+                                    indexHtmlFile.writeText(modifiedIndexHtml)
+                                }
                             }
-                        }
 
-                        tempWebUIRoot
-                    } else {
-                        // Use the original webUI root when no subpath
-                        applicationDirs.webUIRoot
-                    }
+                            tempWebUIRoot
+                        } else {
+                            // Use the original webUI root when no subpath
+                            applicationDirs.webUIRoot
+                        }
 
                     // Initial setup of a servable WebUI directory
                     val servableWebUIRoot = createServableWebUIRoot()
@@ -203,7 +206,6 @@ object JavalinSetup {
 
         val subpath = serverConfig.webUISubpath.value
         val loginPath = if (subpath.isNotBlank()) "$subpath/login.html" else "/login.html"
-
 
         app.get(loginPath) { ctx ->
             val locale: Locale = LocalizationHelper.ctxToLocale(ctx)

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -43,6 +43,7 @@ import suwayomi.tachidesk.server.user.getUserFromWsContext
 import suwayomi.tachidesk.server.util.Browser
 import suwayomi.tachidesk.server.util.WebInterfaceManager
 import uy.kohesive.injekt.injectLazy
+import java.io.File
 import java.io.IOException
 import java.net.URLEncoder
 import java.util.Locale
@@ -78,8 +79,7 @@ object JavalinSetup {
                             val tempWebUIRoot = WebInterfaceManager.createServableWebUIDirectory()
 
                             // Inject subpath configuration
-                            val indexHtmlPath = "$tempWebUIRoot/index.html"
-                            val indexHtmlFile = java.io.File(indexHtmlPath)
+                            val indexHtmlFile = File("$tempWebUIRoot/index.html")
 
                             if (indexHtmlFile.exists()) {
                                 val originalIndexHtml = indexHtmlFile.readText()

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/Browser.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/Browser.kt
@@ -18,7 +18,9 @@ object Browser {
 
     private fun getAppBaseUrl(): String {
         val appIP = if (serverConfig.ip.value == "0.0.0.0") "127.0.0.1" else serverConfig.ip.value
-        return "http://$appIP:${serverConfig.port.value}"
+        val baseUrl = "http://$appIP:${serverConfig.port.value}"
+        val subpath = serverConfig.webUISubpath.value
+        return if (subpath.isNotBlank()) "$baseUrl$subpath/" else baseUrl
     }
 
     fun openInBrowser() {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -155,6 +155,23 @@ object WebInterfaceManager {
         this.serveWebUI = serveWebUI
     }
 
+    fun createServableWebUIDirectory(): String {
+        val originalWebUIRoot = applicationDirs.webUIRoot
+        val tempWebUIRoot = "${applicationDirs.tempRoot}/webui-serve"
+
+        // Clean and create temp directory
+        File(tempWebUIRoot).deleteRecursively()
+        File(tempWebUIRoot).mkdirs()
+
+        // Copy entire WebUI directory to temp location
+        File(originalWebUIRoot).copyRecursively(File(tempWebUIRoot))
+
+        logger.info { "Created servable WebUI directory at: $tempWebUIRoot" }
+
+        // Return canonical path to avoid Jetty alias issues
+        return File(tempWebUIRoot).canonicalPath
+    }
+
     private fun setServedWebUIFlavor(flavor: WebUIFlavor) {
         preferences.edit().putString(SERVED_WEBUI_FLAVOR_KEY, flavor.uiName).apply()
     }


### PR DESCRIPTION
Enables server-side configuration for hosting WebUI under non-root URL paths (e.g., /manga) with automatic client injection.

## Changes
- Add webUISubpath configuration setting with regex validation
- Create temporary WebUI directory for subpath serving  
- Inject subpath config into index.html for client detection
- Support all WebUI flavors with subpath compatibility
- Update browser opening to use subpath URLs

Related to Suwayomi/Suwayomi-WebUI#174