### PR TITLE
Use canonical path for static files directory

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -161,7 +161,8 @@ object WebInterfaceManager {
 
         config.staticFiles.add { staticFiles ->
             if (ServerSubpath.isDefined()) staticFiles.hostedPath = ServerSubpath.normalized()
-            staticFiles.directory = applicationDirs.webUIServe
+            // Use canonical path to avoid Jetty alias issues
+            staticFiles.directory = File(applicationDirs.webUIServe).canonicalPath
             staticFiles.location = Location.EXTERNAL
         }
 


### PR DESCRIPTION
On mac the temp system folder is a symlink which jetty does not allow by default due to security reasons. This caused the webui files to not get served on mac.