### PR TITLE
Settings generator: Validate that protoNumber is unique

### DIFF
--- a/server/server-config-generate/src/main/kotlin/suwayomi/tachidesk/server/settings/generation/SettingsGenerator.kt
+++ b/server/server-config-generate/src/main/kotlin/suwayomi/tachidesk/server/settings/generation/SettingsGenerator.kt
@@ -45,6 +45,8 @@ object SettingsGenerator {
                     // Ignore errors during registration
                 }
             }
+        } catch (e: IllegalStateException) {
+            throw e
         } catch (e: Exception) {
             // Registration failed, but we tried
         }

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsRegistry.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsRegistry.kt
@@ -2,6 +2,7 @@ package suwayomi.tachidesk.server.settings
 
 import com.typesafe.config.ConfigValue
 import com.typesafe.config.parser.ConfigDocument
+import kotlin.collections.find
 import kotlin.reflect.KClass
 
 /**
@@ -78,6 +79,9 @@ object SettingsRegistry {
     private val settings = mutableMapOf<String, SettingMetadata>()
 
     fun register(metadata: SettingMetadata) {
+        settings.values.find { it.protoNumber == metadata.protoNumber }?.let {
+            throw IllegalStateException("Setting ${metadata.name} uses protoNumber ${it.protoNumber} already used by ${it.name}")
+        }
         settings[metadata.name] = metadata
     }
 


### PR DESCRIPTION
This makes specifying an already-used number a compile time error