### PR TITLE
Overwrite existing served webui files on copy

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -224,7 +224,7 @@ object WebInterfaceManager {
         File(tempWebUIRoot).deleteRecursively()
         File(tempWebUIRoot).mkdirs()
 
-        File(originalWebUIRoot).copyRecursively(File(tempWebUIRoot))
+        File(originalWebUIRoot).copyRecursively(File(tempWebUIRoot), overwrite = true)
 
         logger.debug { "Created servable WebUI directory at: $tempWebUIRoot" }
 


### PR DESCRIPTION
There is a possibility that the serve folder was only partially deleted. This then could cause "FileAlreadyExistsException" when copying the webui files to the serve folder.