### PR TITLE
Minor updates to Docs

### DIFF
--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -6,8 +6,7 @@ The configuration file is written in HOCON. Google is your friend if you want to
 
 ## Troubleshooting
 ### I messed up my configuration file
-- The reference configuration file can be found [here](https://github.com/Suwayomi/Suwayomi-Server/blob/master/server/src/main/resources/server-reference.conf) replace your whole configuration or erroneous keys referring to it.
-- Suwayomi will create a default configuration file when one doesn't exist, you can delete `server.conf` to get a copy of the reference configuration file after a restart.
+Suwayomi will create a default configuration file when one doesn't exist, you can delete `server.conf` to get a copy of the reference configuration file after a restart.
 
 ### I am running Suwayomi in a headless environment (docker, NAS, VPS, etc.)
 - Set `server.systemTrayEnabled` to false, it will prevent Suwayomi to attempt to create a System Tray icon.

--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -254,8 +254,7 @@ server.useHikariConnectionPool = true
 
 **Note:** The example [docker-compose.yml file](https://github.com/Suwayomi/Suwayomi-Server-docker/blob/main/docker-compose.yml) contains everything you need to get started with Suwayomi+PostgreSQL. Please be aware that PostgreSQL support is currently still in beta.
 
-> [!CAUTION]
-> Be careful when restoring backups if you change these options! Server settings may be included in the backup, so restoring a backup with those settings may unintentionally switch your setup to a different database than intended.
+**Note:** These settings are excluded from backups, so a backup can be used to easily switch database installations by setting up the connection first, then restoring the backup.
 
 ## Overriding configuration options with command-line arguments
 You can override the above configuration options with command-line arguments. 


### PR DESCRIPTION
- Remove link to reference config as we don't include that any more
- Update outdated note regarding backup in Database section

If desired, I could document for each setting whether it is excluded from backup. For now, I only added the note in the DB section, since it's most relevant there.