### PR TITLE
Allow WebUI files to be located in a symlink

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -75,6 +75,7 @@ object JavalinSetup {
                     }
 
                     logger.info { "Serving web static files for ${serverConfig.webUIFlavor.value}" }
+                    config.aliasCheckForStaticFiles = new ContextHandler.ApproveAliases()
                     config.staticFiles.add(applicationDirs.webUIRoot, Location.EXTERNAL)
                     serveWebUI()
 


### PR DESCRIPTION
Allow WebUI files to be located in a symlink to support usage on immutable distros. Probably a dirty hack (there should be a way to fine-grain this instead of allowing all symlinks) but I just wish to see if this works.