### PR TITLE
catch_abort: Remove java interop & catch SIGILL

### DIFF
--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -39,7 +39,7 @@ main() {
   download_launcher
 
   if [ ! -f scripts/resources/catch_abort.so ]; then
-    gcc -fPIC -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -shared scripts/resources/catch_abort.c -lpthread -o scripts/resources/catch_abort.so
+    gcc -fPIC -shared scripts/resources/catch_abort.c -lpthread -o scripts/resources/catch_abort.so
   fi
 
   JRE_ZULU="25.30.17_25.0.1"

--- a/scripts/resources/catch_abort.c
+++ b/scripts/resources/catch_abort.c
@@ -1,35 +1,12 @@
 // Linux only:
-// Attempts to catch SIGTRAP, inform Java, then exit the thread instead of bringing down the whole process
+// Attempts to catch SIGTRAP and exit the thread instead of bringing down the whole process
 
 #define _GNU_SOURCE
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <dlfcn.h>
 #include <signal.h>
 #include <pthread.h>
 #include <execinfo.h>
-
-#include <jni.h>
-
-JavaVM *g_vm;
-
-void load_vm() {
-  if (g_vm) return;
-  JavaVM *vms[1];
-  jsize n = 0;
-  // JNI_OnLoad won't be called when loaded via LD_PRELOAD, so attempt to find the VM now
-  if (JNI_GetCreatedJavaVMs(vms, 1, &n) == JNI_OK && n > 0) {
-    g_vm = vms[0];
-  }
-}
-
-jint throwThreadDeath(JNIEnv *env, char *message) {
-  char *className = "java/lang/UnknownError";
-  jclass exClass = (*env)->FindClass(env, className);
-  if (exClass == NULL) return JNI_ERR;
-  return (*env)->ThrowNew(env, exClass, message);
-}
 
 void signalHandler(int signum, siginfo_t* si, void* uc) {
   void *retaddrs[64];
@@ -37,16 +14,6 @@ void signalHandler(int signum, siginfo_t* si, void* uc) {
   printf("\n### ABORT :: Backtrace: ###\n");
   backtrace_symbols_fd(retaddrs, n, STDERR_FILENO);
   printf("### ABORT :: Exiting this thread. If this causes problems, please report the above backtrace to Suwayomi. ###\n\n");
-
-  load_vm();
-  if (g_vm) {
-    JNIEnv *env;
-    jint getEnvStat = (*g_vm)->GetEnv(g_vm, (void**) &env, JNI_VERSION_1_2);
-    if (getEnvStat == JNI_EDETACHED) (*g_vm)->AttachCurrentThread(g_vm, (void**) &env, NULL);
-    jint exStat = throwThreadDeath(env, "SIGTRAP caught");
-    if (exStat != 0) printf("Exception throwing failed: %d\n", exStat);
-    (*g_vm)->DetachCurrentThread(g_vm);
-  }
   pthread_exit(NULL);
 }
 

--- a/scripts/resources/catch_abort.c
+++ b/scripts/resources/catch_abort.c
@@ -26,4 +26,7 @@ void dlmain() {
   if (sigaction(SIGTRAP, &sa, NULL) != 0) {
     printf("[FATAL] sigaction failed\n");
   }
+  if (sigaction(SIGILL, &sa, NULL) != 0) {
+    printf("[FATAL] sigaction failed\n");
+  }
 }


### PR DESCRIPTION
The Java stuff wasn't working anyway (we kill the thread) and more likely to cause problems itself

SIGILL is raised by CEF on some platforms via `ud2`