### PR TITLE
fix: don't resuse invalidated `cf_clearance` cookie on `CloudFlareInterceptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - .
 
 ### Fixed
+- (CloudFlareInterceptor) Don't send the `cf_clearance` cookie back to Flaresolverr
 - (WebUI) Handle serving non-default webui with "bundled"
 - (WebUI) Wait until WebUI is ready to open in browser
 

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -205,7 +205,8 @@ object CFClearance {
                                             session = serverConfig.flareSolverrSessionName.value,
                                             sessionTtlMinutes = serverConfig.flareSolverrSessionTtl.value,
                                             cookies =
-                                                network.cookieStore.get(originalRequest.url)
+                                                network.cookieStore
+                                                    .get(originalRequest.url)
                                                     .groupBy { it.name }
                                                     .filter { it.key !in CloudflareInterceptor.COOKIE_NAMES }
                                                     .values
@@ -280,7 +281,8 @@ object CFClearance {
                     }
             logger.trace { "New cookies\n${cookies.joinToString("; ")}" }
             val finalCookies =
-                network.cookieStore.get(originalRequest.url)
+                network.cookieStore
+                    .get(originalRequest.url)
                     .groupBy { it.name }
                     .values
                     .map { cookies -> cookies.maxBy { it.expiresAt } }

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -103,7 +103,7 @@ class CloudflareInterceptor(
     companion object {
         private val ERROR_CODES = listOf(403, 503)
         private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
-        private val COOKIE_NAMES = listOf("cf_clearance")
+        val COOKIE_NAMES = listOf("cf_clearance")
         private val CHROME_IMAGE_TEMPLATE_REGEX = Regex("""<title>(.*?) \(\d+×\d+\)</title>""")
     }
 }
@@ -205,9 +205,14 @@ object CFClearance {
                                             session = serverConfig.flareSolverrSessionName.value,
                                             sessionTtlMinutes = serverConfig.flareSolverrSessionTtl.value,
                                             cookies =
-                                                network.cookieStore.get(originalRequest.url).map {
-                                                    FlareSolverCookie(it.name, it.value)
-                                                },
+                                                network.cookieStore.get(originalRequest.url)
+                                                    .groupBy { it.name }
+                                                    .filter { it.key !in CloudflareInterceptor.COOKIE_NAMES }
+                                                    .values
+                                                    .map { cookies ->
+                                                        val cookie = cookies.maxBy { it.expiresAt }
+                                                        FlareSolverCookie(cookie.name, cookie.value)
+                                                    },
                                             returnOnlyCookies = onlyCookies,
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
                                             postData =
@@ -275,9 +280,13 @@ object CFClearance {
                     }
             logger.trace { "New cookies\n${cookies.joinToString("; ")}" }
             val finalCookies =
-                network.cookieStore.get(originalRequest.url).joinToString("; ", postfix = "; ") {
-                    "${it.name}=${it.value}"
-                }
+                network.cookieStore.get(originalRequest.url)
+                    .groupBy { it.name }
+                    .values
+                    .map { cookies -> cookies.maxBy { it.expiresAt } }
+                    .joinToString("; ", postfix = "; ") {
+                        "${it.name}=${it.value}"
+                    }
             logger.trace { "Final cookies\n$finalCookies" }
             return originalRequest
                 .newBuilder()

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -208,8 +208,7 @@ object CFClearance {
                                                 network.cookieStore
                                                     .get(originalRequest.url)
                                                     .filter { it.name !in CloudflareInterceptor.COOKIE_NAMES }
-                                                    .map { cookies ->
-                                                        val cookie = cookies.maxBy { it.expiresAt }
+                                                    .map { cookie ->
                                                         FlareSolverCookie(cookie.name, cookie.value)
                                                     },
                                             returnOnlyCookies = onlyCookies,

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -207,9 +207,7 @@ object CFClearance {
                                             cookies =
                                                 network.cookieStore
                                                     .get(originalRequest.url)
-                                                    .groupBy { it.name }
-                                                    .filter { it.key !in CloudflareInterceptor.COOKIE_NAMES }
-                                                    .values
+                                                    .filter { it.name !in CloudflareInterceptor.COOKIE_NAMES }
                                                     .map { cookies ->
                                                         val cookie = cookies.maxBy { it.expiresAt }
                                                         FlareSolverCookie(cookie.name, cookie.value)
@@ -281,14 +279,9 @@ object CFClearance {
                     }
             logger.trace { "New cookies\n${cookies.joinToString("; ")}" }
             val finalCookies =
-                network.cookieStore
-                    .get(originalRequest.url)
-                    .groupBy { it.name }
-                    .values
-                    .map { cookies -> cookies.maxBy { it.expiresAt } }
-                    .joinToString("; ", postfix = "; ") {
-                        "${it.name}=${it.value}"
-                    }
+                network.cookieStore.get(originalRequest.url).joinToString("; ", postfix = "; ") {
+                    "${it.name}=${it.value}"
+                }
             logger.trace { "Final cookies\n$finalCookies" }
             return originalRequest
                 .newBuilder()


### PR DESCRIPTION
Old invalidated `cf_clearance` cookies can cause http code 403 on Kagane requests and invalid responses on other sources:

<img width="818" height="131" alt="image" src="https://github.com/user-attachments/assets/81bdfb81-b085-4a0c-8a60-523781919554" />

Filtering this cookie only in the FlareSolverr request let's it replace the cookie when needed, otherwise it tries to use the old one.

This PR also dedups the sent cookies.