### PR TITLE
Fix GTK+ 2 / GTK+ 3 conflict on GNOME/Wayland (#1921)

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
@@ -22,6 +22,11 @@ object SystemTray {
     private var instance: SystemTray? = null
 
     fun create() {
+        if (!isSupportedEnvironment()) {
+            logger.warn { "System tray disabled on this environment" }
+            return
+        }
+
         instance =
             try {
                 // ref: https://github.com/dorkbox/SystemTray/blob/master/test/dorkbox/TestTray.java
@@ -70,5 +75,17 @@ object SystemTray {
     fun remove() {
         instance?.remove()
         instance = null
+    }
+
+    private fun isSupportedEnvironment(): Boolean {
+        val osName = System.getProperty("os.name")?.lowercase() ?: ""
+        if (osName.contains("linux")) {
+            val sessionType = System.getenv("XDG_SESSION_TYPE")?.lowercase()
+            val waylandDisplay = System.getenv("WAYLAND_DISPLAY")
+            if (sessionType == "wayland" || !waylandDisplay.isNullOrEmpty()) {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
@@ -22,11 +22,6 @@ object SystemTray {
     private var instance: SystemTray? = null
 
     fun create() {
-        if (!isSupportedEnvironment()) {
-            logger.warn { "System tray disabled on this environment" }
-            return
-        }
-
         instance =
             try {
                 // ref: https://github.com/dorkbox/SystemTray/blob/master/test/dorkbox/TestTray.java
@@ -38,8 +33,9 @@ object SystemTray {
 
                 CacheUtil.clear(BuildConfig.NAME)
 
-                if (System.getProperty("os.name").startsWith("Mac")) {
-                    SystemTray.FORCE_TRAY_TYPE = SystemTray.TrayType.Awt
+                val forcedTrayType = resolveForcedTrayType()
+                if (forcedTrayType != null) {
+                    SystemTray.FORCE_TRAY_TYPE = forcedTrayType
                 }
 
                 val systemTray = SystemTray.get(BuildConfig.NAME)
@@ -77,15 +73,21 @@ object SystemTray {
         instance = null
     }
 
-    private fun isSupportedEnvironment(): Boolean {
+    private fun resolveForcedTrayType(): SystemTray.TrayType? {
         val osName = System.getProperty("os.name")?.lowercase() ?: ""
+
+        if (osName.startsWith("mac")) {
+            return SystemTray.TrayType.Awt
+        }
+
         if (osName.contains("linux")) {
             val sessionType = System.getenv("XDG_SESSION_TYPE")?.lowercase()
             val waylandDisplay = System.getenv("WAYLAND_DISPLAY")
             if (sessionType == "wayland" || !waylandDisplay.isNullOrEmpty()) {
-                return false
+                return SystemTray.TrayType.Swing
             }
         }
-        return true
+
+        return null
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
@@ -22,11 +22,6 @@ object SystemTray {
     private var instance: SystemTray? = null
 
     fun create() {
-        if (!isSupportedEnvironment()) {
-            logger.warn { "System tray disabled on this environment" }
-            return
-        }
-
         instance =
             try {
                 // ref: https://github.com/dorkbox/SystemTray/blob/master/test/dorkbox/TestTray.java
@@ -38,8 +33,8 @@ object SystemTray {
 
                 CacheUtil.clear(BuildConfig.NAME)
 
-                if (System.getProperty("os.name").startsWith("Mac")) {
-                    SystemTray.FORCE_TRAY_TYPE = SystemTray.TrayType.Awt
+                resolveForcedTrayType()?.let { forcedType ->
+                    SystemTray.FORCE_TRAY_TYPE = forcedType
                 }
 
                 val systemTray = SystemTray.get(BuildConfig.NAME)
@@ -81,15 +76,29 @@ object SystemTray {
         instance = null
     }
 
-    private fun isSupportedEnvironment(): Boolean {
+    private fun resolveForcedTrayType(): SystemTray.TrayType? {
         val osName = System.getProperty("os.name")?.lowercase() ?: ""
+
+        if (osName.startsWith("mac")) {
+            return SystemTray.TrayType.Awt
+        }
+
         if (osName.contains("linux")) {
             val sessionType = System.getenv("XDG_SESSION_TYPE")?.lowercase()
             val waylandDisplay = System.getenv("WAYLAND_DISPLAY")
-            if (sessionType == "wayland" || !waylandDisplay.isNullOrEmpty()) {
-                return false
+            val isWayland = sessionType == "wayland" || !waylandDisplay.isNullOrEmpty()
+
+            if (isWayland) {
+                val currentDesktop = System.getenv("XDG_CURRENT_DESKTOP")?.lowercase().orEmpty()
+                val desktopSession = System.getenv("DESKTOP_SESSION")?.lowercase().orEmpty()
+                val isGnome = currentDesktop.contains("gnome") || desktopSession.contains("gnome")
+
+                if (isGnome) {
+                    return SystemTray.TrayType.AppIndicator
+                }
             }
         }
-        return true
+
+        return null
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
@@ -22,6 +22,11 @@ object SystemTray {
     private var instance: SystemTray? = null
 
     fun create() {
+        if (!isSupportedEnvironment()) {
+            logger.warn { "System tray disabled on this environment" }
+            return
+        }
+
         instance =
             try {
                 // ref: https://github.com/dorkbox/SystemTray/blob/master/test/dorkbox/TestTray.java
@@ -33,12 +38,15 @@ object SystemTray {
 
                 CacheUtil.clear(BuildConfig.NAME)
 
-                val forcedTrayType = resolveForcedTrayType()
-                if (forcedTrayType != null) {
-                    SystemTray.FORCE_TRAY_TYPE = forcedTrayType
+                if (System.getProperty("os.name").startsWith("Mac")) {
+                    SystemTray.FORCE_TRAY_TYPE = SystemTray.TrayType.Awt
                 }
 
                 val systemTray = SystemTray.get(BuildConfig.NAME)
+                if (systemTray == null) {
+                    logger.warn { "System tray not supported; disabling tray" }
+                    return null
+                }
                 val mainMenu = systemTray.menu
 
                 mainMenu.add(
@@ -73,21 +81,15 @@ object SystemTray {
         instance = null
     }
 
-    private fun resolveForcedTrayType(): SystemTray.TrayType? {
+    private fun isSupportedEnvironment(): Boolean {
         val osName = System.getProperty("os.name")?.lowercase() ?: ""
-
-        if (osName.startsWith("mac")) {
-            return SystemTray.TrayType.Awt
-        }
-
         if (osName.contains("linux")) {
             val sessionType = System.getenv("XDG_SESSION_TYPE")?.lowercase()
             val waylandDisplay = System.getenv("WAYLAND_DISPLAY")
             if (sessionType == "wayland" || !waylandDisplay.isNullOrEmpty()) {
-                return SystemTray.TrayType.Swing
+                return false
             }
         }
-
-        return null
+        return true
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/SystemTray.kt
@@ -8,7 +8,7 @@ package suwayomi.tachidesk.server.util
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import dorkbox.systemTray.MenuItem
-import dorkbox.systemTray.SystemTray
+import dorkbox.systemTray.SystemTray as DorkboxSystemTray
 import dorkbox.util.CacheUtil
 import io.github.oshai.kotlinlogging.KotlinLogging
 import suwayomi.tachidesk.server.ServerConfig
@@ -19,56 +19,56 @@ import suwayomi.tachidesk.server.util.ExitCode.Success
 
 object SystemTray {
     private val logger = KotlinLogging.logger { }
-    private var instance: SystemTray? = null
+    private var instance: DorkboxSystemTray? = null
 
     fun create() {
-        instance =
-            try {
-                // ref: https://github.com/dorkbox/SystemTray/blob/master/test/dorkbox/TestTray.java
-                serverConfig.subscribeTo(
-                    serverConfig.debugLogsEnabled,
-                    { debugLogsEnabled -> SystemTray.DEBUG = debugLogsEnabled },
-                    ignoreInitialValue = false,
-                )
+        try {
+            // ref: https://github.com/dorkbox/SystemTray/blob/master/test/dorkbox/TestTray.java
+            serverConfig.subscribeTo(
+                serverConfig.debugLogsEnabled,
+                { debugLogsEnabled -> DorkboxSystemTray.DEBUG = debugLogsEnabled },
+                ignoreInitialValue = false,
+            )
 
-                CacheUtil.clear(BuildConfig.NAME)
+            CacheUtil.clear(BuildConfig.NAME)
 
-                resolveForcedTrayType()?.let { forcedType ->
-                    SystemTray.FORCE_TRAY_TYPE = forcedType
-                }
+            val forcedTrayType = resolveForcedTrayType()
+            logger.debug { "SystemTray resolved tray type: ${forcedTrayType ?: "AutoDetect"}" }
+            forcedTrayType?.let { DorkboxSystemTray.FORCE_TRAY_TYPE = it }
 
-                val systemTray = SystemTray.get(BuildConfig.NAME)
-                if (systemTray == null) {
-                    logger.warn { "System tray not supported; disabling tray" }
-                    return null
-                }
-                val mainMenu = systemTray.menu
-
-                mainMenu.add(
-                    MenuItem(
-                        "Open Suwayomi",
-                    ) {
-                        openInBrowser()
-                    },
-                )
-
-                val icon = ServerConfig::class.java.getResource("/icon/faviconlogo.png")
-
-                // systemTray.setTooltip("Tachidesk")
-                systemTray.setImage(icon)
-                // systemTray.status = "No Mail"
-
-                mainMenu.add(
-                    MenuItem("Quit") {
-                        shutdownApp(Success)
-                    },
-                )
-
-                systemTray
-            } catch (e: Exception) {
-                logger.error(e) { "create: failed to create SystemTray due to" }
-                null
+            val systemTray = DorkboxSystemTray.get(BuildConfig.NAME)
+            if (systemTray == null) {
+                logger.warn { "System tray not supported; disabling tray" }
+                instance = null
+                return
             }
+            val mainMenu = systemTray.menu
+
+            mainMenu.add(
+                MenuItem(
+                    "Open Suwayomi",
+                ) {
+                    openInBrowser()
+                },
+            )
+
+            val icon = ServerConfig::class.java.getResource("/icon/faviconlogo.png")
+
+            // systemTray.setTooltip("Tachidesk")
+            systemTray.setImage(icon)
+            // systemTray.status = "No Mail"
+
+            mainMenu.add(
+                MenuItem("Quit") {
+                    shutdownApp(Success)
+                },
+            )
+
+            instance = systemTray
+        } catch (e: Exception) {
+            logger.error(e) { "create: failed to create SystemTray due to" }
+            instance = null
+        }
     }
 
     fun remove() {
@@ -76,11 +76,11 @@ object SystemTray {
         instance = null
     }
 
-    private fun resolveForcedTrayType(): SystemTray.TrayType? {
+    private fun resolveForcedTrayType(): DorkboxSystemTray.TrayType? {
         val osName = System.getProperty("os.name")?.lowercase() ?: ""
 
         if (osName.startsWith("mac")) {
-            return SystemTray.TrayType.Awt
+            return DorkboxSystemTray.TrayType.Awt
         }
 
         if (osName.contains("linux")) {
@@ -94,7 +94,7 @@ object SystemTray {
                 val isGnome = currentDesktop.contains("gnome") || desktopSession.contains("gnome")
 
                 if (isGnome) {
-                    return SystemTray.TrayType.AppIndicator
+                    return DorkboxSystemTray.TrayType.AppIndicator
                 }
             }
         }


### PR DESCRIPTION
Prevents Suwayomi-Server from initializing the dorkbox system tray on Linux Wayland sessions, avoiding the GTK+ 2.x + GTK+ 3 mix that causes the AppImage to crash.