### PR TITLE
Optionally allow basic auth fallback for chapter page endpoint

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -457,6 +457,7 @@ object MangaController {
             pathParam<Int>("index"),
             queryParam<Boolean?>("updateProgress"),
             queryParam<String?>("format"),
+            queryParam<Boolean?>("opds"),
             documentWith = {
                 withOperation {
                     summary("Get a chapter page")
@@ -465,8 +466,13 @@ object MangaController {
                     )
                 }
             },
-            behaviorOf = { ctx, mangaId, chapterIndex, index, updateProgress, format ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
+            behaviorOf = { ctx, mangaId, chapterIndex, index, updateProgress, format, opds ->
+                if (opds == true) {
+                    ctx.getAttribute(Attribute.TachideskUser).requireUserWithBasicFallback(ctx)
+                } else {
+                    ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                }
+
                 ctx.future {
                     future {
                         Page.getPageImage(

--- a/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/opds/impl/OpdsEntryBuilder.kt
@@ -365,7 +365,7 @@ object OpdsEntryBuilder {
         if (chapter.pageCount > 0) {
             val basePageHref =
                 "/api/v1/manga/${manga.id}/chapter/${chapter.sourceOrder}/page/{pageNumber}" +
-                    "?updateProgress=${serverConfig.opdsEnablePageReadProgress.value}"
+                    "?updateProgress=${serverConfig.opdsEnablePageReadProgress.value}&opds=true"
 
             val title: String =
                 when {


### PR DESCRIPTION
Requesting a chapter page while having a non basic auth mode (e.g. ui login) enabled caused the basic auth prompt.
However, this is only supposed to be happen for opds