### PR TITLE
Ensure webui static resources folder exists before serving it

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -160,6 +160,8 @@ object WebInterfaceManager {
             return
         }
 
+        File(applicationDirs.webUIServe).mkdirs()
+
         config.staticFiles.add { staticFiles ->
             if (ServerSubpath.isDefined()) staticFiles.hostedPath = ServerSubpath.normalized()
             // Use canonical path to avoid Jetty alias issues


### PR DESCRIPTION
When the webUI got opened before the setup was completed, the missing folder caused an exception and broke the javalin server. In that case, even after the webui setup completed, the server just returned the index.html for every path