### PR TITLE
Include jogamp native files in all bundles

### DIFF
--- a/scripts/resources/appimage/AppRun
+++ b/scripts/resources/appimage/AppRun
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+cd "$APPDIR"
 exec $APPDIR/jre/bin/java -jar $APPDIR/bin/Suwayomi-Server.jar

--- a/scripts/resources/deb/install
+++ b/scripts/resources/deb/install
@@ -2,6 +2,7 @@
 
 Suwayomi-Server.jar         usr/share/java/suwayomi-server/bin/
 Suwayomi-Launcher.jar       usr/share/java/suwayomi-server/
+natives/*                   usr/share/java/suwayomi-server/natives/
 suwayomi-server.png         usr/share/pixmaps/
 suwayomi-server.desktop     usr/share/applications/
 suwayomi-launcher.desktop   usr/share/applications/

--- a/scripts/resources/msi/suwayomi-server-x64.wxs
+++ b/scripts/resources/msi/suwayomi-server-x64.wxs
@@ -17,6 +17,7 @@
         <Directory Id="INSTALLDIR" Name="Suwayomi-Server" >
           <Directory Id="jre"/>
           <Directory Id="electron"/>
+          <Directory Id="natives"/>
           <Directory Id="bin"/>
         </Directory>
       </Directory>
@@ -62,6 +63,7 @@
       <ComponentRef Id="SuwayomiLauncherBAT" />
       <ComponentRef Id="ProgramMenuDir" />
       <ComponentGroupRef Id="electron" />
+      <ComponentGroupRef Id="natives" />
     </Feature>
 
     <Icon Id="Suwayomi.ico" SourceFile="$(var.Icon)" />

--- a/scripts/resources/pkg/suwayomi-server.sh
+++ b/scripts/resources/pkg/suwayomi-server.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 export LD_PRELOAD="/usr/share/java/suwayomi-server/bin/catch_abort.so"
+cd /usr/share/java/suwayomi-server/
 
 if [ -z "$DISPLAY" ] && command -v Xvfb >/dev/null; then
   echo "-- START: Spawning X server using xvfb-run --"


### PR DESCRIPTION
Fixes `java.lang.UnsatisfiedLinkError: Couldn't load library 'gluegen_rt' generically including [...]` as reported on discord

I don't have any arm64 devices to test the arm deb install nor the arm macos bundle, but they should be working fine, since it follows Jogamp bundling.

I also bundle the .so's in the .deb even though Debian and Ubuntu both provide packages, since their installation is not easily configured (see docker; maybe a symlink would be possible? but depending on version it's [`/usr/lib/jni/libgluegen2_rt.so`](https://packages.ubuntu.com/questing/amd64/libgluegen2-jni/filelist) or [`/usr/lib/jni/libgluegen2-rt.so`](https://packages.ubuntu.com/jammy/amd64/libgluegen2-jni/filelist)). Note that this does increase the bundle size to 188M