### PR TITLE
Use new Kitsu search URL

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/kitsu/KitsuApi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/kitsu/KitsuApi.kt
@@ -276,7 +276,7 @@ class KitsuApi(
         private const val ALGOLIA_KEY_URL = "https://kitsu.app/api/edge/algolia-keys/media/"
 
         private const val ALGOLIA_APP_ID = "AWQO5J657S"
-        private const val ALGOLIA_URL = "https://$ALGOLIA_APP_ID-dsn.algolia.net/1/indexes/production_media/query/"
+        private const val ALGOLIA_URL = "https://$ALGOLIA_APP_ID-1.algolianet.com/1/indexes/production_media/query/"
         private const val ALGOLIA_FILTER =
             "&facetFilters=%5B%22kind%3Amanga%22%5D&attributesToRetrieve=" +
                 "%5B%22synopsis%22%2C%22averageRating%22%2C%22canonicalTitle%22%2C%22chapterCount%22%2C%22" +


### PR DESCRIPTION
The algolia URL changed recently, so now searching always returns "Remote host terminated the handshake"