### PR TITLE
Add `--adds-opens` JVM args to access `sun.awt` module on MacOS

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -196,6 +196,21 @@ tasks {
         }
     }
 
+    withType<JavaExec> {
+        jvmArgs(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+            "--add-opens=java.desktop/sun.java2d=ALL-UNNAMED",
+            "--add-opens=java.desktop/java.awt.peer=ALL-UNNAMED"
+        )
+        if (System.getProperty("os.name").contains("Mac")) {
+            jvmArgs(
+                "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
+                "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED"
+            )
+        }
+    }
+
     named<Copy>("processResources") {
         duplicatesStrategy = DuplicatesStrategy.INCLUDE
         mustRunAfter("downloadWebUI")


### PR DESCRIPTION
Fixes: https://github.com/Suwayomi/Suwayomi-Server/issues/1717

When running the server in debug mode, during the `createImmediately()` call in [KcefWebView:loadUrl](https://github.com/Suwayomi/Suwayomi-Server/blob/cdb98d2175db80a15ed87138dbe18675c05c6d61/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt#L295), the following exception is thrown in `org/eclipse/jetty/websocket/core/internal/messages/StringMessageSink.java`:

> java.lang.IllegalAccessError: class org.cef.browser.mac.CefBrowserWindowMac (in unnamed module @0x2acf57e3) cannot access class sun.awt.AWTAccessor (in module java.desktop) because module java.desktop does not export sun.awt to unnamed module @0x2acf57e3

Googling around led me to this [GitHub issue](https://github.com/KevinnZou/compose-webview-multiplatform/issues/235) which I used as a basis for this fix. I tested the fix in my local using debug server run and a full jar build for `macOS-arm64`.

Webview after fix:
<img width="1920" height="1080" alt="Screenshot 2025-10-12 at 3 38 12 PM" src="https://github.com/user-attachments/assets/382e00d8-f5ae-436a-b408-564218532f60" />
