### PR TITLE
Provide webui update timestamp in about webui gql query

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/WebUIUpdateType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/WebUIUpdateType.kt
@@ -3,6 +3,7 @@ package suwayomi.tachidesk.graphql.types
 data class AboutWebUI(
     val channel: WebUIChannel,
     val tag: String,
+    val updateTimestamp: Long,
 )
 
 data class WebUIUpdateCheck(

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -84,6 +84,7 @@ object WebInterfaceManager {
 
     private const val LAST_WEBUI_UPDATE_CHECK_KEY = "lastWebUIUpdateCheck"
     private const val SERVED_WEBUI_FLAVOR_KEY = "servedWebUIFlavor"
+    private const val VERSION_UPDATE_TIMESTAMP_KEY = "webUIVersionUpdateTimestamp"
 
     private val preferences = Injekt.get<Application>().getSharedPreferences("server_util", Context.MODE_PRIVATE)
     private var currentUpdateTaskId: String = ""
@@ -141,6 +142,7 @@ object WebInterfaceManager {
         return AboutWebUI(
             channel = serverConfig.webUIChannel.value,
             tag = currentVersion,
+            updateTimestamp = preferences.getLong(VERSION_UPDATE_TIMESTAMP_KEY, System.currentTimeMillis()),
         )
     }
 
@@ -476,6 +478,7 @@ object WebInterfaceManager {
         log.info { "An update is available, starting download..." }
         try {
             downloadVersion(flavor, getLatestCompatibleVersion(flavor))
+            preferences.edit().putLong(VERSION_UPDATE_TIMESTAMP_KEY, System.currentTimeMillis()).apply()
             serveWebUI()
         } catch (e: Exception) {
             log.warn(e) { "failed due to" }


### PR DESCRIPTION
Makes it possible for the client to determine if a forced page refresh is required to ensure up-to-date webui files are being used