### PR TITLE
[#1749] Only consider path in SIMPLE_LOGIN redirect

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -199,7 +199,8 @@ object JavalinSetup {
             }
 
             if (authMode == AuthMode.SIMPLE_LOGIN && !cookieValid() && !isApi) {
-                val url = "$loginPath?redirect=" + URLEncoder.encode(ctx.fullUrl(), Charsets.UTF_8)
+                val url =
+                    "$loginPath?redirect=" + URLEncoder.encode(ctx.path() + (ctx.queryString()?.let { "?" + it } ?: ""), Charsets.UTF_8)
                 ctx.header("Location", url)
                 throw RedirectResponse(HttpStatus.SEE_OTHER)
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -42,6 +42,7 @@ import suwayomi.tachidesk.server.util.Browser
 import suwayomi.tachidesk.server.util.ServerSubpath
 import suwayomi.tachidesk.server.util.WebInterfaceManager
 import java.io.IOException
+import java.net.URI
 import java.net.URLEncoder
 import java.util.Locale
 import java.util.concurrent.CompletableFuture
@@ -149,6 +150,10 @@ object JavalinSetup {
 
             if (isValid) {
                 val redirect = ctx.queryParam("redirect") ?: ServerSubpath.maybeAddAsPrefix("/")
+                val uri = URI(redirect)
+                if (uri.host != null || uri.scheme != null) {
+                    throw IllegalArgumentException("Given redirect is not relative, refusing")
+                }
                 // NOTE: We currently have no session handler attached.
                 // Thus, all sessions are stored in memory and not persisted.
                 // Furthermore, default session timeout appears to be 30m


### PR DESCRIPTION
We don't really care about the origin, since that is implicit in `Location` headers if not given, which sidesteps the HTTP/HTTPS issue

Closes #1749