### PR TITLE
Add --change-stack-guard-on-fork=disable to fix stack smashing

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -527,7 +527,13 @@ fun applicationSetup() {
                 }
                 appHandler(
                     KCEF.AppHandler(
-                        arrayOf("--disable-gpu", "--off-screen-rendering-enabled", "--disable-dev-shm-usage", "--enable-widevine-cdm"),
+                        arrayOf(
+                            "--disable-gpu",
+                            "--off-screen-rendering-enabled",
+                            "--disable-dev-shm-usage",
+                            "--enable-widevine-cdm",
+                            "--change-stack-guard-on-fork=disable",
+                        ),
                     ),
                 )
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -529,9 +529,13 @@ fun applicationSetup() {
                     KCEF.AppHandler(
                         arrayOf(
                             "--disable-gpu",
+                            // #1486 needed to be able to render without a window
                             "--off-screen-rendering-enabled",
+                            // #1489 since /dev/shm is restricted in docker (OOM)
                             "--disable-dev-shm-usage",
+                            // #1723 support Widevine (incomplete)
                             "--enable-widevine-cdm",
+                            // #1736 JCEF does implement stack guards properly
                             "--change-stack-guard-on-fork=disable",
                         ),
                     ),


### PR DESCRIPTION
This should fix frequent stack smashing messages. In my testing, these occured when 2 or more instances of CEF browser were open at the same time. Most easily reproducible by opening the webview endpoint and using an extension that requires webview.

See chromiumembedded/cef#3912

I would argue that this is a bug in JCEF, since they are missing the `NO_STACK_PROTECTOR` that CEF requires, but it might also be related to our usage.