### PR TITLE
Detect non-standard bot challenges behind Cloudflare

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNames
 import okhttp3.Cookie
 import okhttp3.FormBody
 import okhttp3.HttpUrl
@@ -44,7 +45,19 @@ class CloudflareInterceptor(
         val originalResponse = chain.proceed(originalRequest)
 
         // Check if Cloudflare anti-bot is on
-        if (!(originalResponse.code in ERROR_CODES && originalResponse.header("Server") in SERVER_CHECK)) {
+        val isCloudflareChallenge =
+            originalResponse.code in ERROR_CODES && originalResponse.header("Server") in SERVER_CHECK
+
+        // Some sites serve bot challenges as HTTP 200 behind Cloudflare (e.g. vShield/BalooPow)
+        val isNonStandardChallenge =
+            !isCloudflareChallenge &&
+                originalResponse.code == 200 &&
+                originalResponse.header("Server") in SERVER_CHECK &&
+                originalResponse.peekBody(8192).string().let { body ->
+                    CHALLENGE_MARKERS.any { marker -> marker in body }
+                }
+
+        if (!isCloudflareChallenge && !isNonStandardChallenge) {
             return originalResponse
         }
 
@@ -76,7 +89,9 @@ class CloudflareInterceptor(
                     if (!isImage) {
                         logger.debug { "Falling back to FlareSolverr response" }
 
-                        setUserAgent(flareResponse.solution.userAgent)
+                        // Save cookies and user agent from the FlareSolverr solution so subsequent
+                        // requests can bypass the challenge without calling FlareSolverr again
+                        CFClearance.saveSolutionCookies(flareResponse, setUserAgent)
 
                         return originalResponse
                             .newBuilder()
@@ -105,6 +120,7 @@ class CloudflareInterceptor(
         private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
         private val COOKIE_NAMES = listOf("cf_clearance")
         private val CHROME_IMAGE_TEMPLATE_REGEX = Regex("""<title>(.*?) \(\d+×\d+\)</title>""")
+        private val CHALLENGE_MARKERS = listOf("_vShield_v=", "balooPow", "ddosmitigation")
     }
 }
 
@@ -157,6 +173,7 @@ object CFClearance {
         val value: String,
         val domain: String,
         val path: String? = null,
+        @JsonNames("expiry")
         val expires: Double? = null,
         val size: Int? = null,
         val httpOnly: Boolean? = null,
@@ -235,45 +252,56 @@ object CFClearance {
         }
     }
 
+    fun saveSolutionCookies(
+        flareSolverResponse: FlareSolverResponse,
+        setUserAgent: (String) -> Unit,
+    ) {
+        setUserAgent(flareSolverResponse.solution.userAgent)
+        val cookies =
+            flareSolverResponse.solution.cookies
+                .map { cookie ->
+                    Cookie
+                        .Builder()
+                        .name(cookie.name)
+                        .value(cookie.value)
+                        .domain(cookie.domain.removePrefix("."))
+                        .also {
+                            if (cookie.httpOnly != null && cookie.httpOnly) it.httpOnly()
+                            if (cookie.secure != null && cookie.secure) it.secure()
+                            if (!cookie.path.isNullOrEmpty()) it.path(cookie.path)
+                            // We need to convert the expires time to milliseconds for the persistent cookie store
+                            if (cookie.expires != null && cookie.expires > 0) {
+                                it.expiresAt((cookie.expires * 1000).toLong())
+                            } else {
+                                it.expiresAt(Long.MAX_VALUE)
+                            }
+                            if (!cookie.domain.startsWith('.')) {
+                                it.hostOnlyDomain(cookie.domain.removePrefix("."))
+                            }
+                        }.build()
+                }.groupBy { it.domain }
+                .flatMap { (domain, cookies) ->
+                    network.cookieStore.addAll(
+                        HttpUrl
+                            .Builder()
+                            .scheme("http")
+                            .host(domain.removePrefix("."))
+                            .build(),
+                        cookies,
+                    )
+
+                    cookies
+                }
+        logger.trace { "New cookies\n${cookies.joinToString("; ")}" }
+    }
+
     fun requestWithFlareSolverr(
         flareSolverResponse: FlareSolverResponse,
         setUserAgent: (String) -> Unit,
         originalRequest: Request,
     ): Request {
         if (flareSolverResponse.solution.status in 200..299) {
-            setUserAgent(flareSolverResponse.solution.userAgent)
-            val cookies =
-                flareSolverResponse.solution.cookies
-                    .map { cookie ->
-                        Cookie
-                            .Builder()
-                            .name(cookie.name)
-                            .value(cookie.value)
-                            .domain(cookie.domain.removePrefix("."))
-                            .also {
-                                if (cookie.httpOnly != null && cookie.httpOnly) it.httpOnly()
-                                if (cookie.secure != null && cookie.secure) it.secure()
-                                if (!cookie.path.isNullOrEmpty()) it.path(cookie.path)
-                                // We need to convert the expires time to milliseconds for the persistent cookie store
-                                if (cookie.expires != null && cookie.expires > 0) it.expiresAt((cookie.expires * 1000).toLong())
-                                if (!cookie.domain.startsWith('.')) {
-                                    it.hostOnlyDomain(cookie.domain.removePrefix("."))
-                                }
-                            }.build()
-                    }.groupBy { it.domain }
-                    .flatMap { (domain, cookies) ->
-                        network.cookieStore.addAll(
-                            HttpUrl
-                                .Builder()
-                                .scheme("http")
-                                .host(domain.removePrefix("."))
-                                .build(),
-                            cookies,
-                        )
-
-                        cookies
-                    }
-            logger.trace { "New cookies\n${cookies.joinToString("; ")}" }
+            saveSolutionCookies(flareSolverResponse, setUserAgent)
             val finalCookies =
                 network.cookieStore.get(originalRequest.url).joinToString("; ", postfix = "; ") {
                     "${it.name}=${it.value}"


### PR DESCRIPTION
Some sites behind Cloudflare use non-standard bot challenges (vShield/BalooPow) that return HTTP 200 instead of 403/503. The interceptor skips these since it only checks for 403/503, so FlareSolverr never gets called and extensions fail to parse the challenge page.

This peeks at the response body when it's HTTP 200 from a Cloudflare server and checks for known challenge markers. If found, it routes through FlareSolverr like a normal Cloudflare challenge.

Fixes issues with Iken-based extensions (e.g. Vortex Scans) throwing `Unable to retrieve NEXT data`.