### PR TITLE
fix: Do not return inputStream from conversion & handle conversion error

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -296,7 +296,7 @@ object Page {
             )
         if (conversionWriter == null) {
             logger.warn { "Conversion aborted: No reader for target format ${target.target}" }
-            return inputStream to sourceMimeType
+            return null
         }
 
         val (writer, writerParams) = conversionWriter
@@ -310,7 +310,7 @@ object Page {
                 writer.write(null, IIOImage(inImage, null, null), writerParams)
             }
         } catch (e: Exception) {
-            logger.warn(e) { "Conversion aborted" }
+            logger.warn(e) { "Conversion aborted ($sourceMimeType -> ${target.target})" }
             return null
         } finally {
             writer.dispose()

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -169,7 +169,9 @@ object Page {
                 )
             } catch (e: Exception) {
                 logger.error(e) { "Error while post-processing image" }
-                null
+                // re-open cached image in case of an error, since conversion likely (partially) consumed the input stream
+                // so it's likely not possible to serve it
+                getPageImage(mangaId = mangaId, chapterIndex = chapterIndex, index = index)
             }
         return converted?.also { inputStream.close() } ?: (inputStream to mime)
     }
@@ -269,11 +271,12 @@ object Page {
 
                     return processedStream to mime
                 }
+                throw Exception("HTTP-service did not return a usable stream")
             } catch (e: Exception) {
                 // HTTP post-processing failed, continue with original image
                 logger.warn(e) { "Error while post-processing image" }
+                throw e
             }
-            return null
         } else {
             if (mime == conversion.target) {
                 return null
@@ -311,12 +314,12 @@ object Page {
             }
         } catch (e: Exception) {
             logger.warn(e) { "Conversion aborted ($sourceMimeType -> ${target.target})" }
-            return null
+            throw e
         } finally {
             writer.dispose()
         }
         val inStream = ByteArrayInputStream(outStream.toByteArray())
-        return Pair(inStream.buffered(), target.target)
+        return inStream.buffered() to target.target
     }
 
     private fun getConversionWriter(


### PR DESCRIPTION
The serve conversion was implemented such that error cases did not work:
- No suitable reader: The inputstream was returned, but the caller closes the input stream if one is returned, since it assumes that conversion produces a new image. We should return `null` instead to signal to the caller that it should return the original (untouched) stream
- Conversion fails: E.g. when converting an ARGB-valued PNG to JPEG, the writer will fail. This will only happen after the input stream is consumed (since it has to attempt to convert), so the caller now attempts to return a dead stream (stream already closed exception from Javalin). Instead all code paths that may attempt to read from the input should instead throw on error, and the caller can then re-initialize the stream from the page


The former case may be tested by loading an image and supplying an invalid `format` query parameter.  
The latter may be tested by loading an ARGB image (e.g. one generated by DM5 for comments) and attempting a JPEG conversion.