### PR TITLE
Feature/search work aggregation sv

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -23,6 +23,7 @@ import suwayomi.tachidesk.manga.controller.MangaController
 import suwayomi.tachidesk.manga.controller.SourceController
 import suwayomi.tachidesk.manga.controller.TrackController
 import suwayomi.tachidesk.manga.controller.UpdateController
+import suwayomi.tachidesk.manga.controller.WorkController
 
 object MangaAPI {
     fun defineEndpoints() {
@@ -46,6 +47,8 @@ object MangaAPI {
 
             get("{sourceId}/preferences", SourceController.getPreferences)
             post("{sourceId}/preferences", SourceController.setPreference)
+            get("{sourceId}/policy", SourceController.getPolicy)
+            patch("{sourceId}/policy", SourceController.updatePolicy)
 
             get("{sourceId}/filters", SourceController.getFilters)
             post("{sourceId}/filters", SourceController.setFilters)
@@ -53,6 +56,17 @@ object MangaAPI {
             get("{sourceId}/search", SourceController.searchSingle)
             post("{sourceId}/quick-search", SourceController.quickSearchSingle)
 //            get("all/search", SourceController.searchGlobal) // TODO
+        }
+
+        path("search") {
+            get("", WorkController.search)
+        }
+
+        path("work") {
+            get("{workId}", WorkController.retrieve)
+            get("{workId}/sources", WorkController.sources)
+            post("merge", WorkController.merge)
+            post("{workId}/alias", WorkController.addAlias)
         }
 
         path("manga") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/ExtensionController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/ExtensionController.kt
@@ -9,6 +9,7 @@ package suwayomi.tachidesk.manga.controller
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.javalin.http.HttpStatus
+import suwayomi.tachidesk.manga.impl.WorkSearch
 import suwayomi.tachidesk.manga.impl.extension.Extension
 import suwayomi.tachidesk.manga.impl.extension.ExtensionsList
 import suwayomi.tachidesk.manga.model.dataclass.ExtensionDataClass
@@ -125,6 +126,7 @@ object ExtensionController {
                 ctx.getAttribute(Attribute.TachideskUser).requireUser()
                 ctx.future {
                     future {
+                        WorkSearch.ensureExtensionMutationAllowed(pkgName)
                         Extension.updateExtension(pkgName)
                     }.thenApply {
                         ctx.status(it)
@@ -151,6 +153,7 @@ object ExtensionController {
             },
             behaviorOf = { ctx, pkgName ->
                 ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                WorkSearch.ensureExtensionMutationAllowed(pkgName)
                 Extension.uninstallExtension(pkgName)
                 ctx.status(200)
             },

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/SourceController.kt
@@ -15,7 +15,9 @@ import suwayomi.tachidesk.manga.impl.Search.FilterChange
 import suwayomi.tachidesk.manga.impl.Search.FilterData
 import suwayomi.tachidesk.manga.impl.Source
 import suwayomi.tachidesk.manga.impl.Source.SourcePreferenceChange
+import suwayomi.tachidesk.manga.impl.WorkSearch
 import suwayomi.tachidesk.manga.model.dataclass.PagedMangaListDataClass
+import suwayomi.tachidesk.manga.model.dataclass.SourcePolicyDataClass
 import suwayomi.tachidesk.manga.model.dataclass.SourceDataClass
 import suwayomi.tachidesk.server.JavalinSetup.Attribute
 import suwayomi.tachidesk.server.JavalinSetup.future
@@ -174,6 +176,46 @@ object SourceController {
             },
         )
 
+    /** fetch aggregation policy of source with id `sourceId` */
+    val getPolicy =
+        handler(
+            pathParam<Long>("sourceId"),
+            documentWith = {
+                withOperation {
+                    summary("Source aggregation policy")
+                    description("Fetch the aggregation/search policy of source with id `sourceId`.")
+                }
+            },
+            behaviorOf = { ctx, sourceId ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.json(WorkSearch.getSourcePolicy(sourceId))
+            },
+            withResults = {
+                json<SourcePolicyDataClass>(HttpStatus.OK)
+            },
+        )
+
+    /** update aggregation policy of source with id `sourceId` */
+    val updatePolicy =
+        handler(
+            pathParam<Long>("sourceId"),
+            documentWith = {
+                withOperation {
+                    summary("Source aggregation policy update")
+                    description("Update the aggregation/search policy of source with id `sourceId`.")
+                }
+                body<WorkSearch.SourcePolicyPatchInput>()
+            },
+            behaviorOf = { ctx, sourceId ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                val input = json.decodeFromString<WorkSearch.SourcePolicyPatchInput>(ctx.body())
+                ctx.json(WorkSearch.updateSourcePolicy(sourceId, input))
+            },
+            withResults = {
+                json<SourcePolicyDataClass>(HttpStatus.OK)
+            },
+        )
+
     private val json: Json by injectLazy()
 
     /** change filters of source with id `sourceId` */
@@ -265,8 +307,10 @@ object SourceController {
             },
             behaviorOf = { ctx, searchTerm ->
                 ctx.getAttribute(Attribute.TachideskUser).requireUser()
-                // TODO
-                ctx.json(Search.sourceGlobalSearch(searchTerm))
+                ctx.future {
+                    future { Search.sourceGlobalSearch(searchTerm) }
+                        .thenApply { ctx.json(it) }
+                }
             },
             withResults = {
                 httpCode(HttpStatus.OK)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/WorkController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/WorkController.kt
@@ -1,0 +1,127 @@
+package suwayomi.tachidesk.manga.controller
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import io.javalin.http.HttpStatus
+import kotlinx.serialization.json.Json
+import suwayomi.tachidesk.manga.impl.WorkSearch
+import suwayomi.tachidesk.manga.model.dataclass.WorkDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkSearchResultDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkSourceEntryDataClass
+import suwayomi.tachidesk.server.JavalinSetup.Attribute
+import suwayomi.tachidesk.server.JavalinSetup.future
+import suwayomi.tachidesk.server.JavalinSetup.getAttribute
+import suwayomi.tachidesk.server.user.requireUser
+import suwayomi.tachidesk.server.util.handler
+import suwayomi.tachidesk.server.util.pathParam
+import suwayomi.tachidesk.server.util.queryParam
+import suwayomi.tachidesk.server.util.withOperation
+import uy.kohesive.injekt.injectLazy
+import java.util.UUID
+
+object WorkController {
+    private val json: Json by injectLazy()
+
+    val search =
+        handler(
+            queryParam("q", ""),
+            documentWith = {
+                withOperation {
+                    summary("Aggregated search")
+                    description("Search installed sources and aggregate matches into canonical works.")
+                }
+            },
+            behaviorOf = { ctx, query ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.future {
+                    future { WorkSearch.search(query) }
+                        .thenApply { ctx.json(it) }
+                }
+            },
+            withResults = {
+                json<WorkSearchResultDataClass>(HttpStatus.OK)
+            },
+        )
+
+    val retrieve =
+        handler(
+            pathParam<String>("workId"),
+            documentWith = {
+                withOperation {
+                    summary("Get work")
+                    description("Fetch a canonical work and all of its aggregated sources.")
+                }
+            },
+            behaviorOf = { ctx, workId ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                val work = WorkSearch.getWork(UUID.fromString(workId)) ?: throw IllegalArgumentException("work $workId not found")
+                ctx.json(work)
+            },
+            withResults = {
+                json<WorkDataClass>(HttpStatus.OK)
+                httpCode(HttpStatus.NOT_FOUND)
+            },
+        )
+
+    val sources =
+        handler(
+            pathParam<String>("workId"),
+            documentWith = {
+                withOperation {
+                    summary("Get work sources")
+                    description("List all source entries associated with a canonical work.")
+                }
+            },
+            behaviorOf = { ctx, workId ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.json(WorkSearch.getWorkSources(UUID.fromString(workId)))
+            },
+            withResults = {
+                json<Array<WorkSourceEntryDataClass>>(HttpStatus.OK)
+            },
+        )
+
+    val merge =
+        handler(
+            documentWith = {
+                withOperation {
+                    summary("Merge works")
+                    description("Manually merge multiple canonical works into a target work.")
+                }
+                body<WorkSearch.MergeInput>()
+            },
+            behaviorOf = { ctx ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                val input = json.decodeFromString<WorkSearch.MergeInput>(ctx.body())
+                ctx.json(WorkSearch.mergeWorks(input))
+            },
+            withResults = {
+                json<WorkDataClass>(HttpStatus.OK)
+            },
+        )
+
+    val addAlias =
+        handler(
+            pathParam<String>("workId"),
+            documentWith = {
+                withOperation {
+                    summary("Add work alias")
+                    description("Add a manual alias to a canonical work.")
+                }
+                body<WorkSearch.AliasInput>()
+            },
+            behaviorOf = { ctx, workId ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                val input = json.decodeFromString<WorkSearch.AliasInput>(ctx.body())
+                ctx.json(WorkSearch.addAlias(UUID.fromString(workId), input))
+            },
+            withResults = {
+                json<WorkDataClass>(HttpStatus.OK)
+            },
+        )
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Search.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Search.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
 import suwayomi.tachidesk.manga.impl.MangaList.processEntries
 import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
 import suwayomi.tachidesk.manga.model.dataclass.PagedMangaListDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkSearchResultDataClass
 import uy.kohesive.injekt.injectLazy
 
 object Search {
@@ -188,8 +189,5 @@ object Search {
         val filter: List<FilterChange>?,
     )
 
-    @Suppress("UNUSED_PARAMETER")
-    fun sourceGlobalSearch(searchTerm: String) {
-        // TODO
-    }
+    suspend fun sourceGlobalSearch(searchTerm: String): WorkSearchResultDataClass = WorkSearch.search(searchTerm)
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/WorkSearch.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/WorkSearch.kt
@@ -1,0 +1,1032 @@
+package suwayomi.tachidesk.manga.impl
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import io.github.reactivecircus.cache4k.Cache
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.Serializable
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import suwayomi.tachidesk.manga.model.dataclass.MangaDataClass
+import suwayomi.tachidesk.manga.model.dataclass.SourcePolicyDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkAliasDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkSearchResultDataClass
+import suwayomi.tachidesk.manga.model.dataclass.WorkSourceEntryDataClass
+import suwayomi.tachidesk.manga.impl.extension.Extension
+import suwayomi.tachidesk.manga.model.table.ChapterTable
+import suwayomi.tachidesk.manga.model.table.ExtensionTable
+import suwayomi.tachidesk.manga.model.table.MangaTable
+import suwayomi.tachidesk.manga.model.table.MergeCandidateTable
+import suwayomi.tachidesk.manga.model.table.SourcePolicyTable
+import suwayomi.tachidesk.manga.model.table.SourceTable
+import suwayomi.tachidesk.manga.model.table.WorkAliasTable
+import suwayomi.tachidesk.manga.model.table.WorkSourceEntryTable
+import suwayomi.tachidesk.manga.model.table.WorkTable
+import suwayomi.tachidesk.server.serverConfig
+import java.text.Normalizer
+import java.time.Instant
+import java.util.UUID
+import kotlin.math.max
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+object WorkSearch {
+    private const val SAFE_MATCH_THRESHOLD = 80.0
+    private const val PROBABLE_MATCH_THRESHOLD = 60.0
+    private val SOURCE_STATS_REFRESH_INTERVAL = 12.hours
+    private val SOURCE_FAILURE_COOLDOWN = 5.minutes
+    private val SOURCE_SEARCH_TIMEOUT = 15.seconds
+    private val SOURCE_STATS_TIMEOUT = 20.seconds
+    private val searchCache = Cache.Builder<String, WorkSearchResultDataClass>().expireAfterWrite(5.minutes).build()
+    private val searchFailureCooldown = Cache.Builder<Long, Unit>().expireAfterWrite(SOURCE_FAILURE_COOLDOWN).build()
+    private val sourceStatsFailureCooldown = Cache.Builder<Long, Unit>().expireAfterWrite(SOURCE_FAILURE_COOLDOWN).build()
+
+    @Serializable
+    data class MergeInput(
+        val targetWorkId: String,
+        val workIds: List<String>,
+    )
+
+    @Serializable
+    data class AliasInput(
+        val alias: String,
+        val source: String = "user",
+        val confidence: Double = 1.0,
+    )
+
+    @Serializable
+    data class SourcePolicyPatchInput(
+        val enabled: Boolean? = null,
+        val trusted: Boolean? = null,
+        val rankWeight: Double? = null,
+        val languagePriority: Int? = null,
+        val installLocked: Boolean? = null,
+    )
+
+    private data class WorkCandidate(
+        val id: UUID,
+        val canonicalTitle: String,
+        val normalizedTitle: String,
+        val aliases: MutableSet<String>,
+    )
+
+    private data class ChapterStats(
+        val chaptersCount: Int,
+        val lastChapter: Double?,
+        val lastUpdate: Long?,
+    )
+
+    private data class SourceDescriptor(
+        val id: Long,
+        val name: String,
+        val language: String,
+    )
+
+    private data class SourceEntryRefreshTarget(
+        val entryId: UUID,
+        val mangaId: Int,
+        val sourceId: Long,
+        val policy: SourcePolicyDataClass,
+    )
+
+    fun invalidateCache() {
+        searchCache.invalidateAll()
+    }
+
+    suspend fun search(query: String): WorkSearchResultDataClass {
+        val normalizedQuery = normalize(query)
+        require(normalizedQuery.isNotBlank()) { "query must not be blank" }
+
+        searchCache.get(normalizedQuery)?.let { return it }
+
+        val enabledPolicies = loadSourcePolicies().filter { it.enabled }
+        val sourceSemaphore = Semaphore(serverConfig.maxSourcesInParallel.value.coerceAtLeast(1))
+        val mangasBySource =
+            coroutineScope {
+                enabledPolicies.map { policy ->
+                    async {
+                        policy to searchSourceMangaList(policy.sourceId.toLong(), query, sourceSemaphore)
+                    }
+                }.awaitAll()
+            }
+
+        val mangas = mangasBySource.flatMap { it.second }.distinctBy { it.id }
+        val matchedSources = mangasBySource.count { it.second.isNotEmpty() }
+        val result =
+            aggregateSearchResults(
+                query = query,
+                normalizedQuery = normalizedQuery,
+                mangas = mangas,
+                matchedSources = matchedSources,
+                searchedSources = enabledPolicies.size,
+                policiesBySource = enabledPolicies.associateBy { it.sourceId.toLong() },
+            )
+
+        searchCache.put(normalizedQuery, result)
+        return result
+    }
+
+    fun getWork(workId: UUID): WorkDataClass? {
+        refreshWorkSourceStats(workId)
+        return transaction { loadWorks(setOf(workId)).firstOrNull() }
+    }
+
+    fun getWorkSources(workId: UUID): List<WorkSourceEntryDataClass> {
+        refreshWorkSourceStats(workId)
+        return transaction { loadWorks(setOf(workId)).firstOrNull()?.sources.orEmpty() }
+    }
+
+    fun addAlias(
+        workId: UUID,
+        input: AliasInput,
+    ): WorkDataClass {
+        transaction {
+            require(input.alias.isNotBlank()) { "alias must not be blank" }
+            requireWorkExists(workId)
+            insertAliasIfMissing(workId, input.alias, input.source, input.confidence)
+            touchWork(workId, input.confidence)
+        }
+        invalidateCache()
+        return getWork(workId) ?: error("work $workId not found after alias update")
+    }
+
+    fun mergeWorks(input: MergeInput): WorkDataClass {
+        val targetWorkId = UUID.fromString(input.targetWorkId)
+        val workIds = input.workIds.map(UUID::fromString).distinct().filterNot { it == targetWorkId }
+
+        transaction {
+            requireWorkExists(targetWorkId)
+            if (workIds.isNotEmpty()) {
+                val sourceWorks = WorkTable.selectAll().where { WorkTable.id inList workIds }.toList()
+                sourceWorks.forEach { row ->
+                    insertAliasIfMissing(targetWorkId, row[WorkTable.canonicalTitle], "system", 1.0)
+                }
+
+                val aliasRows = WorkAliasTable.selectAll().where { WorkAliasTable.workId inList workIds }.toList()
+                aliasRows.forEach { row ->
+                    insertAliasIfMissing(
+                        workId = targetWorkId,
+                        alias = row[WorkAliasTable.alias],
+                        source = row[WorkAliasTable.aliasSource],
+                        confidence = row[WorkAliasTable.confidence],
+                    )
+                }
+
+                WorkSourceEntryTable.update({ WorkSourceEntryTable.workId inList workIds }) {
+                    it[workId] = targetWorkId
+                }
+
+                MergeCandidateTable.update({ MergeCandidateTable.candidateWorkId inList workIds }) {
+                    it[candidateWorkId] = targetWorkId
+                }
+
+                WorkAliasTable.deleteWhere { WorkAliasTable.workId inList workIds }
+                WorkTable.deleteWhere { WorkTable.id inList workIds }
+                touchWork(targetWorkId, 1.0)
+            }
+        }
+
+        invalidateCache()
+        return getWork(targetWorkId) ?: error("work $targetWorkId not found after merge")
+    }
+
+    fun getSourcePolicy(sourceId: Long): SourcePolicyDataClass {
+        val policies = loadSourcePolicies()
+        return policies.firstOrNull { it.sourceId == sourceId.toString() } ?: error("source $sourceId not found")
+    }
+
+    fun updateSourcePolicy(
+        sourceId: Long,
+        input: SourcePolicyPatchInput,
+    ): SourcePolicyDataClass {
+        transaction {
+            val sourceRow = SourceTable.selectAll().where { SourceTable.id eq sourceId }.firstOrNull() ?: error("source $sourceId not found")
+            ensurePolicyExists(sourceRow)
+
+            SourcePolicyTable.update({ SourcePolicyTable.sourceId eq sourceId }) {
+                input.enabled?.let { value -> it[enabled] = value }
+                input.trusted?.let { value -> it[trusted] = value }
+                input.rankWeight?.let { value -> it[rankWeight] = value }
+                input.languagePriority?.let { value -> it[languagePriority] = value }
+                input.installLocked?.let { value -> it[installLocked] = value }
+                it[SourcePolicyTable.sourceName] = sourceRow[SourceTable.name]
+            }
+        }
+
+        invalidateCache()
+        return getSourcePolicy(sourceId)
+    }
+
+    fun ensureExtensionMutationAllowed(pkgName: String) {
+        val isLocked =
+            transaction {
+                val extensionId =
+                    ExtensionTable
+                        .selectAll()
+                        .where { ExtensionTable.pkgName eq pkgName }
+                        .firstOrNull()
+                        ?.get(ExtensionTable.id)
+                        ?.value
+                        ?: return@transaction false
+
+                val sourceIds =
+                    SourceTable
+                        .selectAll()
+                        .where { SourceTable.extension eq extensionId }
+                        .map { it[SourceTable.id].value }
+
+                if (sourceIds.isEmpty()) {
+                    false
+                } else {
+                    SourcePolicyTable
+                        .selectAll()
+                        .where { (SourcePolicyTable.sourceId inList sourceIds) and (SourcePolicyTable.installLocked eq true) }
+                        .any()
+                }
+            }
+
+        check(!isLocked) { "Extension $pkgName is locked by source policy" }
+    }
+
+    fun normalize(text: String): String {
+        val withoutTags =
+            text.replace(
+                Regex("""\[[^\]]*]|\([^)]*official[^)]*\)|\([^)]*es[^)]*\)|\{[^}]*}""", RegexOption.IGNORE_CASE),
+                " ",
+            )
+        val withoutAccents =
+            Normalizer
+                .normalize(withoutTags.lowercase(), Normalizer.Form.NFD)
+                .replace(Regex("""\p{Mn}+"""), "")
+
+        return withoutAccents
+            .replace(Regex("""[^a-z0-9]+"""), " ")
+            .trim()
+            .replace(Regex("""\s+"""), " ")
+    }
+
+    fun previewMatchScore(
+        title: String,
+        canonicalTitle: String,
+        aliases: List<String> = emptyList(),
+    ): Double =
+        calculateMatchScore(
+            normalizedTitle = normalize(title),
+            candidate =
+                WorkCandidate(
+                    id = UUID.randomUUID(),
+                    canonicalTitle = canonicalTitle,
+                    normalizedTitle = normalize(canonicalTitle),
+                    aliases = aliases.mapTo(mutableSetOf(), ::normalize),
+                ),
+        )
+
+    private fun aggregateSearchResults(
+        query: String,
+        normalizedQuery: String,
+        mangas: List<MangaDataClass>,
+        matchedSources: Int,
+        searchedSources: Int,
+        policiesBySource: Map<Long, SourcePolicyDataClass>,
+    ): WorkSearchResultDataClass =
+        transaction {
+            if (mangas.isEmpty()) {
+                return@transaction WorkSearchResultDataClass(query, normalizedQuery, emptyList(), searchedSources, matchedSources)
+            }
+
+            val allCandidates = loadAllWorkCandidates()
+            val sourceEntriesByMangaId =
+                WorkSourceEntryTable
+                    .selectAll()
+                    .where { WorkSourceEntryTable.mangaId inList mangas.map { it.id } }
+                    .associateBy { it[WorkSourceEntryTable.mangaId].value }
+            val sourceDescriptors =
+                SourceTable
+                    .selectAll()
+                    .where { SourceTable.id inList mangas.map { it.sourceId.toLong() }.distinct() }
+                    .associate {
+                        it[SourceTable.id].value to
+                            SourceDescriptor(
+                                id = it[SourceTable.id].value,
+                                name = it[SourceTable.name],
+                                language = it[SourceTable.lang],
+                            )
+                    }
+
+            val touchedWorkIds = linkedSetOf<UUID>()
+
+            mangas.forEach { manga ->
+                val sourceId = manga.sourceId.toLong()
+                val sourceDescriptor = sourceDescriptors[sourceId] ?: return@forEach
+                val policy = policiesBySource[sourceId] ?: defaultPolicy(sourceDescriptor)
+                val normalizedTitle = normalize(manga.title)
+                val chapterStats = loadChapterStats(manga.id)
+
+                val existingSourceEntry = sourceEntriesByMangaId[manga.id]
+                val assignedWorkId: UUID
+                val matchScore: Double
+
+                if (existingSourceEntry != null) {
+                    assignedWorkId = existingSourceEntry[WorkSourceEntryTable.workId]
+                    val workCandidate = allCandidates[assignedWorkId]
+                    matchScore =
+                        if (workCandidate != null) {
+                            calculateMatchScore(normalizedTitle, workCandidate)
+                        } else {
+                            SAFE_MATCH_THRESHOLD
+                        }
+                } else {
+                    val bestMatch =
+                        allCandidates.values
+                            .map { candidate -> candidate to calculateMatchScore(normalizedTitle, candidate) }
+                            .maxByOrNull { it.second }
+
+                    if (bestMatch != null && bestMatch.second >= SAFE_MATCH_THRESHOLD) {
+                        assignedWorkId = bestMatch.first.id
+                        matchScore = bestMatch.second
+                        insertAliasIfMissing(assignedWorkId, manga.title, "system", (bestMatch.second / 100.0).coerceAtMost(1.0))
+                        allCandidates[assignedWorkId]?.aliases?.add(normalizedTitle)
+                    } else {
+                        assignedWorkId =
+                            createWork(
+                                title = manga.title,
+                                normalizedTitle = normalizedTitle,
+                                coverUrl = manga.thumbnailUrl,
+                                type = guessType(manga),
+                                status = mapStatus(manga.status),
+                                confidenceScore = (bestMatch?.second ?: SAFE_MATCH_THRESHOLD) / 100.0,
+                            )
+                        allCandidates[assignedWorkId] =
+                            WorkCandidate(
+                                id = assignedWorkId,
+                                canonicalTitle = manga.title,
+                                normalizedTitle = normalizedTitle,
+                                aliases = mutableSetOf(),
+                            )
+                        matchScore = SAFE_MATCH_THRESHOLD
+                    }
+
+                    if (bestMatch != null && bestMatch.second in PROBABLE_MATCH_THRESHOLD..<SAFE_MATCH_THRESHOLD && assignedWorkId != bestMatch.first.id) {
+                        val sourceEntryId =
+                            upsertSourceEntry(
+                                workId = assignedWorkId,
+                                manga = manga,
+                                source = sourceDescriptor,
+                                chapterStats = chapterStats,
+                                matchScore = matchScore,
+                                qualityScore = calculateQualityScore(chapterStats, policy),
+                            )
+                        insertMergeCandidate(sourceEntryId, bestMatch.first.id, bestMatch.second)
+                        touchedWorkIds += assignedWorkId
+                        return@forEach
+                    }
+                }
+
+                val qualityScore = calculateQualityScore(chapterStats, policy)
+                upsertSourceEntry(
+                    workId = assignedWorkId,
+                    manga = manga,
+                    source = sourceDescriptor,
+                    chapterStats = chapterStats,
+                    matchScore = matchScore,
+                    qualityScore = qualityScore,
+                )
+                updateWorkMetadata(
+                    workId = assignedWorkId,
+                    manga = manga,
+                    normalizedTitle = normalizedTitle,
+                    confidenceScore = (matchScore / 100.0).coerceAtMost(1.0),
+                )
+                touchedWorkIds += assignedWorkId
+            }
+
+            WorkSearchResultDataClass(
+                query = query,
+                normalizedQuery = normalizedQuery,
+                works = loadWorks(touchedWorkIds, normalizedQuery),
+                searchedSources = searchedSources,
+                matchedSources = matchedSources,
+            )
+        }
+
+    private fun loadSourcePolicies(): List<SourcePolicyDataClass> =
+        transaction {
+            val sourceRows = SourceTable.selectAll().toList()
+            sourceRows.forEach(::ensurePolicyExists)
+
+            val policyRows =
+                SourcePolicyTable
+                    .selectAll()
+                    .where { SourcePolicyTable.sourceId inList sourceRows.map { it[SourceTable.id].value } }
+                    .associateBy { it[SourcePolicyTable.sourceId] }
+
+            sourceRows.map { sourceRow ->
+                val sourceId = sourceRow[SourceTable.id].value
+                val policyRow = policyRows[sourceId]
+                SourcePolicyDataClass(
+                    sourceId = sourceId.toString(),
+                    sourceName = policyRow?.get(SourcePolicyTable.sourceName) ?: sourceRow[SourceTable.name],
+                    enabled = policyRow?.get(SourcePolicyTable.enabled) ?: true,
+                    trusted = policyRow?.get(SourcePolicyTable.trusted) ?: true,
+                    rankWeight = policyRow?.get(SourcePolicyTable.rankWeight) ?: 0.0,
+                    languagePriority = policyRow?.get(SourcePolicyTable.languagePriority) ?: 0,
+                    installLocked = policyRow?.get(SourcePolicyTable.installLocked) ?: false,
+                )
+            }
+        }
+
+    private fun ensurePolicyExists(sourceRow: ResultRow) {
+        val sourceId = sourceRow[SourceTable.id].value
+        val exists = SourcePolicyTable.selectAll().where { SourcePolicyTable.sourceId eq sourceId }.firstOrNull() != null
+        if (!exists) {
+            SourcePolicyTable.insert {
+                it[this.sourceId] = sourceId
+                it[sourceName] = sourceRow[SourceTable.name]
+                it[enabled] = true
+                it[trusted] = true
+                it[rankWeight] = 0.0
+                it[languagePriority] = 0
+                it[installLocked] = false
+            }
+        }
+    }
+
+    private fun defaultPolicy(source: SourceDescriptor) =
+        SourcePolicyDataClass(
+            sourceId = source.id.toString(),
+            sourceName = source.name,
+            enabled = true,
+            trusted = true,
+            rankWeight = 0.0,
+            languagePriority = 0,
+            installLocked = false,
+        )
+
+    private fun loadAllWorkCandidates(): MutableMap<UUID, WorkCandidate> {
+        val workRows = WorkTable.selectAll().toList()
+        if (workRows.isEmpty()) {
+            return linkedMapOf()
+        }
+
+        val aliasesByWorkId =
+            WorkAliasTable
+                .selectAll()
+                .where { WorkAliasTable.workId inList workRows.map { it[WorkTable.id] } }
+                .groupBy { it[WorkAliasTable.workId] }
+                .mapValues { entry -> entry.value.mapTo(mutableSetOf()) { it[WorkAliasTable.normalizedAlias] } }
+
+        return workRows.associate {
+            val id = it[WorkTable.id]
+            id to
+                WorkCandidate(
+                    id = id,
+                    canonicalTitle = it[WorkTable.canonicalTitle],
+                    normalizedTitle = it[WorkTable.normalizedTitle],
+                    aliases = aliasesByWorkId[id] ?: mutableSetOf(),
+                )
+        }.toMutableMap()
+    }
+
+    private fun loadWorks(
+        workIds: Set<UUID>,
+        normalizedQuery: String? = null,
+    ): List<WorkDataClass> {
+        if (workIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val workRows = WorkTable.selectAll().where { WorkTable.id inList workIds.toList() }.toList()
+        val aliasRows = WorkAliasTable.selectAll().where { WorkAliasTable.workId inList workIds.toList() }.toList()
+        val sourceEntryRows = WorkSourceEntryTable.selectAll().where { WorkSourceEntryTable.workId inList workIds.toList() }.toList()
+        val mangaRows =
+            MangaTable
+                .selectAll()
+                .where { MangaTable.id inList sourceEntryRows.map { it[WorkSourceEntryTable.mangaId].value } }
+                .associateBy { it[MangaTable.id].value }
+        val sourceRows =
+            SourceTable
+                .selectAll()
+                .where { SourceTable.id inList sourceEntryRows.map { it[WorkSourceEntryTable.sourceId] }.distinct() }
+                .associateBy { it[SourceTable.id].value }
+        val extensionRows =
+            ExtensionTable
+                .selectAll()
+                .where { ExtensionTable.id inList sourceRows.values.map { it[SourceTable.extension].value }.distinct() }
+                .associateBy { it[ExtensionTable.id].value }
+
+        val aliasesByWorkId = aliasRows.groupBy { it[WorkAliasTable.workId] }
+        val sourcesByWorkId = sourceEntryRows.groupBy { it[WorkSourceEntryTable.workId] }
+
+        return workRows.map { workRow ->
+            val sourceEntries =
+                sourcesByWorkId[workRow[WorkTable.id]]
+                    .orEmpty()
+                    .sortedWith(
+                        compareByDescending<ResultRow> { it[WorkSourceEntryTable.qualityScore] }
+                            .thenByDescending { it[WorkSourceEntryTable.matchScore] }
+                            .thenByDescending { it[WorkSourceEntryTable.chaptersCount] }
+                            .thenByDescending { it[WorkSourceEntryTable.lastUpdate] ?: 0L }
+                            .thenBy { it[WorkSourceEntryTable.sourceName] },
+                    )
+            val recommendedSourceId = sourceEntries.firstOrNull()?.get(WorkSourceEntryTable.id)?.toString()
+            val sources =
+                sourceEntries.mapIndexed { index, row ->
+                    WorkSourceEntryDataClass(
+                        id = row[WorkSourceEntryTable.id].toString(),
+                        workId = row[WorkSourceEntryTable.workId].toString(),
+                        mangaId = row[WorkSourceEntryTable.mangaId].value,
+                        sourceId = row[WorkSourceEntryTable.sourceId].toString(),
+                        sourceName = row[WorkSourceEntryTable.sourceName],
+                        sourceIconUrl =
+                            sourceRows[row[WorkSourceEntryTable.sourceId]]
+                                ?.let { sourceRow -> extensionRows[sourceRow[SourceTable.extension].value] }
+                                ?.let { extensionRow -> Extension.getExtensionIconUrl(extensionRow[ExtensionTable.apkName]) },
+                        sourceMangaId = row[WorkSourceEntryTable.sourceMangaId],
+                        sourceTitle = row[WorkSourceEntryTable.sourceTitle],
+                        normalizedSourceTitle = row[WorkSourceEntryTable.normalizedSourceTitle],
+                        chaptersCount = row[WorkSourceEntryTable.chaptersCount],
+                        lastChapter = row[WorkSourceEntryTable.lastChapter],
+                        lastUpdate = row[WorkSourceEntryTable.lastUpdate],
+                        language = row[WorkSourceEntryTable.language],
+                        matchScore = row[WorkSourceEntryTable.matchScore],
+                        qualityScore = row[WorkSourceEntryTable.qualityScore],
+                        thumbnailUrl = mangaRows[row[WorkSourceEntryTable.mangaId].value]?.get(MangaTable.thumbnail_url),
+                        recommended = index == 0,
+                    )
+                }
+            val candidate =
+                WorkCandidate(
+                    id = workRow[WorkTable.id],
+                    canonicalTitle = workRow[WorkTable.canonicalTitle],
+                    normalizedTitle = workRow[WorkTable.normalizedTitle],
+                    aliases =
+                        aliasesByWorkId[workRow[WorkTable.id]]
+                            .orEmpty()
+                            .mapTo(mutableSetOf()) { it[WorkAliasTable.normalizedAlias] },
+                )
+
+            WorkDataClass(
+                id = workRow[WorkTable.id].toString(),
+                canonicalTitle = workRow[WorkTable.canonicalTitle],
+                normalizedTitle = workRow[WorkTable.normalizedTitle],
+                coverUrl = workRow[WorkTable.coverUrl] ?: sources.firstOrNull()?.thumbnailUrl,
+                type = workRow[WorkTable.type],
+                status = workRow[WorkTable.status],
+                createdAt = workRow[WorkTable.createdAt],
+                updatedAt = workRow[WorkTable.updatedAt],
+                confidenceScore = workRow[WorkTable.confidenceScore],
+                searchScore = normalizedQuery?.let { calculateMatchScore(it, candidate) },
+                recommendedSourceId = recommendedSourceId,
+                aliases =
+                    aliasesByWorkId[workRow[WorkTable.id]]
+                        .orEmpty()
+                        .map { aliasRow ->
+                            WorkAliasDataClass(
+                                id = aliasRow[WorkAliasTable.id].toString(),
+                                workId = aliasRow[WorkAliasTable.workId].toString(),
+                                alias = aliasRow[WorkAliasTable.alias],
+                                normalizedAlias = aliasRow[WorkAliasTable.normalizedAlias],
+                                source = aliasRow[WorkAliasTable.aliasSource],
+                                confidence = aliasRow[WorkAliasTable.confidence],
+                            )
+                        },
+                sources = sources,
+            )
+        }.sortedWith(
+            compareByDescending<WorkDataClass> { it.searchScore ?: 0.0 }
+                .thenByDescending { it.sources.maxOfOrNull(WorkSourceEntryDataClass::qualityScore) ?: 0.0 }
+                .thenBy { it.canonicalTitle },
+        )
+    }
+
+    private fun refreshWorkSourceStats(workId: UUID) =
+        runBlocking {
+            val policiesBySource = loadSourcePolicies().associateBy { it.sourceId.toLong() }
+            val refreshTargets =
+                transaction {
+                    val sourceRows =
+                        WorkSourceEntryTable
+                            .innerJoin(MangaTable)
+                            .select(
+                                WorkSourceEntryTable.columns + MangaTable.columns,
+                            ).where { WorkSourceEntryTable.workId eq workId }
+                            .toList()
+                    if (sourceRows.isEmpty()) {
+                        return@transaction emptyList()
+                    }
+
+                    val now = Instant.now().epochSecond
+
+                    sourceRows.mapNotNull { row ->
+                        val sourceId = row[WorkSourceEntryTable.sourceId]
+                        val policy = policiesBySource[sourceId] ?: return@mapNotNull null
+                        val chaptersLastFetchedAt = row[MangaTable.chaptersLastFetchedAt]
+                        val shouldRefresh =
+                            row[WorkSourceEntryTable.chaptersCount] <= 0 ||
+                                row[WorkSourceEntryTable.lastUpdate] == null ||
+                                chaptersLastFetchedAt <= 0L ||
+                                (now - chaptersLastFetchedAt) >= SOURCE_STATS_REFRESH_INTERVAL.inWholeSeconds
+
+                        if (!shouldRefresh) {
+                            return@mapNotNull null
+                        }
+
+                        SourceEntryRefreshTarget(
+                            entryId = row[WorkSourceEntryTable.id],
+                            mangaId = row[WorkSourceEntryTable.mangaId].value,
+                            sourceId = sourceId,
+                            policy = policy,
+                        )
+                    }
+                }
+            val sourceSemaphore = Semaphore(serverConfig.maxSourcesInParallel.value.coerceAtLeast(1))
+
+            coroutineScope {
+                refreshTargets.map { target ->
+                    async {
+                        sourceSemaphore.withPermit {
+                            refreshSourceEntryStats(target)
+                        }
+                    }
+                }.awaitAll()
+            }
+        }
+
+    private suspend fun refreshSourceEntryStats(target: SourceEntryRefreshTarget) {
+        if (sourceStatsFailureCooldown.get(target.sourceId) != null) {
+            return
+        }
+
+        val didRefresh =
+            withTimeoutOrNull(SOURCE_STATS_TIMEOUT) {
+                runCatching { Chapter.fetchChapterList(target.mangaId) }.isSuccess
+            } ?: false
+        if (!didRefresh) {
+            sourceStatsFailureCooldown.put(target.sourceId, Unit)
+            return
+        }
+        sourceStatsFailureCooldown.invalidate(target.sourceId)
+
+        val updatedStats = transaction { loadChapterStats(target.mangaId) }
+        val qualityScore = calculateQualityScore(updatedStats, target.policy)
+
+        transaction {
+            WorkSourceEntryTable.update({ WorkSourceEntryTable.id eq target.entryId }) {
+                it[chaptersCount] = updatedStats.chaptersCount
+                it[lastChapter] = updatedStats.lastChapter
+                it[lastUpdate] = updatedStats.lastUpdate
+                it[WorkSourceEntryTable.qualityScore] = qualityScore
+            }
+        }
+    }
+
+    private fun calculateMatchScore(
+        normalizedTitle: String,
+        candidate: WorkCandidate,
+    ): Double {
+        val exactMatch = if (normalizedTitle == candidate.normalizedTitle) 1.0 else 0.0
+        val aliasMatch = if (normalizedTitle in candidate.aliases) 1.0 else 0.0
+        val comparableTitles = listOf(candidate.normalizedTitle) + candidate.aliases
+        val fuzzySimilarity = comparableTitles.maxOf { similarity(normalizedTitle, it) }
+        val tokenOverlap = comparableTitles.maxOf { tokenOverlap(normalizedTitle, it) }
+
+        return (exactMatch * 100) + (aliasMatch * 80) + (fuzzySimilarity * 60) + (tokenOverlap * 40)
+    }
+
+    private fun similarity(
+        left: String,
+        right: String,
+    ): Double {
+        if (left.isBlank() || right.isBlank()) {
+            return 0.0
+        }
+        if (left == right) {
+            return 1.0
+        }
+
+        val distance = levenshtein(left, right)
+        val maxLength = max(left.length, right.length)
+        return (1.0 - (distance.toDouble() / maxLength.toDouble())).coerceIn(0.0, 1.0)
+    }
+
+    private fun levenshtein(
+        left: String,
+        right: String,
+    ): Int {
+        val distances = IntArray(right.length + 1) { it }
+        for (leftIndex in 1..left.length) {
+            var previousDiagonal = distances[0]
+            distances[0] = leftIndex
+            for (rightIndex in 1..right.length) {
+                val previous = distances[rightIndex]
+                distances[rightIndex] =
+                    if (left[leftIndex - 1] == right[rightIndex - 1]) {
+                        previousDiagonal
+                    } else {
+                        minOf(distances[rightIndex] + 1, distances[rightIndex - 1] + 1, previousDiagonal + 1)
+                    }
+                previousDiagonal = previous
+            }
+        }
+        return distances[right.length]
+    }
+
+    private fun tokenOverlap(
+        left: String,
+        right: String,
+    ): Double {
+        val leftTokens = left.split(" ").filter(String::isNotBlank).toSet()
+        val rightTokens = right.split(" ").filter(String::isNotBlank).toSet()
+        if (leftTokens.isEmpty() || rightTokens.isEmpty()) {
+            return 0.0
+        }
+
+        val intersection = leftTokens.intersect(rightTokens).size.toDouble()
+        val union = leftTokens.union(rightTokens).size.toDouble()
+        return if (union == 0.0) 0.0 else (intersection / union).coerceIn(0.0, 1.0)
+    }
+
+    private fun createWork(
+        title: String,
+        normalizedTitle: String,
+        coverUrl: String?,
+        type: String,
+        status: String,
+        confidenceScore: Double,
+    ): UUID {
+        val now = Instant.now().epochSecond
+        val id = UUID.randomUUID()
+        WorkTable.insert {
+            it[this.id] = id
+            it[canonicalTitle] = title
+            it[WorkTable.normalizedTitle] = normalizedTitle
+            it[WorkTable.coverUrl] = coverUrl
+            it[WorkTable.type] = type
+            it[WorkTable.status] = status
+            it[createdAt] = now
+            it[updatedAt] = now
+            it[WorkTable.confidenceScore] = confidenceScore.coerceIn(0.0, 1.0)
+        }
+        return id
+    }
+
+    private fun insertAliasIfMissing(
+        workId: UUID,
+        alias: String,
+        source: String,
+        confidence: Double,
+    ) {
+        val normalizedAlias = normalize(alias)
+        if (normalizedAlias.isBlank()) {
+            return
+        }
+
+        val work = WorkTable.selectAll().where { WorkTable.id eq workId }.firstOrNull() ?: return
+        if (work[WorkTable.normalizedTitle] == normalizedAlias) {
+            return
+        }
+
+        val exists =
+            WorkAliasTable
+                .selectAll()
+                .where { (WorkAliasTable.workId eq workId) and (WorkAliasTable.normalizedAlias eq normalizedAlias) }
+                .firstOrNull() != null
+
+        if (!exists) {
+            WorkAliasTable.insert {
+                it[id] = UUID.randomUUID()
+                it[this.workId] = workId
+                it[this.alias] = alias
+                it[this.normalizedAlias] = normalizedAlias
+                it[aliasSource] = source
+                it[this.confidence] = confidence.coerceIn(0.0, 1.0)
+            }
+        }
+    }
+
+    private fun upsertSourceEntry(
+        workId: UUID,
+        manga: MangaDataClass,
+        source: SourceDescriptor,
+        chapterStats: ChapterStats,
+        matchScore: Double,
+        qualityScore: Double,
+    ): UUID {
+        val existing = WorkSourceEntryTable.selectAll().where { WorkSourceEntryTable.mangaId eq manga.id }.firstOrNull()
+        val entryId = existing?.get(WorkSourceEntryTable.id) ?: UUID.randomUUID()
+
+        if (existing == null) {
+            WorkSourceEntryTable.insert {
+                it[id] = entryId
+                it[this.workId] = workId
+                it[mangaId] = manga.id
+                it[sourceId] = source.id
+                it[sourceName] = source.name
+                it[sourceMangaId] = manga.url
+                it[sourceTitle] = manga.title
+                it[normalizedSourceTitle] = normalize(manga.title)
+                it[chaptersCount] = chapterStats.chaptersCount
+                it[lastChapter] = chapterStats.lastChapter
+                it[lastUpdate] = chapterStats.lastUpdate
+                it[language] = source.language
+                it[this.matchScore] = matchScore
+                it[this.qualityScore] = qualityScore
+                it[rawMetadata] = """{"url":"${manga.url.replace("\"", "\\\"")}","sourceId":"${manga.sourceId}"}"""
+            }
+        } else {
+            WorkSourceEntryTable.update({ WorkSourceEntryTable.id eq entryId }) {
+                it[this.workId] = workId
+                it[sourceId] = source.id
+                it[sourceName] = source.name
+                it[sourceMangaId] = manga.url
+                it[sourceTitle] = manga.title
+                it[normalizedSourceTitle] = normalize(manga.title)
+                it[chaptersCount] = chapterStats.chaptersCount
+                it[lastChapter] = chapterStats.lastChapter
+                it[lastUpdate] = chapterStats.lastUpdate
+                it[language] = source.language
+                it[this.matchScore] = matchScore
+                it[this.qualityScore] = qualityScore
+                it[rawMetadata] = """{"url":"${manga.url.replace("\"", "\\\"")}","sourceId":"${manga.sourceId}"}"""
+            }
+        }
+
+        return entryId
+    }
+
+    private fun insertMergeCandidate(
+        sourceEntryId: UUID,
+        candidateWorkId: UUID,
+        score: Double,
+    ) {
+        val exists =
+            MergeCandidateTable
+                .selectAll()
+                .where {
+                    (MergeCandidateTable.sourceEntryId eq sourceEntryId) and
+                        (MergeCandidateTable.candidateWorkId eq candidateWorkId)
+                }.firstOrNull() != null
+
+        if (!exists) {
+            MergeCandidateTable.insert {
+                it[id] = UUID.randomUUID()
+                it[this.sourceEntryId] = sourceEntryId
+                it[this.candidateWorkId] = candidateWorkId
+                it[this.score] = score
+                it[status] = "pending"
+            }
+        }
+    }
+
+    private fun loadChapterStats(mangaId: Int): ChapterStats {
+        val chapterRows = ChapterTable.selectAll().where { ChapterTable.manga eq mangaId }.toList()
+        if (chapterRows.isEmpty()) {
+            return ChapterStats(chaptersCount = 0, lastChapter = null, lastUpdate = null)
+        }
+
+        return ChapterStats(
+            chaptersCount = chapterRows.size,
+            lastChapter = chapterRows.maxOfOrNull { it[ChapterTable.chapter_number].toDouble() }?.takeIf { it >= 0.0 },
+            lastUpdate =
+                chapterRows
+                    .maxOfOrNull { normalizeEpochSeconds(it[ChapterTable.date_upload]) }
+                    .takeIf { it != null && it > 0 },
+        )
+    }
+
+    private fun calculateQualityScore(
+        stats: ChapterStats,
+        policy: SourcePolicyDataClass,
+    ): Double {
+        val now = Instant.now().epochSecond
+        val age = stats.lastUpdate?.let { now - normalizeEpochSeconds(it) }
+        val latestChapter = stats.lastChapter?.takeIf { it > 0.0 } ?: stats.chaptersCount.toDouble()
+        val recencyBonus =
+            when {
+                age == null -> 0.0
+                age <= 1.days.inWholeSeconds -> 12.0
+                age <= 7.days.inWholeSeconds -> 8.0
+                age <= 30.days.inWholeSeconds -> 3.0
+                else -> 0.0
+            }
+        val outdatedPenalty = if (age != null && age > 90.days.inWholeSeconds) 10.0 else 0.0
+        val missingChaptersPenalty = if (stats.chaptersCount == 0) 15.0 else 0.0
+        val sourceWeight = (if (policy.trusted) 10.0 else 0.0) + (policy.rankWeight * 10.0)
+
+        return (minOf(stats.chaptersCount, 200) * 0.05) +
+            (minOf(latestChapter, 400.0) * 0.5) +
+            recencyBonus +
+            sourceWeight +
+            policy.languagePriority -
+            missingChaptersPenalty -
+            outdatedPenalty
+    }
+
+    private fun normalizeEpochSeconds(timestamp: Long): Long = if (timestamp > 10_000_000_000L) timestamp / 1000 else timestamp
+
+    private suspend fun searchSourceMangaList(
+        sourceId: Long,
+        query: String,
+        sourceSemaphore: Semaphore,
+    ): List<MangaDataClass> {
+        if (searchFailureCooldown.get(sourceId) != null) {
+            return emptyList()
+        }
+
+        val result =
+            sourceSemaphore.withPermit {
+                withTimeoutOrNull(SOURCE_SEARCH_TIMEOUT) {
+                    runCatching { Search.sourceSearch(sourceId, query, 1).mangaList }.getOrNull()
+                }
+            }
+
+        return result?.also { searchFailureCooldown.invalidate(sourceId) } ?: run {
+            searchFailureCooldown.put(sourceId, Unit)
+            emptyList()
+        }
+    }
+
+    private fun updateWorkMetadata(
+        workId: UUID,
+        manga: MangaDataClass,
+        normalizedTitle: String,
+        confidenceScore: Double,
+    ) {
+        val existing = WorkTable.selectAll().where { WorkTable.id eq workId }.firstOrNull() ?: return
+        val now = Instant.now().epochSecond
+        val currentConfidence = existing[WorkTable.confidenceScore]
+        val currentCanonicalTitle = existing[WorkTable.canonicalTitle]
+        val shouldPromoteTitle = normalizedTitle == normalize(currentCanonicalTitle) && manga.title.length < currentCanonicalTitle.length
+
+        WorkTable.update({ WorkTable.id eq workId }) {
+            it[updatedAt] = now
+            it[WorkTable.confidenceScore] = max(currentConfidence, confidenceScore.coerceIn(0.0, 1.0))
+            if (existing[WorkTable.coverUrl].isNullOrBlank() && !manga.thumbnailUrl.isNullOrBlank()) {
+                it[coverUrl] = manga.thumbnailUrl
+            }
+            if (shouldPromoteTitle) {
+                it[canonicalTitle] = manga.title
+                it[WorkTable.normalizedTitle] = normalizedTitle
+            }
+            if (existing[WorkTable.type] == "unknown") {
+                it[type] = guessType(manga)
+            }
+            if (existing[WorkTable.status] == "unknown") {
+                it[status] = mapStatus(manga.status)
+            }
+        }
+    }
+
+    private fun touchWork(
+        workId: UUID,
+        confidenceScore: Double,
+    ) {
+        val existing = WorkTable.selectAll().where { WorkTable.id eq workId }.firstOrNull() ?: return
+        WorkTable.update({ WorkTable.id eq workId }) {
+            it[updatedAt] = Instant.now().epochSecond
+            it[WorkTable.confidenceScore] = max(existing[WorkTable.confidenceScore], confidenceScore.coerceIn(0.0, 1.0))
+        }
+    }
+
+    private fun requireWorkExists(workId: UUID) {
+        check(WorkTable.selectAll().where { WorkTable.id eq workId }.firstOrNull() != null) { "work $workId not found" }
+    }
+
+    private fun guessType(manga: MangaDataClass): String {
+        val haystack = (manga.genre + listOfNotNull(manga.description, manga.title)).joinToString(" ").lowercase()
+        return when {
+            "manhwa" in haystack -> "manhwa"
+            "manhua" in haystack -> "manhua"
+            "manga" in haystack -> "manga"
+            else -> "unknown"
+        }
+    }
+
+    private fun mapStatus(status: String): String =
+        when (status.uppercase()) {
+            "ONGOING", "ON_HIATUS" -> "ongoing"
+            "COMPLETED", "PUBLISHING_FINISHED" -> "completed"
+            else -> "unknown"
+        }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/WorkDataClass.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/dataclass/WorkDataClass.kt
@@ -1,0 +1,71 @@
+package suwayomi.tachidesk.manga.model.dataclass
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+data class WorkAliasDataClass(
+    val id: String,
+    val workId: String,
+    val alias: String,
+    val normalizedAlias: String,
+    val source: String,
+    val confidence: Double,
+)
+
+data class WorkSourceEntryDataClass(
+    val id: String,
+    val workId: String,
+    val mangaId: Int,
+    val sourceId: String,
+    val sourceName: String,
+    val sourceIconUrl: String?,
+    val sourceMangaId: String,
+    val sourceTitle: String,
+    val normalizedSourceTitle: String,
+    val chaptersCount: Int,
+    val lastChapter: Double?,
+    val lastUpdate: Long?,
+    val language: String,
+    val matchScore: Double,
+    val qualityScore: Double,
+    val thumbnailUrl: String?,
+    val recommended: Boolean,
+)
+
+data class WorkDataClass(
+    val id: String,
+    val canonicalTitle: String,
+    val normalizedTitle: String,
+    val coverUrl: String?,
+    val type: String,
+    val status: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val confidenceScore: Double,
+    val searchScore: Double?,
+    val recommendedSourceId: String?,
+    val aliases: List<WorkAliasDataClass>,
+    val sources: List<WorkSourceEntryDataClass>,
+)
+
+data class WorkSearchResultDataClass(
+    val query: String,
+    val normalizedQuery: String,
+    val works: List<WorkDataClass>,
+    val searchedSources: Int,
+    val matchedSources: Int,
+)
+
+data class SourcePolicyDataClass(
+    val sourceId: String,
+    val sourceName: String,
+    val enabled: Boolean,
+    val trusted: Boolean,
+    val rankWeight: Double,
+    val languagePriority: Int,
+    val installLocked: Boolean,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/WorkTable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/model/table/WorkTable.kt
@@ -1,0 +1,87 @@
+package suwayomi.tachidesk.manga.model.table
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+import suwayomi.tachidesk.manga.model.table.columns.truncatingVarchar
+
+object WorkTable : Table("works") {
+    val id = uuid("id")
+    val canonicalTitle = truncatingVarchar("canonical_title", 512)
+    val normalizedTitle = truncatingVarchar("normalized_title", 512).index()
+    val coverUrl = varchar("cover_url", 2048).nullable()
+    val type = varchar("type", 32).default("unknown")
+    val status = varchar("status", 32).default("unknown")
+    val createdAt = long("created_at")
+    val updatedAt = long("updated_at")
+    val confidenceScore = double("confidence_score").default(0.0)
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object WorkAliasTable : Table("work_aliases") {
+    val id = uuid("id")
+    val workId = reference("work_id", WorkTable.id, onDelete = ReferenceOption.CASCADE)
+    val alias = truncatingVarchar("alias", 512)
+    val normalizedAlias = truncatingVarchar("normalized_alias", 512)
+    val aliasSource = varchar("source", 32)
+    val confidence = double("confidence").default(0.0)
+
+    init {
+        uniqueIndex("work_aliases_work_id_normalized_alias_uindex", workId, normalizedAlias)
+    }
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object WorkSourceEntryTable : Table("source_entries") {
+    val id = uuid("id")
+    val workId = reference("work_id", WorkTable.id, onDelete = ReferenceOption.CASCADE)
+    val mangaId = reference("manga_id", MangaTable.id, onDelete = ReferenceOption.CASCADE).uniqueIndex()
+    val sourceId = long("source_id")
+    val sourceName = varchar("source_name", 128)
+    val sourceMangaId = varchar("source_manga_id", 2048)
+    val sourceTitle = truncatingVarchar("source_title", 512)
+    val normalizedSourceTitle = truncatingVarchar("normalized_source_title", 512).index()
+    val chaptersCount = integer("chapters_count").default(0)
+    val lastChapter = double("last_chapter").nullable()
+    val lastUpdate = long("last_update").nullable()
+    val language = varchar("language", 32)
+    val matchScore = double("match_score").default(0.0)
+    val qualityScore = double("quality_score").default(0.0)
+    val rawMetadata = text("raw_metadata").nullable()
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object SourcePolicyTable : Table("source_policy") {
+    val sourceId = long("source_id")
+    val sourceName = varchar("source_name", 128)
+    val enabled = bool("enabled").default(true)
+    val trusted = bool("trusted").default(true)
+    val rankWeight = double("rank_weight").default(0.0)
+    val languagePriority = integer("language_priority").default(0)
+    val installLocked = bool("install_locked").default(false)
+
+    override val primaryKey = PrimaryKey(sourceId)
+}
+
+object MergeCandidateTable : Table("merge_candidates") {
+    val id = uuid("id")
+    val sourceEntryId = reference("source_entry_id", WorkSourceEntryTable.id, onDelete = ReferenceOption.CASCADE)
+    val candidateWorkId = reference("candidate_work_id", WorkTable.id, onDelete = ReferenceOption.CASCADE)
+    val score = double("score")
+    val status = varchar("status", 32).default("pending")
+
+    init {
+        uniqueIndex("merge_candidates_source_entry_candidate_work_uindex", sourceEntryId, candidateWorkId)
+    }
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0055_MangaAggregation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0055_MangaAggregation.kt
@@ -1,0 +1,85 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+
+@Suppress("ClassName", "unused")
+class M0055_MangaAggregation : SQLMigration() {
+    override val sql =
+        """
+        CREATE TABLE IF NOT EXISTS works (
+            id UUID PRIMARY KEY,
+            canonical_title VARCHAR(512) NOT NULL,
+            normalized_title VARCHAR(512) NOT NULL,
+            cover_url VARCHAR(2048),
+            type VARCHAR(32) NOT NULL DEFAULT 'unknown',
+            status VARCHAR(32) NOT NULL DEFAULT 'unknown',
+            created_at BIGINT NOT NULL,
+            updated_at BIGINT NOT NULL,
+            confidence_score DOUBLE PRECISION NOT NULL DEFAULT 0.0
+        );
+
+        CREATE INDEX IF NOT EXISTS works_normalized_title_idx ON works(normalized_title);
+
+        CREATE TABLE IF NOT EXISTS work_aliases (
+            id UUID PRIMARY KEY,
+            work_id UUID NOT NULL,
+            alias VARCHAR(512) NOT NULL,
+            normalized_alias VARCHAR(512) NOT NULL,
+            source VARCHAR(32) NOT NULL,
+            confidence DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+            CONSTRAINT fk_work_aliases_work FOREIGN KEY (work_id) REFERENCES works(id) ON DELETE CASCADE,
+            CONSTRAINT uq_work_aliases_work_normalized_alias UNIQUE (work_id, normalized_alias)
+        );
+
+        CREATE TABLE IF NOT EXISTS source_entries (
+            id UUID PRIMARY KEY,
+            work_id UUID NOT NULL,
+            manga_id INT NOT NULL,
+            source_id BIGINT NOT NULL,
+            source_name VARCHAR(128) NOT NULL,
+            source_manga_id VARCHAR(2048) NOT NULL,
+            source_title VARCHAR(512) NOT NULL,
+            normalized_source_title VARCHAR(512) NOT NULL,
+            chapters_count INT NOT NULL DEFAULT 0,
+            last_chapter DOUBLE PRECISION,
+            last_update BIGINT,
+            language VARCHAR(32) NOT NULL,
+            match_score DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+            quality_score DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+            raw_metadata TEXT,
+            CONSTRAINT fk_source_entries_work FOREIGN KEY (work_id) REFERENCES works(id) ON DELETE CASCADE,
+            CONSTRAINT fk_source_entries_manga FOREIGN KEY (manga_id) REFERENCES manga(id) ON DELETE CASCADE,
+            CONSTRAINT uq_source_entries_manga UNIQUE (manga_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS source_entries_normalized_source_title_idx ON source_entries(normalized_source_title);
+
+        CREATE TABLE IF NOT EXISTS source_policy (
+            source_id BIGINT PRIMARY KEY,
+            source_name VARCHAR(128) NOT NULL,
+            enabled BOOLEAN NOT NULL DEFAULT TRUE,
+            trusted BOOLEAN NOT NULL DEFAULT TRUE,
+            rank_weight DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+            language_priority INT NOT NULL DEFAULT 0,
+            install_locked BOOLEAN NOT NULL DEFAULT FALSE
+        );
+
+        CREATE TABLE IF NOT EXISTS merge_candidates (
+            id UUID PRIMARY KEY,
+            source_entry_id UUID NOT NULL,
+            candidate_work_id UUID NOT NULL,
+            score DOUBLE PRECISION NOT NULL,
+            status VARCHAR(32) NOT NULL DEFAULT 'pending',
+            CONSTRAINT fk_merge_candidates_source_entry FOREIGN KEY (source_entry_id) REFERENCES source_entries(id) ON DELETE CASCADE,
+            CONSTRAINT fk_merge_candidates_candidate_work FOREIGN KEY (candidate_work_id) REFERENCES works(id) ON DELETE CASCADE,
+            CONSTRAINT uq_merge_candidates_source_entry_candidate_work UNIQUE (source_entry_id, candidate_work_id)
+        );
+        """.trimIndent()
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/WorkSearchTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/WorkSearchTest.kt
@@ -1,0 +1,50 @@
+package suwayomi.tachidesk.manga.impl
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WorkSearchTest {
+    @Test
+    fun `normalize removes tags punctuation and accents`() {
+        assertEquals(
+            "solo leveling",
+            WorkSearch.normalize("Sóló Leveling [ES] (Official)"),
+        )
+    }
+
+    @Test
+    fun `variant titles pass safe match threshold`() {
+        val score = WorkSearch.previewMatchScore("Solo Leveling [ES]", "Solo Leveling")
+
+        assertTrue(score >= 80.0, "expected a safe match but got $score")
+    }
+
+    @Test
+    fun `alias titles pass safe match threshold`() {
+        val score =
+            WorkSearch.previewMatchScore(
+                title = "Only I Level Up",
+                canonicalTitle = "Solo Leveling",
+                aliases = listOf("Only I Level Up"),
+            )
+
+        assertTrue(score >= 80.0, "expected an alias match but got $score")
+    }
+
+    @Test
+    fun `sequels and spin offs stay below grouping threshold`() {
+        val sequelScore = WorkSearch.previewMatchScore("Naruto Shippuden", "Naruto")
+        val spinoffScore = WorkSearch.previewMatchScore("Berserk of Gluttony", "Berserk")
+
+        assertTrue(sequelScore < 60.0, "expected sequel score below threshold but got $sequelScore")
+        assertTrue(spinoffScore < 60.0, "expected spinoff score below threshold but got $spinoffScore")
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the backend foundation for an optional aggregated search flow that groups matching source entries into canonical works.

It introduces:
- aggregated search endpoint
- work detail endpoint
- work sources endpoint
- manual merge endpoint
- manual alias endpoint
- source aggregation policy endpoints
- source ranking/matching logic
- persistence for works, aliases, source entries, source policy, and merge candidates

## Why

When searching across many sources, the current experience can become noisy because the same series appears multiple times under slightly different names.

This backend adds an optional work-level aggregation layer so clients can present:
- one canonical work entry
- multiple source options inside that work
- a recommended source

## Notes

- This is designed as an optional feature for clients.
- Matching and ranking are heuristic-based and intentionally conservative.
- The implementation includes concurrency limiting, timeouts, and cooldowns to reduce source load.
- Tests currently cover normalization and match-threshold behavior.

## API

New REST endpoints:
- `GET /api/v1/search?q=...`
- `GET /api/v1/work/{id}`
- `GET /api/v1/work/{id}/sources`
- `POST /api/v1/work/merge`
- `POST /api/v1/work/{id}/alias`
- `GET /api/v1/source/{sourceId}/policy`
- `PATCH /api/v1/source/{sourceId}/policy`

## Companion PR

Companion WebUI PR adds the optional `Smart search` toggle and the grouped work/sources UI.

## Testing

- `./gradlew :server:compileKotlin`
- unit tests added for normalization and match threshold behavior
