### PR TITLE
Fix base path injection when serving from root

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -199,7 +199,7 @@ object WebInterfaceManager {
                 <script>
                     "// <<suwayomi-subpath-injection>>"
                     const baseTag = document.createElement('base');
-                    baseTag.href = location.origin + "${ServerSubpath.normalized()}/";
+                    baseTag.href = location.origin + "${ServerSubpath.asRootPath()}";
                     document.head.appendChild(baseTag);
                 </script>
                 """.trimIndent()


### PR DESCRIPTION
Without having a subpath defined, the base path incorrectly ended with two "/" instead of one