### PR TITLE
Add way to exclude settings from backups

### DIFF
--- a/server/server-config-generate/src/main/kotlin/suwayomi/tachidesk/server/settings/generation/SettingsBackupSettingsHandlerGenerator.kt
+++ b/server/server-config-generate/src/main/kotlin/suwayomi/tachidesk/server/settings/generation/SettingsBackupSettingsHandlerGenerator.kt
@@ -88,6 +88,12 @@ object SettingsBackupSettingsHandlerGenerator {
                     ") as? ${getSettingType(setting, false)},",
             )
         }
+        val excludedSettings = settings.filter { it.excludeFromBackup == true }
+        excludedSettings.forEach { setting ->
+            appendLine(
+                "${setting.name} = null,".addIndentation(indentation * 4),
+            )
+        }
         appendLine("),".addIndentation(indentation * 3))
         appendLine(")".addIndentation(contentIndentation))
         appendLine("}".addIndentation(indentation))
@@ -126,6 +132,9 @@ object SettingsBackupSettingsHandlerGenerator {
     }
 
     private fun getConfigAccess(setting: SettingsRegistry.SettingMetadata): String {
+        if (setting.excludeFromBackup == true) {
+            return "null"
+        }
         if (setting.typeInfo.convertToBackupType != null) {
             return "SettingsRegistry.get(\"${setting.name}\")!!.typeInfo.convertToBackupType!!(" +
                 "serverConfig.${setting.name}.value" +

--- a/server/server-config-generate/src/main/kotlin/suwayomi/tachidesk/server/settings/generation/SettingsBackupSettingsHandlerGenerator.kt
+++ b/server/server-config-generate/src/main/kotlin/suwayomi/tachidesk/server/settings/generation/SettingsBackupSettingsHandlerGenerator.kt
@@ -132,7 +132,7 @@ object SettingsBackupSettingsHandlerGenerator {
     }
 
     private fun getConfigAccess(setting: SettingsRegistry.SettingMetadata): String {
-        if (setting.excludeFromBackup == true) {
+        if (setting.excludeFromBackup == true || setting.deprecated != null) {
             return "null"
         }
         if (setting.typeInfo.convertToBackupType != null) {

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -77,6 +77,7 @@ class ServerConfig(
         group = SettingGroup.NETWORK,
         defaultValue = "0.0.0.0",
         pattern = "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$".toRegex(),
+        excludeFromBackup = true,
     )
 
     val port: MutableStateFlow<Int> by IntSetting(
@@ -85,6 +86,7 @@ class ServerConfig(
         defaultValue = 4567,
         min = 1,
         max = 65535,
+        excludeFromBackup = true,
     )
 
     val socksProxyEnabled: MutableStateFlow<Boolean> by BooleanSetting(
@@ -153,6 +155,7 @@ class ServerConfig(
         group = SettingGroup.WEB_UI,
         defaultValue = "",
         mustExist = true,
+        excludeFromBackup = true,
     )
 
     val webUIChannel: MutableStateFlow<WebUIChannel> by EnumSetting(
@@ -183,6 +186,7 @@ class ServerConfig(
         group = SettingGroup.DOWNLOADER,
         defaultValue = "",
         mustExist = true,
+        excludeFromBackup = true,
     )
 
     val autoDownloadNewChapters: MutableStateFlow<Boolean> by BooleanSetting(
@@ -386,6 +390,7 @@ class ServerConfig(
         group = SettingGroup.BACKUP,
         defaultValue = "",
         mustExist = true,
+        excludeFromBackup = true,
     )
 
     val backupTime: MutableStateFlow<String> by StringSetting(
@@ -417,6 +422,7 @@ class ServerConfig(
         group = SettingGroup.LOCAL_SOURCE,
         defaultValue = "",
         mustExist = true,
+        excludeFromBackup = true,
     )
 
     val flareSolverrEnabled: MutableStateFlow<Boolean> by BooleanSetting(
@@ -724,24 +730,28 @@ class ServerConfig(
         defaultValue = DatabaseType.H2,
         enumClass = DatabaseType::class,
         typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.DatabaseType")),
+        excludeFromBackup = true,
     )
 
     val databaseUrl: MutableStateFlow<String> by StringSetting(
         protoNumber = 70,
         group = SettingGroup.DATABASE,
         defaultValue = "postgresql://localhost:5432/suwayomi",
+        excludeFromBackup = true,
     )
 
     val databaseUsername: MutableStateFlow<String> by StringSetting(
         protoNumber = 71,
         group = SettingGroup.DATABASE,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val databasePassword: MutableStateFlow<String> by StringSetting(
         protoNumber = 72,
         group = SettingGroup.DATABASE,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val koreaderSyncStrategyForward: MutableStateFlow<KoreaderSyncConflictStrategy> by EnumSetting(
@@ -769,6 +779,7 @@ class ServerConfig(
         pattern = "^(/[a-zA-Z0-9._-]+)*$".toRegex(),
         description = "Serve WebUI under a subpath (e.g., /manga). Leave empty for root path. Must start with / if specified.",
         requiresRestart = true,
+        excludeFromBackup = true,
     )
 
 

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -523,6 +523,7 @@ class ServerConfig(
         defaultValue = AuthMode.NONE,
         enumClass = AuthMode::class,
         typeInfo = SettingsRegistry.PartialTypeInfo(imports = listOf("suwayomi.tachidesk.graphql.types.AuthMode")),
+        excludeFromBackup = true,
     )
 
     val downloadConversions: MutableStateFlow<Map<String, DownloadConversion>> by MapSetting<String, DownloadConversion>(

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -119,12 +119,14 @@ class ServerConfig(
         protoNumber = 7,
         group = SettingGroup.PROXY,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val socksProxyPassword: MutableStateFlow<String> by StringSetting(
         protoNumber = 8,
         group = SettingGroup.PROXY,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val webUIFlavor: MutableStateFlow<WebUIFlavor> by EnumSetting(
@@ -330,12 +332,14 @@ class ServerConfig(
         protoNumber = 30,
         group = SettingGroup.AUTH,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val authPassword: MutableStateFlow<String> by StringSetting(
         protoNumber = 31,
         group = SettingGroup.AUTH,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val debugLogsEnabled: MutableStateFlow<Boolean> by BooleanSetting(
@@ -597,12 +601,14 @@ class ServerConfig(
         protoNumber = 60,
         group = SettingGroup.KOREADER_SYNC,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val koreaderSyncUserkey: MutableStateFlow<String> by StringSetting(
         protoNumber = 61,
         group = SettingGroup.KOREADER_SYNC,
         defaultValue = "",
+        excludeFromBackup = true,
     )
 
     val koreaderSyncDeviceId: MutableStateFlow<String> by StringSetting(

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -429,6 +429,7 @@ class ServerConfig(
         protoNumber = 43,
         defaultValue = false,
         group = SettingGroup.CLOUDFLARE,
+        excludeFromBackup = true,
     )
 
     val flareSolverrUrl: MutableStateFlow<String> by StringSetting(

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingDelegate.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingDelegate.kt
@@ -29,6 +29,7 @@ open class SettingDelegate<T : Any>(
     protected val typeInfo: SettingsRegistry.PartialTypeInfo? = null,
     protected val deprecated: SettingsRegistry.SettingDeprecated? = null,
     protected val description: String? = null,
+    protected val excludeFromBackup: Boolean? = null,
 ) {
     var flow: MutableStateFlow<T>? = null
     lateinit var propertyName: String
@@ -82,6 +83,7 @@ open class SettingDelegate<T : Any>(
                             defaultValueComment
                         }
                     },
+                excludeFromBackup = excludeFromBackup
             ),
         )
 
@@ -171,6 +173,7 @@ class MigratedConfigValue<T : Any>(
                 group = group.value,
                 deprecated = deprecated,
                 requiresRestart = requiresRestart ?: false,
+                excludeFromBackup = null,
             ),
         )
 
@@ -211,6 +214,7 @@ class StringSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<String>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -234,6 +238,7 @@ class StringSetting(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 abstract class RangeSetting<T : Comparable<T>>(
@@ -248,6 +253,7 @@ abstract class RangeSetting<T : Comparable<T>>(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<T>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -280,6 +286,7 @@ abstract class RangeSetting<T : Comparable<T>>(
                     defaultDescription
                 }
             },
+        excludeFromBackup = excludeFromBackup,
     )
 
 class IntSetting(
@@ -293,6 +300,7 @@ class IntSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : RangeSetting<Int>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -304,6 +312,7 @@ class IntSetting(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 class DisableableIntSetting(
@@ -315,6 +324,7 @@ class DisableableIntSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : RangeSetting<Int>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -349,6 +359,7 @@ class DisableableIntSetting(
                     description
                 }
             },
+        excludeFromBackup = excludeFromBackup,
     )
 
 class DoubleSetting(
@@ -362,6 +373,7 @@ class DoubleSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : RangeSetting<Double>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -373,6 +385,7 @@ class DoubleSetting(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 class DisableableDoubleSetting(
@@ -384,6 +397,7 @@ class DisableableDoubleSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : RangeSetting<Double>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -418,6 +432,7 @@ class DisableableDoubleSetting(
                     description
                 }
             },
+        excludeFromBackup = excludeFromBackup,
     )
 
 class BooleanSetting(
@@ -427,6 +442,7 @@ class BooleanSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<Boolean>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -435,6 +451,7 @@ class BooleanSetting(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 class PathSetting(
@@ -445,6 +462,7 @@ class PathSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<String>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -459,6 +477,7 @@ class PathSetting(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 class EnumSetting<T : Enum<T>>(
@@ -470,6 +489,7 @@ class EnumSetting<T : Enum<T>>(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<T>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -494,6 +514,7 @@ class EnumSetting<T : Enum<T>>(
                     defaultDescription
                 }
             },
+        excludeFromBackup = excludeFromBackup,
     )
 
 class DurationSetting(
@@ -507,6 +528,7 @@ class DurationSetting(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : RangeSetting<Duration>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -522,6 +544,7 @@ class DurationSetting(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 class ListSetting<T>(
@@ -534,6 +557,7 @@ class ListSetting<T>(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<List<T>>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -558,6 +582,7 @@ class ListSetting<T>(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )
 
 class MapSetting<K, V>(
@@ -569,6 +594,7 @@ class MapSetting<K, V>(
     deprecated: SettingsRegistry.SettingDeprecated? = null,
     requiresRestart: Boolean? = null,
     description: String? = null,
+    excludeFromBackup: Boolean? = null,
 ) : SettingDelegate<Map<K, V>>(
         protoNumber = protoNumber,
         defaultValue = defaultValue,
@@ -578,4 +604,5 @@ class MapSetting<K, V>(
         deprecated = deprecated,
         requiresRestart = requiresRestart,
         description = description,
+        excludeFromBackup = excludeFromBackup,
     )

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsRegistry.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsRegistry.kt
@@ -72,6 +72,7 @@ object SettingsRegistry {
         val deprecated: SettingDeprecated? = null,
         val requiresRestart: Boolean,
         val description: String? = null,
+        val excludeFromBackup: Boolean? = null,
     )
 
     private val settings = mutableMapOf<String, SettingMetadata>()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupExport.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/ProtoBackupExport.kt
@@ -154,7 +154,7 @@ object ProtoBackupExport : ProtoBackupBase() {
         automatedBackupDir.listFiles { file -> file.name.startsWith(Backup.getBasename(AUTO_BACKUP_FILENAME)) }?.forEach { file ->
             try {
                 cleanupAutomatedBackupFile(file)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // ignore, will be retried on next cleanup
             }
         }
@@ -310,10 +310,6 @@ object ProtoBackupExport : ProtoBackupBase() {
                     backupManga.tracking = tracks
                 }
             }
-
-//            if (flags.includeHistory) {
-//                backupManga.history = TODO()
-//            }
 
             backupManga
         }


### PR DESCRIPTION
Added a way to exclude settings from getting backed-up or restored.

Also exclude deprecated settings from being written to the backup.

Currently excluded settings:
- `server.ip`
- `server.port`
- `server.electronPath`
- `server.webUISubpath`
- `server.downloadsPath`
- `server.localSourcePath`
- `server.databaseType`
- `server.databaseUrl`
- `server.databaseUsername`
- `server.databasePassword`
- `server.flaresolverrEnabled`
- `server.socksProxyUsername`
- `server.socksProxyPassword`
- `server.authUsername`
- `server.authPassword`
- `server.koreaderSyncUsername`
- `server.koreaderSyncUserkey`
- `server.authMode`

More settings to be discussed.