### PR TITLE
Bump deprecated publish workflow MacOS Version

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -86,11 +86,11 @@ jobs:
             name: linux-x64
           - os: windows-latest
             name: windows-x64
-          - os: macos-14
+          - os: macos-15
             name: macOS-arm64
-          - os: macos-13
+          - os: macos-15-intel
             name: macOS-x64
-        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15, macos-15-intel]
 
     steps:
       - name: Set up JDK

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,11 +88,11 @@ jobs:
             name: linux-x64
           - os: windows-latest
             name: windows-x64
-          - os: macos-14
+          - os: macos-15
             name: macOS-arm64
-          - os: macos-13
+          - os: macos-15-intel
             name: macOS-x64
-        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15, macos-15-intel]
 
     steps:
       - name: Set up JDK


### PR DESCRIPTION
https://github.com/KolbyML/Mangatan/actions/runs/20049639604

<img width="1293" height="157" alt="image" src="https://github.com/user-attachments/assets/ebb72189-9991-49b7-80e2-9a24478742a2" />

The publish CI will currently fail due to using a deprecated MacOS github ci verison
