### PR TITLE
Fix updating server settings

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsUpdater.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsUpdater.kt
@@ -25,14 +25,7 @@ object SettingsUpdater {
             if (property != null) {
                 val stateFlow = property.get(serverConfig)
 
-                val maybeConvertedValue =
-                    SettingsRegistry
-                        .get(name)
-                        ?.typeInfo
-                        ?.convertToInternalType
-                        ?.invoke(value) ?: value
-
-                val validationError = SettingsValidator.validate(name, maybeConvertedValue)
+                val validationError = SettingsValidator.validate(name, value)
                 val isValid = validationError == null
 
                 if (!isValid) {
@@ -40,6 +33,13 @@ object SettingsUpdater {
 
                     return
                 }
+
+                val maybeConvertedValue =
+                    SettingsRegistry
+                        .get(name)
+                        ?.typeInfo
+                        ?.convertToInternalType
+                        ?.invoke(value) ?: value
 
                 // Normal update - MigratedConfigValue handles deprecated mappings automatically
                 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
The server setting updater passed an already converted value to the setting validator, which then tried to convert the value again, which caused an error

Regression aa8d27f6792576d091350acac678ac74296cf45a