### PR TITLE
feat(koreader): Set public server as default for KOReader Sync

### DIFF
--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -202,7 +202,7 @@ server.opdsChapterSortOrder = "DESC"
 
 ### KOReader Sync
 ```
-server.koreaderSyncServerUrl = "http://localhost:17200"
+server.koreaderSyncServerUrl = "https://sync.koreader.rocks/"
 server.koreaderSyncUsername = ""
 server.koreaderSyncUserkey = ""
 server.koreaderSyncDeviceId = ""
@@ -211,7 +211,7 @@ server.koreaderSyncPercentageTolerance = 1.0E-15 # range: [1.0E-15, 1.0]
 server.koreaderSyncStrategyForward = PROMPT # PROMPT, KEEP_LOCAL, KEEP_REMOTE, DISABLED
 server.koreaderSyncStrategyBackward = DISABLED # PROMPT, KEEP_LOCAL, KEEP_REMOTE, DISABLED
 ```
-- `server.koreaderSyncServerUrl` where KOReader Sync Server is running.
+- `server.koreaderSyncServerUrl` where KOReader Sync Server is running. Public servers (e.g.,  `https://sync.koreader.rocks/`, `https://kosync.ak-team.com:3042/`) or self-hosted instances can also be used.
 - `server.koreaderSyncUsername` the username with which to authenticate at the KOReader instance.
 - `server.koreaderSyncUserkey` the password/key with which to authenticate at the KOReader instance.
 - `server.koreaderSyncDeviceId` a unique ID to identify Suwayomi at the KOReader Sync Server. Leave blank to auto-generate.

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -599,7 +599,8 @@ class ServerConfig(
     val koreaderSyncServerUrl: MutableStateFlow<String> by StringSetting(
         protoNumber = 59,
         group = SettingGroup.KOREADER_SYNC,
-        defaultValue = "http://localhost:17200",
+        defaultValue = "https://sync.koreader.rocks/",
+        description = "KOReader Sync Server URL. Public alternative: https://kosync.ak-team.com:3042/",
     )
 
     val koreaderSyncUsername: MutableStateFlow<String> by StringSetting(


### PR DESCRIPTION
This PR updates the default KOReader Sync server from `http://localhost:17200` to the official public server `https://sync.koreader.rocks/`.

The previous `localhost` default is not practical for most users and requires manual configuration to get started. By using a public, functional server as the default, we provide a better out-of-the-box experience.

An alternative public server, `https://kosync.ak-team.com:3042/`, is also mentioned in the configuration file and documentation as a secondary option.

#### Changes:

*   **`server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt`**:
    *   Updated the `defaultValue` for `koreaderSyncServerUrl` to `https://sync.koreader.rocks/`.
    *   Added a description mentioning the alternative public server.

*   **`docs/Configuring-Suwayomi‐Server.md`**:
    *   Updated the default value in the KOReader Sync configuration example.
    *   Expanded the description for `server.koreaderSyncServerUrl` to clarify the new default and mention other public options.

In the future, we could consider making this a selectable list of public/custom servers in the UI, but for now, just changing the default and documenting an alternative seems like a good, simple improvement. I didn't have time to open this PR earlier, but here it is.
