### PR TITLE
Actually set Track ID when updating track

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/Track.kt
@@ -414,8 +414,9 @@ object Track {
                     }.singleOrNull()
 
             if (existingRecord != null) {
+                track.id = existingRecord[TrackRecordTable.id].value
                 updateTrackRecord(track)
-                existingRecord[TrackRecordTable.id].value
+                track.id!!
             } else {
                 insertTrackRecord(track)
             }


### PR DESCRIPTION
Fixes updating the tracked manga title (i.e. `remoteId` changes)

As reported on discord