### PR TITLE
fix: support for `POST` requests on `CloudflareInterceptor`

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -208,9 +208,10 @@ object CFClearance {
                                                 },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
-                                            postData = if (originalRequest.method == "POST") {
-                                                originalRequest.body?.let { encodeToString(it) }
-                                            } else null,
+                                            postData = if (originalRequest.method == "POST" && originalRequest.body is FormBody) {
+                                                Buffer().also { (originalRequest.body as FormBody).writeTo(it) }
+                                                    .readUtf8()
+                                            } else null
                                         ),
                                     ).toRequestBody(jsonMediaType),
                         ),

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Cookie
+import okhttp3.FormBody
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -23,6 +24,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
 import suwayomi.tachidesk.server.serverConfig
 import uy.kohesive.injekt.injectLazy
 import java.io.IOException

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -210,10 +210,14 @@ object CFClearance {
                                                 },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
-                                            postData = if (originalRequest.method == "POST" && originalRequest.body is FormBody) {
-                                                Buffer().also { (originalRequest.body as FormBody).writeTo(it) }
-                                                    .readUtf8()
-                                            } else null
+                                            postData =
+                                                if (originalRequest.method == "POST" && originalRequest.body is FormBody) {
+                                                    Buffer()
+                                                        .also { (originalRequest.body as FormBody).writeTo(it) }
+                                                        .readUtf8()
+                                                } else {
+                                                    null
+                                                },
                                         ),
                                     ).toRequestBody(jsonMediaType),
                         ),
@@ -244,11 +248,9 @@ object CFClearance {
                                 if (!cookie.path.isNullOrEmpty()) it.path(cookie.path)
                                 // We need to convert the expires time to milliseconds for the persistent cookie store
                                 if (cookie.expires != null && cookie.expires > 0) it.expiresAt((cookie.expires * 1000).toLong())
-                                if (!cookie.domain.startsWith('.')) it.hostOnlyDomain(
-                                    cookie.domain.removePrefix(
-                                        ".",
-                                    ),
-                                )
+                                if (!cookie.domain.startsWith('.')) {
+                                    it.hostOnlyDomain(cookie.domain.removePrefix("."))
+                                }
                             }.build()
                     }.groupBy { it.domain }
                     .flatMap { (domain, cookies) ->

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.network.interceptor
 
-import com.alibaba.fastjson2.toJSONString
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
@@ -187,7 +186,6 @@ object CFClearance {
         onlyCookies: Boolean,
     ): FlareSolverResponse {
         val timeout = serverConfig.flareSolverrTimeout.value.seconds
-
         return with(json) {
             mutex.withLock {
                 client.value
@@ -208,7 +206,7 @@ object CFClearance {
                                                 },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
-                                            postData = if (originalRequest.method == "POST") originalRequest.body.toJSONString() else null,
+                                            postData = if (originalRequest.method == "POST") originalRequest.body?.let { encodeToString(it) } else null,
                                         ),
                                     ).toRequestBody(jsonMediaType),
                         ),

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.network.interceptor
 
+import com.alibaba.fastjson2.toJSONString
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
@@ -14,7 +15,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.Cookie
 import okhttp3.HttpUrl
@@ -198,7 +198,7 @@ object CFClearance {
                                 Json
                                     .encodeToString(
                                         FlareSolverRequest(
-                                            "request.get",
+                                            "request.${originalRequest.method.lowercase()}",
                                             originalRequest.url.toString(),
                                             session = serverConfig.flareSolverrSessionName.value,
                                             sessionTtlMinutes = serverConfig.flareSolverrSessionTtl.value,
@@ -208,6 +208,7 @@ object CFClearance {
                                                 },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
+                                            postData = if (originalRequest.method == "POST") originalRequest.body.toJSONString() else null,
                                         ),
                                     ).toRequestBody(jsonMediaType),
                         ),

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -69,7 +69,8 @@ class CloudflareInterceptor(
                     flareResponse.solution.status in 200..299 &&
                     flareResponse.solution.response != null
                 ) {
-                    val isImage = flareResponse.solution.response.contains(CHROME_IMAGE_TEMPLATE_REGEX)
+                    val isImage =
+                        flareResponse.solution.response.contains(CHROME_IMAGE_TEMPLATE_REGEX)
                     if (!isImage) {
                         logger.debug { "Falling back to FlareSolverr response" }
 
@@ -86,7 +87,8 @@ class CloudflareInterceptor(
                 }
             }
 
-            val request = CFClearance.requestWithFlareSolverr(flareResponse, setUserAgent, originalRequest)
+            val request =
+                CFClearance.requestWithFlareSolverr(flareResponse, setUserAgent, originalRequest)
 
             chain.proceed(request)
         } catch (e: Exception) {
@@ -206,7 +208,9 @@ object CFClearance {
                                                 },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
-                                            postData = if (originalRequest.method == "POST") originalRequest.body?.let { encodeToString(it) } else null,
+                                            postData = if (originalRequest.method == "POST") {
+                                                originalRequest.body?.let { encodeToString(it) }
+                                            } else null,
                                         ),
                                     ).toRequestBody(jsonMediaType),
                         ),
@@ -237,7 +241,11 @@ object CFClearance {
                                 if (!cookie.path.isNullOrEmpty()) it.path(cookie.path)
                                 // We need to convert the expires time to milliseconds for the persistent cookie store
                                 if (cookie.expires != null && cookie.expires > 0) it.expiresAt((cookie.expires * 1000).toLong())
-                                if (!cookie.domain.startsWith('.')) it.hostOnlyDomain(cookie.domain.removePrefix("."))
+                                if (!cookie.domain.startsWith('.')) it.hostOnlyDomain(
+                                    cookie.domain.removePrefix(
+                                        ".",
+                                    ),
+                                )
                             }.build()
                     }.groupBy { it.domain }
                     .flatMap { (domain, cookies) ->


### PR DESCRIPTION
Works with Flaresolverr. Required for Kagane.

Sadly, Byparr is not a drop-in replacement for everything, it just ignores the `cmd` and interprets anything it receives as a GET request.