### PR TITLE
Add enableCookieApi flag to allow for WebView's on mobile support

### DIFF
--- a/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/AndroidCompatInitializer.kt
+++ b/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/AndroidCompatInitializer.kt
@@ -11,7 +11,7 @@ import xyz.nulldev.ts.config.GlobalConfigManager
  * Initializes the Android compatibility module
  */
 class AndroidCompatInitializer {
-    fun init() {
+    fun init(kcefEnabled: Boolean) {
         // Register config modules
         GlobalConfigManager.registerModules(
             FilesConfigModule.register(GlobalConfigManager.config),
@@ -19,7 +19,9 @@ class AndroidCompatInitializer {
             SystemConfigModule.register(GlobalConfigManager.config),
         )
 
-        WebView.setProviderFactory({ view: WebView -> KcefWebViewProvider(view) })
+        if (kcefEnabled) {
+            WebView.setProviderFactory({ view: WebView -> KcefWebViewProvider(view) })
+        }
 
         // Set some properties extensions use
         System.setProperty(

--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -71,6 +71,12 @@ server.kcefEnable = true
 ```
 - `server.kcefEnable` controls if KCEF WebView provider is enabled.
 
+### Network
+```
+server.enableCookieApi = true
+```
+- `server.enableCookieApi = true` enables the `/api/v1/cookie` endpoint for syncing cookies from external webviews. This is useful for sources that require login via webview, as it allows the webview to share cookies with Suwayomi-Server. Or bypassing Cloudflare challenges that require a webview to solve.
+
 
 ### Downloader
 ```

--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -52,6 +52,7 @@ server.webUIFlavor = "WebUI" # "WebUI" or "Custom"
 server.webUIChannel = preview # "BUNDLED" or "STABLE" or "PREVIEW"
 server.webUIUpdateCheckInterval = 23
 server.webUISubpath = ""
+server.kcefEnable = true
 ```
 - `server.webUIEnabled` controls if Suwayomi will serve `Suwayomi-WebUI` and if it downloads/updates it on startup.
 - `server.initialOpenInBrowserEnabled` controls if Suwayomi will attempt to open a brwoser/electron window on startup, disabling this on headless servers is recommended.
@@ -62,6 +63,7 @@ server.webUISubpath = ""
 - `server.webUIChannel` allows to choose which update channel to use (only valid when flavor is set to "WebUI"). Use `"BUNDLED"` to use the version included in the server download, `"STABLE"` to use the latest stable release or `"PREVIEW"` to use the latest preview release (potentially buggy).
 - `server.webUIUpdateCheckInterval` the interval time in hours at which to check for updates. Use `0` to disable update checking.
 - `server.webUISubpath` controls on which sub-path the UI is served; by default, it will be accessible on `/` (i.e. directly), with this setting it can also be set to appear at e.g. `/suwayomi`
+- `server.kcefEnable` controls if KCEF WebView provider is enabled.
 
 ### Downloader
 ```

--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -65,6 +65,13 @@ server.kcefEnable = true
 - `server.webUISubpath` controls on which sub-path the UI is served; by default, it will be accessible on `/` (i.e. directly), with this setting it can also be set to appear at e.g. `/suwayomi`
 - `server.kcefEnable` controls if KCEF WebView provider is enabled.
 
+### webView
+```
+server.kcefEnable = true
+```
+- `server.kcefEnable` controls if KCEF WebView provider is enabled.
+
+
 ### Downloader
 ```
 server.downloadAsCbz = true

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -1016,6 +1016,13 @@ class ServerConfig(
         description = "Use Hikari Connection Pool to connect to the database.",
     )
 
+    val kcefEnable: MutableStateFlow<Boolean> by BooleanSetting(
+        protoNumber = 86,
+        group = SettingGroup.WEB_UI,
+        privacySafe = true,
+        defaultValue = false,
+        requiresRestart = true,
+    )
 
 
     /** ****************************************************************** **/

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -1018,7 +1018,7 @@ class ServerConfig(
 
     val kcefEnable: MutableStateFlow<Boolean> by BooleanSetting(
         protoNumber = 86,
-        group = SettingGroup.WEB_UI,
+        group = SettingGroup.WEB_VIEW,
         privacySafe = true,
         defaultValue = false,
         requiresRestart = true,

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -1024,6 +1024,13 @@ class ServerConfig(
         requiresRestart = true,
     )
 
+    val enableCookieApi: MutableStateFlow<Boolean> by BooleanSetting(
+        protoNumber = 87,
+        group = SettingGroup.NETWORK,
+        privacySafe = true,
+        defaultValue = false,
+        description = "Enable the /api/v1/cookie endpoint for syncing cookies from external webviews."
+    )    
 
     /** ****************************************************************** **/
     /**                                                                    **/

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingGroup.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingGroup.kt
@@ -17,6 +17,7 @@ enum class SettingGroup(
     CLOUDFLARE("Cloudflare"),
     OPDS("OPDS"),
     KOREADER_SYNC("KOReader sync"),
+    WEB_VIEW("WebView"),
     ;
 
     override fun toString(): String = value

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/GlobalAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/GlobalAPI.kt
@@ -14,6 +14,7 @@ import io.javalin.apibuilder.ApiBuilder.ws
 import suwayomi.tachidesk.global.controller.GlobalMetaController
 import suwayomi.tachidesk.global.controller.SettingsController
 import suwayomi.tachidesk.global.controller.WebViewController
+import suwayomi.tachidesk.server.serverConfig
 
 object GlobalAPI {
     fun defineEndpoints() {
@@ -25,9 +26,11 @@ object GlobalAPI {
             get("about", SettingsController.about)
             get("check-update", SettingsController.checkUpdate)
         }
-        path("webview") {
-            get("", WebViewController.webview)
-            ws("", WebViewController::webviewWS)
+        if (serverConfig.kcefEnable.value) {
+            path("webview") {
+                get("", WebViewController.webview)
+                ws("", WebViewController::webviewWS)
+            }
         }
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/GlobalAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/GlobalAPI.kt
@@ -10,7 +10,9 @@ package suwayomi.tachidesk.global
 import io.javalin.apibuilder.ApiBuilder.get
 import io.javalin.apibuilder.ApiBuilder.patch
 import io.javalin.apibuilder.ApiBuilder.path
+import io.javalin.apibuilder.ApiBuilder.post
 import io.javalin.apibuilder.ApiBuilder.ws
+import suwayomi.tachidesk.global.controller.CookieController
 import suwayomi.tachidesk.global.controller.GlobalMetaController
 import suwayomi.tachidesk.global.controller.SettingsController
 import suwayomi.tachidesk.global.controller.WebViewController
@@ -25,6 +27,11 @@ object GlobalAPI {
         path("settings") {
             get("about", SettingsController.about)
             get("check-update", SettingsController.checkUpdate)
+        }
+        if (serverConfig.enableCookieApi.value) {
+            path("cookie") {
+                post("", CookieController.updateCookies)
+            }
         }
         if (serverConfig.kcefEnable.value) {
             path("webview") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/controller/CookieController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/controller/CookieController.kt
@@ -1,0 +1,69 @@
+package suwayomi.tachidesk.global.controller
+
+import eu.kanade.tachiyomi.network.NetworkHelper
+import io.javalin.http.Context
+import kotlinx.coroutines.launch
+import okhttp3.Cookie
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import suwayomi.tachidesk.server.mutableConfigValueScope
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+object CookieController {
+    data class CookieInput(
+        val name: String,
+        val value: String,
+        val domain: String,
+        val path: String? = "/",
+        val secure: Boolean = false,
+        val httpOnly: Boolean = false,
+        val expiresAt: Long? = null,
+    )
+
+    data class UpdateCookiesRequest(
+        val cookies: List<CookieInput>,
+        val userAgent: String? = null,
+    )
+
+    val updateCookies: (Context) -> Unit = { ctx ->
+        val body = ctx.bodyAsClass(UpdateCookiesRequest::class.java)
+        val networkHelper = Injekt.get<NetworkHelper>()
+
+        if (!body.userAgent.isNullOrBlank()) {
+            mutableConfigValueScope.launch {
+            }
+        }
+
+        val cookieStore = networkHelper.cookieStore
+
+        val cookiesByDomain = body.cookies.groupBy { it.domain }
+
+        cookiesByDomain.forEach { (domain, inputs) ->
+            val url = "http://${domain.removePrefix(".")}".toHttpUrlOrNull() ?: return@forEach
+
+            val okCookies =
+                inputs.map { input ->
+                    Cookie
+                        .Builder()
+                        .name(input.name)
+                        .value(input.value)
+                        .domain(input.domain.removePrefix("."))
+                        .path(input.path ?: "/")
+                        .apply {
+                            if (input.secure) secure()
+                            if (input.httpOnly) httpOnly()
+                            if (input.expiresAt != null) expiresAt(input.expiresAt)
+                            if (input.domain.startsWith(".")) {
+                                domain(input.domain.removePrefix("."))
+                            } else {
+                                hostOnlyDomain(input.domain)
+                            }
+                        }.build()
+                }
+
+            cookieStore.addAll(url, okCookies)
+        }
+
+        ctx.status(200).json(mapOf("success" to true, "count" to body.cookies.size))
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/WebView.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/WebView.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.eclipse.jetty.websocket.api.CloseStatus
 import suwayomi.tachidesk.manga.impl.update.Websocket
+import suwayomi.tachidesk.server.serverConfig
 
 object WebView : Websocket<String>() {
     private val logger = KotlinLogging.logger {}
@@ -19,7 +20,7 @@ object WebView : Websocket<String>() {
             clients.forEach { it.value.closeSession(CloseStatus(1001, "Other client connected")) }
             clients.clear()
         }
-        if (driver == null) {
+        if (driver == null && serverConfig.kcefEnable.value) {
             driver = KcefWebView()
         }
         super.addClient(ctx)

--- a/server/src/test/kotlin/suwayomi/tachidesk/test/ApplicationTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/test/ApplicationTest.kt
@@ -92,7 +92,7 @@ open class ApplicationTest {
             handleAppMutex()
 
             // Load Android compatibility dependencies
-            AndroidCompatInitializer().init()
+            AndroidCompatInitializer().init(serverConfig.kcefEnable.value)
             // start app
             androidCompat.startApp(app)
 


### PR DESCRIPTION
This PR should be merged first
- https://github.com/Suwayomi/Suwayomi-Server/pull/1856

This PR makes it possible for 3rd party webview's can be used. This is required for mobile as kcef isn't supported on iOS or Android.

With this PR and my other one I can support webviews on mobile :partying_face: 

This PR can be tested with
```
curl -X POST http://localhost:4567/api/v1/cookie   -H "Content-Type: application/json"   -d '{
    "userAgent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36",
    "cookies": [
      {
        "name": "cf_clearance",
        "value": "example_token_value_123",
        "domain": ".example.com",
        "path": "/",
        "secure": true,
        "httpOnly": true,
        "expiresAt": 1775000000000
      }
    ]
  }'
```