### PR TITLE
Move to Zulu JRE

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: Package JDK
         run: jlink --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.naming,java.prefs,java.scripting,java.se,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.attach,jdk.crypto.ec,jdk.jdi,jdk.management,jdk.net,jdk.random,jdk.unsupported,jdk.unsupported.desktop,jdk.zipfs --output suwa --strip-debug --no-man-pages --no-header-files --compress=2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -99,7 +99,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 21
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: Package JDK
         run: jlink --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.naming,java.prefs,java.scripting,java.se,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.attach,jdk.crypto.ec,jdk.jdi,jdk.management,jdk.net,jdk.random,jdk.unsupported,jdk.unsupported.desktop,jdk.zipfs --output suwa --strip-debug --no-man-pages --no-header-files --compress=2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This structure is chosen to
 ### Prerequisites
 You need these software packages installed in order to build the project
 
-- Java Development Kit version 21 or newer(we suggest using Temurin instead of Oracle JDK)
+- Java Development Kit version 21 or newer(we suggest using Zulu or Temurin instead of Oracle JDK)
 
 ### building the full-blown jar (Suwayomi-Server + Suwayomi-WebUI bundle)
 Run `./gradlew server:downloadWebUI server:shadowJar`, the resulting built jar file will be `server/build/Suwayomi-Server-vX.Y.Z-rxxx.jar`.

--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,16 @@
       "matchStrings": [
         "JRE_RELEASE=[\"'](?<currentValue>.+?)[\"']\\s+"
       ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "adoptium/temurin21-binaries",
-      "versioningTemplate": "regex:^jdk-?(?<major>\\d+).(?<minor>\\d+).+?(?<patch>[\\d+]+)$"
+      "datasourceTemplate": "custom.zulu",
+      "versioningTemplate": "regex:^(?<major>\\d+)\.(?<minor>\\d+)\.(?<patch>\\d+).*$"
     }
-  ]
+  ],
+  "customDatasources": {
+    "zulu": {
+      "defaultRegistryUrlTemplate": "https://api.azul.com/metadata/v1/zulu/packages?availability_types=ca&release_status=both&java_package_type=jre&crac_supported=false&javafx_bundled=false&java_version=21&arch=x86&os=linux&archive_type=zip&page_size=1000&include_fields=java_package_features,release_status,support_term,os,arch,hw_bitness,abi,java_package_type,javafx_bundled,sha256_hash,cpu_gen,size,archive_type,certifications,lib_c_type,crac_supported&page=1&azul_com=true",
+      "transformTemplates": [
+        "{\"releases\": $$.$join([$join($map(distro_version[[0..2]], $string), \".\"), \"_\", $join($map(java_version, $string), \".\")])}"
+      ]
+    }
+  }
 }

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -232,8 +232,10 @@ make_deb_package() {
   sed -i "s/\$pkgver/$RELEASE_VERSION/" "$RELEASE_NAME/$source_dir/debian/changelog"
   sed -i "s/\$pkgrel/1/"                "$RELEASE_NAME/$source_dir/debian/changelog"
 
-  sudo apt update
-  sudo apt install devscripts build-essential dh-exec
+  if [ "$CI" = true ]; then
+    sudo apt update
+    sudo apt install devscripts build-essential dh-exec
+  fi
   cd "$RELEASE_NAME/$source_dir/"
   dpkg-buildpackage --no-sign --build=all
   cd -
@@ -254,8 +256,10 @@ make_appimage() {
   cp "scripts/resources/appimage/AppRun" "$RELEASE_NAME/AppRun"
   chmod +x "$RELEASE_NAME/AppRun"
 
-  sudo apt update
-  sudo apt install libfuse2
+  if [ "$CI" = true ]; then
+    sudo apt update
+    sudo apt install libfuse2
+  fi
   curl -L $APPIMAGE_URL -o $APPIMAGE_TOOLNAME
   chmod +x $APPIMAGE_TOOLNAME
   ARCH=x86_64 ./$APPIMAGE_TOOLNAME "$RELEASE_NAME" "$RELEASE"

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -42,8 +42,9 @@ main() {
     gcc -fPIC -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -shared scripts/resources/catch_abort.c -lpthread -o scripts/resources/catch_abort.so
   fi
 
-  JRE_RELEASE="jre21.0.8"
-  ZULU_RELEASE="zulu21.44.17"
+  JRE_ZULU="21.44.17_21.0.8"
+  JRE_RELEASE="jre${JRE_ZULU#*_}" # e.g. jre21.0.8
+  ZULU_RELEASE="zulu${JRE_ZULU%_*}" # e.g. zulu21.44.17
 
   case "$OS" in
     debian-all)

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -232,7 +232,7 @@ make_deb_package() {
   sed -i "s/\$pkgver/$RELEASE_VERSION/" "$RELEASE_NAME/$source_dir/debian/changelog"
   sed -i "s/\$pkgrel/1/"                "$RELEASE_NAME/$source_dir/debian/changelog"
 
-  if [ "$CI" = true ]; then
+  if [ "${CI:-}" = true ]; then
     sudo apt update
     sudo apt install devscripts build-essential dh-exec
   fi
@@ -256,7 +256,7 @@ make_appimage() {
   cp "scripts/resources/appimage/AppRun" "$RELEASE_NAME/AppRun"
   chmod +x "$RELEASE_NAME/AppRun"
 
-  if [ "$CI" = true ]; then
+  if [ "${CI:-}" = true ]; then
     sudo apt update
     sudo apt install libfuse2
   fi
@@ -271,7 +271,7 @@ make_windows_bundle() {
   ##./bundler.sh: line 250: wine: command not found
 
   ## check if running under github actions
-  #if [ "$CI" = true ]; then
+  #if [ "${CI:-}" = true ]; then
     ## change electron executable's icon
     #sudo dpkg --add-architecture i386
     #wget -qO - https://dl.winehq.org/wine-builds/winehq.key \
@@ -302,7 +302,7 @@ make_windows_bundle() {
 }
 
 make_windows_package() {
-  if [ "$CI" = true ]; then
+  if [ "${CI:-}" = true ]; then
     sudo apt update
     sudo apt install -y wixl
   fi

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -42,6 +42,9 @@ main() {
     gcc -fPIC -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -shared scripts/resources/catch_abort.c -lpthread -o scripts/resources/catch_abort.so
   fi
 
+  JRE_RELEASE="jre21.0.8"
+  ZULU_RELEASE="zulu21.44.17"
+
   case "$OS" in
     debian-all)
       RELEASE="$RELEASE_NAME.deb"
@@ -49,11 +52,9 @@ main() {
       move_release_to_output_dir
       ;;
     appimage)
-      # https://github.com/adoptium/temurin21-binaries/releases/
-      JRE_RELEASE="jdk-21.0.8+9"
-      JRE="OpenJDK21U-jre_x64_linux_hotspot_$(echo "$JRE_RELEASE" | sed 's/jdk//;s/-//g;s/+/_/g').tar.gz"
-      JRE_DIR="$JRE_RELEASE-jre"
-      JRE_URL="https://github.com/adoptium/temurin21-binaries/releases/download/$JRE_RELEASE/$JRE"
+      JRE="$ZULU_RELEASE-ca-$JRE_RELEASE-linux_x64.zip"
+      JRE_DIR="${JRE%.*}"
+      JRE_URL="https://cdn.azul.com/zulu/bin/$JRE"
       setup_jre
 
       RELEASE="$RELEASE_NAME.AppImage"
@@ -67,11 +68,9 @@ main() {
       move_release_to_output_dir
       ;;
     linux-x64)
-      # https://github.com/adoptium/temurin21-binaries/releases/
-      JRE_RELEASE="jdk-21.0.8+9"
-      JRE="OpenJDK21U-jre_x64_linux_hotspot_$(echo "$JRE_RELEASE" | sed 's/jdk//;s/-//g;s/+/_/g').tar.gz"
-      JRE_DIR="$JRE_RELEASE-jre"
-      JRE_URL="https://github.com/adoptium/temurin21-binaries/releases/download/$JRE_RELEASE/$JRE"
+      JRE="$ZULU_RELEASE-ca-$JRE_RELEASE-linux_x64.zip"
+      JRE_DIR="${JRE%.*}"
+      JRE_URL="https://cdn.azul.com/zulu/bin/$JRE"
       ELECTRON="electron-$electron_version-linux-x64.zip"
       ELECTRON_URL="https://github.com/electron/electron/releases/download/$electron_version/$ELECTRON"
       download_electron
@@ -83,11 +82,9 @@ main() {
       move_release_to_output_dir
       ;;
     macOS-x64)
-      # https://github.com/adoptium/temurin21-binaries/releases/
-      JRE_RELEASE="jdk-21.0.8+9"
-      JRE="OpenJDK21U-jre_x64_mac_hotspot_$(echo "$JRE_RELEASE" | sed 's/jdk//;s/-//g;s/+/_/g').tar.gz"
-      JRE_DIR="$JRE_RELEASE-jre"
-      JRE_URL="https://github.com/adoptium/temurin21-binaries/releases/download/$JRE_RELEASE/$JRE"
+      JRE="$ZULU_RELEASE-ca-$JRE_RELEASE-macosx_x64.zip"
+      JRE_DIR="${JRE%.*}"
+      JRE_URL="https://cdn.azul.com/zulu/bin/$JRE"
       ELECTRON="electron-$electron_version-darwin-x64.zip"
       ELECTRON_URL="https://github.com/electron/electron/releases/download/$electron_version/$ELECTRON"
       download_electron
@@ -99,11 +96,9 @@ main() {
       move_release_to_output_dir
       ;;
     macOS-arm64)
-      # https://github.com/adoptium/temurin21-binaries/releases/
-      JRE_RELEASE="jdk-21.0.8+9"
-      JRE="OpenJDK21U-jre_aarch64_mac_hotspot_$(echo "$JRE_RELEASE" | sed 's/jdk//;s/-//g;s/+/_/g').tar.gz"
-      JRE_DIR="$JRE_RELEASE-jre"
-      JRE_URL="https://github.com/adoptium/temurin21-binaries/releases/download/$JRE_RELEASE/$JRE"
+      JRE="$ZULU_RELEASE-ca-$JRE_RELEASE-macosx_aarch64.zip"
+      JRE_DIR="${JRE%.*}"
+      JRE_URL="https://cdn.azul.com/zulu/bin/$JRE"
       ELECTRON="electron-$electron_version-darwin-arm64.zip"
       ELECTRON_URL="https://github.com/electron/electron/releases/download/$electron_version/$ELECTRON"
       download_electron
@@ -115,11 +110,9 @@ main() {
       move_release_to_output_dir
       ;;
     windows-x64)
-      # https://github.com/adoptium/temurin21-binaries/releases/
-      JRE_RELEASE="jdk-21.0.8+9"
-      JRE="OpenJDK21U-jre_x64_windows_hotspot_$(echo "$JRE_RELEASE" | sed 's/jdk//;s/-//g;s/+/_/g').zip"
-      JRE_DIR="$JRE_RELEASE-jre"
-      JRE_URL="https://github.com/adoptium/temurin21-binaries/releases/download/$JRE_RELEASE/$JRE"
+      JRE="$ZULU_RELEASE-ca-$JRE_RELEASE-win_x64.zip"
+      JRE_DIR="${JRE%.*}"
+      JRE_URL="https://cdn.azul.com/zulu/bin/$JRE"
       ELECTRON="electron-$electron_version-win32-x64.zip"
       ELECTRON_URL="https://github.com/electron/electron/releases/download/$electron_version/$ELECTRON"
       download_electron

--- a/scripts/resources/Suwayomi Launcher.bat
+++ b/scripts/resources/Suwayomi Launcher.bat
@@ -1,1 +1,1 @@
-start "" jre/bin/javaw -jar Suwayomi-Launcher.jar
+start "" jre/bin/javaw --add-exports=java.desktop/sun.awt=ALL-UNNAMED -jar Suwayomi-Launcher.jar

--- a/scripts/resources/Suwayomi Launcher.command
+++ b/scripts/resources/Suwayomi Launcher.command
@@ -1,3 +1,3 @@
 cd "`dirname "$0"`"
 
-./jre/bin/java -jar Suwayomi-Launcher.jar
+./jre/bin/java --add-exports=java.desktop/sun.awt=ALL-UNNAMED -jar Suwayomi-Launcher.jar

--- a/scripts/resources/deb/control
+++ b/scripts/resources/deb/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/Suwayomi/Suwayomi-Server
 
 Package: suwayomi-server
 Architecture: all
-Depends: ${misc:Depends}, openjdk-21-jre | openjdk-21-jre-headless | openjdk-21-jdk | openjdk-21-jdk-headless | temurin-21-jre | temurin-21-jdk | zulu21-jre | zulu21-jre-headless | zulu21-jdk | zulu21-jdk-headless | msopenjdk-21 | java-21-amazon-corretto-jdk
+Depends: ${misc:Depends}, zulu21-jre | zulu21-jre-headless | zulu21-jdk | zulu21-jdk-headless | openjdk-21-jre | openjdk-21-jre-headless | openjdk-21-jdk | openjdk-21-jdk-headless | temurin-21-jre | temurin-21-jdk | msopenjdk-21 | java-21-amazon-corretto-jdk
 Description: Manga Reader
  A free and open source manga reader server that runs extensions built for Tachiyomi.
  Suwayomi is an independent Tachiyomi compatible software and is not a Fork of Tachiyomi.

--- a/scripts/resources/suwayomi-launcher.sh
+++ b/scripts/resources/suwayomi-launcher.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec ./jre/bin/java -jar ./Suwayomi-Launcher.jar
+exec ./jre/bin/java --add-exports=java.desktop/sun.awt=ALL-UNNAMED -jar ./Suwayomi-Launcher.jar


### PR DESCRIPTION
Tested on: Ubuntu 24.04 (x64, as AppImage and .tar.gz), Windows 10 (x64) and macOS Sequoia (x64).
Since I have no ARM devices, arm64 testing is not done and still open.

Tested things:
- General usage (reading, browsing, ...)
- Extensions which generate images (#1455, #1562, #1572)
- Image conversion (#1505)
- WebView (#1434)
- Tracking Kitsu
- Authentication

Let me know if there is more to test.
I've added `--add-exports=java.desktop/sun.awt=ALL-UNNAMED`, since otherwise Launcher crashes when using Dropdowns.

Known regressions: Webview on macOS does not load, due to `cannot access class sun.awt.AWTAccessor` which is fixed by adding `--add-exports=java.desktop/sun.awt=ALL-UNNAMED` to the launch command in Suwayomi-Launcher.

Since Zulu includes much more recent certificates, this already fixes #1600 on all platforms. Adding `-Djavax.net.ssl.trustStoreType=WINDOWS-ROOT -Djavax.net.ssl.trustStore=NUL` (Windows) / `-Djavax.net.ssl.trustStoreType=KeychainStore -Djavax.net.ssl.trustStore=/Library/Keychains/System.keychain` (macOS) might still be a good next step to add in the Launcher (or at least mention those in the wiki).