### PR TITLE
feat: add manga metadata editing, cover upload, and metadata providers

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MangaMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MangaMutation.kt
@@ -1,6 +1,11 @@
 package suwayomi.tachidesk.graphql.mutations
 
+import eu.kanade.tachiyomi.source.local.LocalSource
+import eu.kanade.tachiyomi.source.local.image.LocalCoverManager
+import eu.kanade.tachiyomi.source.local.io.LocalSourceFileSystem
+import eu.kanade.tachiyomi.source.model.SManga
 import graphql.execution.DataFetcherResult
+import io.javalin.http.UploadedFile
 import org.jetbrains.exposed.sql.LikePattern
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -18,13 +23,20 @@ import suwayomi.tachidesk.graphql.types.MangaMetaType
 import suwayomi.tachidesk.graphql.types.MangaType
 import suwayomi.tachidesk.graphql.types.MetaInput
 import suwayomi.tachidesk.manga.impl.Library
+import suwayomi.tachidesk.manga.impl.LocalMangaDetailsService
 import suwayomi.tachidesk.manga.impl.Manga
+import suwayomi.tachidesk.manga.impl.MangaList
 import suwayomi.tachidesk.manga.impl.update.IUpdater
+import suwayomi.tachidesk.manga.impl.util.getThumbnailDownloadPath
+import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
 import suwayomi.tachidesk.manga.model.table.MangaMetaTable
+import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
+import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.JavalinSetup.future
 import uy.kohesive.injekt.injectLazy
+import java.io.File
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 
@@ -93,6 +105,172 @@ class MangaMutation {
                 ids.forEach {
                     Library.handleMangaThumbnail(it, patch.inLibrary)
                 }
+            }
+        }
+    }
+
+    // --- Manga Details Editing ---
+
+    data class UpdateMangaDetailsPatch(
+        val title: String? = null,
+        val author: String? = null,
+        val artist: String? = null,
+        val description: String? = null,
+        val genre: List<String>? = null,
+        val status: MangaStatus? = null,
+    )
+
+    data class UpdateMangaDetailsInput(
+        val clientMutationId: String? = null,
+        val id: Int,
+        val patch: UpdateMangaDetailsPatch,
+    )
+
+    data class UpdateMangaDetailsPayload(
+        val clientMutationId: String?,
+        val manga: MangaType,
+    )
+
+    private val applicationDirs: ApplicationDirs by injectLazy()
+    private val localMangaDetailsService = LocalMangaDetailsService()
+
+    @RequireAuth
+    fun updateMangaDetails(input: UpdateMangaDetailsInput): CompletableFuture<DataFetcherResult<UpdateMangaDetailsPayload?>> {
+        val (clientMutationId, id, patch) = input
+
+        return future {
+            asDataFetcherResult {
+                // Step 1: Update database (skip if no fields to update)
+                val hasUpdates =
+                    patch.title != null ||
+                        patch.author != null ||
+                        patch.artist != null ||
+                        patch.description != null ||
+                        patch.genre != null ||
+                        patch.status != null
+
+                if (hasUpdates) {
+                    transaction {
+                        MangaTable.update({ MangaTable.id eq id }) { update ->
+                            patch.title?.let { update[title] = it }
+                            patch.author?.let { update[author] = it }
+                            patch.artist?.let { update[artist] = it }
+                            patch.description?.let { update[description] = it }
+                            patch.genre?.let { update[genre] = it.joinToString(", ") }
+                            patch.status?.let { update[status] = it.value }
+                        }
+                    }
+                }
+
+                // Step 2: Write details.json for local source manga
+                val row =
+                    transaction {
+                        MangaTable.selectAll().where { MangaTable.id eq id }.firstOrNull()
+                            ?: throw IllegalArgumentException("Manga with id $id not found")
+                    }
+
+                val sourceId = row[MangaTable.sourceReference]
+                if (sourceId == LocalSource.ID) {
+                    val mangaUrl = row[MangaTable.url]
+                    val fileSystem = LocalSourceFileSystem(applicationDirs)
+                    val mangaDir = fileSystem.getMangaDirectory(mangaUrl)
+
+                    if (mangaDir != null) {
+                        val existing = localMangaDetailsService.readDetails(mangaDir)
+                        val merged =
+                            localMangaDetailsService.mergeDetails(
+                                existing = existing,
+                                title = patch.title,
+                                author = patch.author,
+                                artist = patch.artist,
+                                description = patch.description,
+                                genre = patch.genre,
+                                status = patch.status?.value,
+                            )
+                        localMangaDetailsService.writeDetailsWithLock(mangaDir, merged)
+                    }
+                }
+
+                // Step 3: Return updated manga
+                val manga =
+                    transaction {
+                        MangaType(MangaTable.selectAll().where { MangaTable.id eq id }.first())
+                    }
+
+                UpdateMangaDetailsPayload(
+                    clientMutationId = clientMutationId,
+                    manga = manga,
+                )
+            }
+        }
+    }
+
+    // --- Cover Image Upload ---
+
+    data class UploadMangaCoverInput(
+        val clientMutationId: String? = null,
+        val id: Int,
+        val cover: UploadedFile,
+    )
+
+    data class UploadMangaCoverPayload(
+        val clientMutationId: String?,
+        val manga: MangaType,
+    )
+
+    @RequireAuth
+    fun uploadMangaCover(input: UploadMangaCoverInput): CompletableFuture<DataFetcherResult<UploadMangaCoverPayload?>> {
+        val (clientMutationId, id, cover) = input
+
+        return future {
+            asDataFetcherResult {
+                // Buffer the uploaded file so we can read it multiple times
+                val imageBytes = cover.content().use { it.readBytes() }
+                val mimeType = cover.contentType()
+
+                val row =
+                    transaction {
+                        MangaTable.selectAll().where { MangaTable.id eq id }.firstOrNull()
+                            ?: throw IllegalArgumentException("Manga with id $id not found")
+                    }
+
+                // Step 1: Clear old cached thumbnail
+                Manga.clearThumbnail(id)
+
+                // Step 2: Save to thumbnail cache
+                val thumbnailDir = applicationDirs.thumbnailDownloadsRoot
+                File(thumbnailDir).let { if (!it.exists()) it.mkdir() }
+                val filePath = getThumbnailDownloadPath(id)
+                ImageResponse.saveImage(filePath, imageBytes.inputStream(), mimeType)
+
+                // Step 3: Update DB with proxy URL and cache-bust timestamp
+                transaction {
+                    MangaTable.update({ MangaTable.id eq id }) { update ->
+                        update[thumbnail_url] = MangaList.proxyThumbnailUrl(id)
+                        update[thumbnailUrlLastFetched] = System.currentTimeMillis()
+                    }
+                }
+
+                // Step 4: Write cover.jpg for local source manga
+                val sourceId = row[MangaTable.sourceReference]
+                if (sourceId == LocalSource.ID) {
+                    val mangaUrl = row[MangaTable.url]
+                    val fileSystem = LocalSourceFileSystem(applicationDirs)
+                    val coverManager = LocalCoverManager(fileSystem)
+                    val sManga = SManga.create().apply { url = mangaUrl }
+                    coverManager.update(sManga, imageBytes.inputStream())
+                }
+
+                // Step 5: Return updated manga
+                val manga =
+                    transaction {
+                        MangaType(MangaTable.selectAll().where { MangaTable.id eq id }.first())
+                    }
+
+                UploadMangaCoverPayload(
+                    clientMutationId = clientMutationId,
+                    manga = manga,
+                )
             }
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MetadataMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MetadataMutation.kt
@@ -1,0 +1,220 @@
+package suwayomi.tachidesk.graphql.mutations
+
+import eu.kanade.tachiyomi.source.local.LocalSource
+import eu.kanade.tachiyomi.source.local.image.LocalCoverManager
+import eu.kanade.tachiyomi.source.local.io.LocalSourceFileSystem
+import eu.kanade.tachiyomi.source.model.SManga
+import graphql.execution.DataFetcherResult
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import suwayomi.tachidesk.graphql.asDataFetcherResult
+import suwayomi.tachidesk.graphql.directives.RequireAuth
+import suwayomi.tachidesk.graphql.types.MangaType
+import suwayomi.tachidesk.manga.impl.LocalMangaDetailsService
+import suwayomi.tachidesk.manga.impl.Manga
+import suwayomi.tachidesk.manga.impl.MangaList
+import suwayomi.tachidesk.manga.impl.metadata.AniListMetadataProvider
+import suwayomi.tachidesk.manga.impl.metadata.MangaUpdatesMetadataProvider
+import suwayomi.tachidesk.manga.impl.metadata.MetadataProvider
+import suwayomi.tachidesk.manga.impl.util.getThumbnailDownloadPath
+import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
+import suwayomi.tachidesk.manga.model.table.MangaStatus
+import suwayomi.tachidesk.manga.model.table.MangaTable
+import suwayomi.tachidesk.server.ApplicationDirs
+import suwayomi.tachidesk.server.JavalinSetup.future
+import uy.kohesive.injekt.injectLazy
+import java.io.File
+import java.net.URI
+import java.util.concurrent.CompletableFuture
+
+class MetadataMutation {
+    private val applicationDirs: ApplicationDirs by injectLazy()
+    private val localMangaDetailsService = LocalMangaDetailsService()
+
+    private val providers: Map<String, MetadataProvider> =
+        listOf(
+            AniListMetadataProvider(),
+            MangaUpdatesMetadataProvider(),
+        ).associateBy { it.name.lowercase() }
+
+    // --- Search ---
+
+    data class MetadataSearchResultType(
+        val externalId: String,
+        val title: String,
+        val author: String?,
+        val coverUrl: String?,
+        val year: Int?,
+        val description: String?,
+    )
+
+    data class SearchMetadataProviderInput(
+        val clientMutationId: String? = null,
+        val provider: String,
+        val query: String,
+        val author: String? = null,
+    )
+
+    data class SearchMetadataProviderPayload(
+        val clientMutationId: String?,
+        val results: List<MetadataSearchResultType>,
+    )
+
+    @RequireAuth
+    fun searchMetadataProvider(input: SearchMetadataProviderInput): CompletableFuture<DataFetcherResult<SearchMetadataProviderPayload?>> {
+        val (clientMutationId, providerName, query, author) = input
+
+        return future {
+            asDataFetcherResult {
+                val provider =
+                    providers[providerName.lowercase()]
+                        ?: throw IllegalArgumentException(
+                            "Unknown provider '$providerName'. Available: ${providers.keys.joinToString()}",
+                        )
+
+                val results =
+                    provider.search(query, author).map {
+                        MetadataSearchResultType(
+                            externalId = it.externalId,
+                            title = it.title,
+                            author = it.author,
+                            coverUrl = it.coverUrl,
+                            year = it.year,
+                            description = it.description,
+                        )
+                    }
+
+                SearchMetadataProviderPayload(
+                    clientMutationId = clientMutationId,
+                    results = results,
+                )
+            }
+        }
+    }
+
+    // --- Apply Match ---
+
+    data class ApplyMetadataMatchInput(
+        val clientMutationId: String? = null,
+        val mangaId: Int,
+        val provider: String,
+        val externalId: String,
+        val includeCover: Boolean = true,
+    )
+
+    data class ApplyMetadataMatchPayload(
+        val clientMutationId: String?,
+        val manga: MangaType,
+    )
+
+    @RequireAuth
+    fun applyMetadataMatch(input: ApplyMetadataMatchInput): CompletableFuture<DataFetcherResult<ApplyMetadataMatchPayload?>> {
+        val (clientMutationId, mangaId, providerName, externalId, includeCover) = input
+
+        return future {
+            asDataFetcherResult {
+                val provider =
+                    providers[providerName.lowercase()]
+                        ?: throw IllegalArgumentException(
+                            "Unknown provider '$providerName'. Available: ${providers.keys.joinToString()}",
+                        )
+
+                val details = provider.getDetails(externalId)
+
+                val row =
+                    transaction {
+                        MangaTable.selectAll().where { MangaTable.id eq mangaId }.firstOrNull()
+                            ?: throw IllegalArgumentException("Manga with id $mangaId not found")
+                    }
+
+                // Step 1: Update DB with text metadata
+                transaction {
+                    MangaTable.update({ MangaTable.id eq mangaId }) { update ->
+                        details.title?.let { update[title] = it }
+                        details.author?.let { update[author] = it }
+                        details.artist?.let { update[artist] = it }
+                        details.description?.let { update[description] = it }
+                        details.genre?.let { update[genre] = it.joinToString(", ") }
+                        details.status?.let { update[status] = it }
+                    }
+                }
+
+                // Step 2: Write details.json for local source manga
+                val sourceId = row[MangaTable.sourceReference]
+                if (sourceId == LocalSource.ID) {
+                    val mangaUrl = row[MangaTable.url]
+                    val fileSystem = LocalSourceFileSystem(applicationDirs)
+                    val mangaDir = fileSystem.getMangaDirectory(mangaUrl)
+
+                    if (mangaDir != null) {
+                        val existing = localMangaDetailsService.readDetails(mangaDir)
+                        val merged =
+                            localMangaDetailsService.mergeDetails(
+                                existing = existing,
+                                title = details.title,
+                                author = details.author,
+                                artist = details.artist,
+                                description = details.description,
+                                genre = details.genre,
+                                status = details.status,
+                            )
+                        localMangaDetailsService.writeDetailsWithLock(mangaDir, merged)
+                    }
+                }
+
+                // Step 3: Download and save cover if requested
+                if (includeCover && details.coverUrl != null) {
+                    downloadAndSaveCover(mangaId, details.coverUrl, sourceId, row[MangaTable.url])
+                }
+
+                // Step 4: Return updated manga
+                val manga =
+                    transaction {
+                        MangaType(MangaTable.selectAll().where { MangaTable.id eq mangaId }.first())
+                    }
+
+                ApplyMetadataMatchPayload(
+                    clientMutationId = clientMutationId,
+                    manga = manga,
+                )
+            }
+        }
+    }
+
+    private suspend fun downloadAndSaveCover(
+        mangaId: Int,
+        coverUrl: String,
+        sourceId: Long,
+        mangaUrl: String,
+    ) {
+        val imageBytes =
+            URI(coverUrl).toURL().openStream().use { it.readBytes() }
+
+        // Clear old cache and save new thumbnail
+        Manga.clearThumbnail(mangaId)
+        val thumbnailDir = applicationDirs.thumbnailDownloadsRoot
+        File(thumbnailDir).let { if (!it.exists()) it.mkdir() }
+        ImageResponse.saveImage(
+            getThumbnailDownloadPath(mangaId),
+            imageBytes.inputStream(),
+            null,
+        )
+
+        // Update DB
+        transaction {
+            MangaTable.update({ MangaTable.id eq mangaId }) { update ->
+                update[thumbnail_url] = MangaList.proxyThumbnailUrl(mangaId)
+                update[thumbnailUrlLastFetched] = System.currentTimeMillis()
+            }
+        }
+
+        // Write cover.jpg for local source
+        if (sourceId == LocalSource.ID) {
+            val fileSystem = LocalSourceFileSystem(applicationDirs)
+            val coverManager = LocalCoverManager(fileSystem)
+            val sManga = SManga.create().apply { url = mangaUrl }
+            coverManager.update(sManga, imageBytes.inputStream())
+        }
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
@@ -25,6 +25,7 @@ import suwayomi.tachidesk.graphql.mutations.InfoMutation
 import suwayomi.tachidesk.graphql.mutations.KoreaderSyncMutation
 import suwayomi.tachidesk.graphql.mutations.MangaMutation
 import suwayomi.tachidesk.graphql.mutations.MetaMutation
+import suwayomi.tachidesk.graphql.mutations.MetadataMutation
 import suwayomi.tachidesk.graphql.mutations.SettingsMutation
 import suwayomi.tachidesk.graphql.mutations.SourceMutation
 import suwayomi.tachidesk.graphql.mutations.TrackMutation
@@ -113,6 +114,7 @@ val schema =
                 TopLevelObject(KoreaderSyncMutation()),
                 TopLevelObject(MangaMutation()),
                 TopLevelObject(MetaMutation()),
+                TopLevelObject(MetadataMutation()),
                 TopLevelObject(SettingsMutation()),
                 TopLevelObject(SourceMutation()),
                 TopLevelObject(TrackMutation()),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsService.kt
@@ -1,0 +1,95 @@
+package suwayomi.tachidesk.manga.impl
+
+import eu.kanade.tachiyomi.source.local.metadata.MangaDetails
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+class LocalMangaDetailsService(
+    private val json: Json =
+        Json {
+            prettyPrint = true
+            encodeDefaults = false
+            ignoreUnknownKeys = true
+        },
+) {
+    private val mutexMap = ConcurrentHashMap<String, Mutex>()
+
+    private val logger = KotlinLogging.logger {}
+
+    fun readDetails(mangaDir: File): MangaDetails {
+        val detailsFile =
+            mangaDir.listFiles()?.firstOrNull { it.extension == "json" }
+                ?: return MangaDetails()
+
+        return try {
+            json.decodeFromString<MangaDetails>(detailsFile.readText())
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse details.json in ${mangaDir.name}, starting fresh" }
+            MangaDetails()
+        }
+    }
+
+    fun mergeDetails(
+        existing: MangaDetails,
+        title: String?,
+        author: String?,
+        artist: String?,
+        description: String?,
+        genre: List<String>?,
+        status: Int?,
+    ): MangaDetails =
+        MangaDetails(
+            title = mergeStringField(existing.title, title),
+            author = mergeStringField(existing.author, author),
+            artist = mergeStringField(existing.artist, artist),
+            description = mergeStringField(existing.description, description),
+            genre =
+                when {
+                    genre == null -> existing.genre
+                    genre.isEmpty() -> null
+                    else -> genre
+                },
+            status = status ?: existing.status,
+        )
+
+    fun writeDetails(
+        mangaDir: File,
+        details: MangaDetails,
+    ) {
+        val content = json.encodeToString(details)
+        val detailsFile = File(mangaDir, DETAILS_FILE_NAME)
+        val tempFile = File(mangaDir, "$DETAILS_FILE_NAME.tmp")
+
+        tempFile.writeText(content)
+        tempFile.renameTo(detailsFile)
+    }
+
+    suspend fun writeDetailsWithLock(
+        mangaDir: File,
+        details: MangaDetails,
+    ) {
+        val mutex = mutexMap.getOrPut(mangaDir.absolutePath) { Mutex() }
+        mutex.withLock {
+            writeDetails(mangaDir, details)
+        }
+    }
+
+    private fun mergeStringField(
+        existing: String?,
+        patch: String?,
+    ): String? =
+        when {
+            patch == null -> existing
+            patch.isEmpty() -> null
+            else -> patch
+        }
+
+    companion object {
+        const val DETAILS_FILE_NAME = "details.json"
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -415,6 +415,16 @@ object Manga {
     suspend fun getMangaThumbnail(mangaId: Int): Pair<InputStream, String> {
         val mangaEntry = transaction { MangaTable.selectAll().where { MangaTable.id eq mangaId }.first() }
 
+        // Check thumbnail cache for user-uploaded covers (any source)
+        val hasUserUploadedCover = mangaEntry[MangaTable.thumbnailUrlLastFetched] > 0
+        if (hasUserUploadedCover) {
+            try {
+                return ThumbnailDownloadHelper.getImage(mangaId)
+            } catch (_: MissingThumbnailException) {
+                // fall through to original logic
+            }
+        }
+
         if (mangaEntry[MangaTable.inLibrary] && mangaEntry[MangaTable.sourceReference] != LocalSource.ID) {
             return try {
                 ThumbnailDownloadHelper.getImage(mangaId)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/AniListMetadataProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/AniListMetadataProvider.kt
@@ -1,0 +1,294 @@
+package suwayomi.tachidesk.manga.impl.metadata
+
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.jsonMime
+import eu.kanade.tachiyomi.network.parseAs
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import okhttp3.RequestBody.Companion.toRequestBody
+import uy.kohesive.injekt.injectLazy
+
+class AniListMetadataProvider : MetadataProvider {
+    private val networkHelper: NetworkHelper by injectLazy()
+    private val json: Json by injectLazy()
+    private val logger = KotlinLogging.logger {}
+
+    override val name: String = "AniList"
+
+    override suspend fun search(
+        query: String,
+        author: String?,
+    ): List<MetadataSearchResult> {
+        val variables =
+            buildJsonObject {
+                put("search", query)
+                put("type", "MANGA")
+            }
+        val body =
+            buildJsonObject {
+                put("query", SEARCH_QUERY)
+                putJsonObject("variables") {
+                    put("search", query)
+                    put("type", "MANGA")
+                }
+            }.toString().toRequestBody(jsonMime)
+
+        val response =
+            with(json) {
+                networkHelper.client
+                    .newCall(POST(API_URL, body = body))
+                    .awaitSuccess()
+                    .parseAs<AniListSearchResponse>()
+            }
+
+        return response.data.page.media.map { media ->
+            MetadataSearchResult(
+                externalId = media.id.toString(),
+                title = media.title.userPreferred ?: media.title.romaji ?: media.title.english ?: "",
+                author =
+                    media.staff
+                        ?.edges
+                        ?.firstOrNull { it.role.contains("Story", ignoreCase = true) }
+                        ?.node
+                        ?.name
+                        ?.full,
+                coverUrl = media.coverImage?.large ?: media.coverImage?.medium,
+                year = media.startDate?.year,
+                description = media.description?.stripHtml(),
+            )
+        }
+    }
+
+    override suspend fun getDetails(externalId: String): MetadataDetails {
+        val body =
+            buildJsonObject {
+                put("query", DETAILS_QUERY)
+                putJsonObject("variables") {
+                    put("id", externalId.toInt())
+                }
+            }.toString().toRequestBody(jsonMime)
+
+        val response =
+            with(json) {
+                networkHelper.client
+                    .newCall(POST(API_URL, body = body))
+                    .awaitSuccess()
+                    .parseAs<AniListDetailsResponse>()
+            }
+
+        val media = response.data.media
+        val staffEdges = media.staff?.edges.orEmpty()
+
+        val author =
+            staffEdges
+                .firstOrNull { it.role.contains("Story", ignoreCase = true) }
+                ?.node
+                ?.name
+                ?.full
+        val artist =
+            staffEdges
+                .firstOrNull { it.role.contains("Art", ignoreCase = true) }
+                ?.node
+                ?.name
+                ?.full
+
+        return MetadataDetails(
+            title = media.title.userPreferred ?: media.title.romaji ?: media.title.english,
+            author = author,
+            artist = artist,
+            description = media.description?.stripHtml(),
+            genre = media.genres?.takeIf { it.isNotEmpty() },
+            status = mapStatus(media.status),
+            coverUrl = media.coverImage?.extraLarge ?: media.coverImage?.large,
+        )
+    }
+
+    private fun mapStatus(status: String?): Int =
+        when (status) {
+            "RELEASING" -> 1
+
+            // ONGOING
+            "FINISHED" -> 2
+
+            // COMPLETED
+            "HIATUS" -> 6
+
+            // ON_HIATUS
+            "CANCELLED" -> 5
+
+            // CANCELLED
+            "NOT_YET_RELEASED" -> 0
+
+            // UNKNOWN
+            else -> 0
+        }
+
+    private fun String.stripHtml(): String =
+        this
+            .replace(Regex("<br\\s*/?>"), "\n")
+            .replace(Regex("<[^>]*>"), "")
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .trim()
+
+    companion object {
+        private const val API_URL = "https://graphql.anilist.co"
+
+        private val SEARCH_QUERY =
+            """
+            query (${'$'}search: String, ${'$'}type: MediaType) {
+                Page(perPage: 10) {
+                    media(search: ${'$'}search, type: ${'$'}type) {
+                        id
+                        title {
+                            romaji
+                            english
+                            userPreferred
+                        }
+                        coverImage {
+                            medium
+                            large
+                        }
+                        startDate {
+                            year
+                        }
+                        description(asHtml: false)
+                        staff(perPage: 5) {
+                            edges {
+                                role
+                                node {
+                                    name {
+                                        full
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+
+        private val DETAILS_QUERY =
+            """
+            query (${'$'}id: Int) {
+                Media(id: ${'$'}id, type: MANGA) {
+                    id
+                    title {
+                        romaji
+                        english
+                        userPreferred
+                    }
+                    coverImage {
+                        medium
+                        large
+                        extraLarge
+                    }
+                    description(asHtml: false)
+                    genres
+                    status
+                    staff(perPage: 10) {
+                        edges {
+                            role
+                            node {
+                                name {
+                                    full
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+    }
+}
+
+// --- AniList Response DTOs ---
+
+@Serializable
+data class AniListSearchResponse(
+    val data: AniListSearchData,
+)
+
+@Serializable
+data class AniListSearchData(
+    @SerialName("Page") val page: AniListPage,
+) {
+    @Serializable
+    data class AniListPage(
+        val media: List<AniListMedia> = emptyList(),
+    )
+}
+
+@Serializable
+data class AniListDetailsResponse(
+    val data: AniListDetailsData,
+)
+
+@Serializable
+data class AniListDetailsData(
+    @SerialName("Media") val media: AniListMedia,
+) {
+    constructor() : this(AniListMedia())
+}
+
+@Serializable
+data class AniListMedia(
+    val id: Int = 0,
+    val title: AniListTitle = AniListTitle(),
+    val coverImage: AniListCoverImage? = null,
+    val startDate: AniListStartDate? = null,
+    val description: String? = null,
+    val genres: List<String>? = null,
+    val status: String? = null,
+    val staff: AniListStaffConnection? = null,
+)
+
+@Serializable
+data class AniListTitle(
+    val romaji: String? = null,
+    val english: String? = null,
+    val userPreferred: String? = null,
+)
+
+@Serializable
+data class AniListCoverImage(
+    val medium: String? = null,
+    val large: String? = null,
+    val extraLarge: String? = null,
+)
+
+@Serializable
+data class AniListStartDate(
+    val year: Int? = null,
+)
+
+@Serializable
+data class AniListStaffConnection(
+    val edges: List<AniListStaffEdge> = emptyList(),
+)
+
+@Serializable
+data class AniListStaffEdge(
+    val role: String = "",
+    val node: AniListStaffNode? = null,
+)
+
+@Serializable
+data class AniListStaffNode(
+    val name: AniListStaffName? = null,
+)
+
+@Serializable
+data class AniListStaffName(
+    val full: String? = null,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MangaUpdatesMetadataProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MangaUpdatesMetadataProvider.kt
@@ -1,0 +1,154 @@
+package suwayomi.tachidesk.manga.impl.metadata
+
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import suwayomi.tachidesk.manga.impl.track.Track.htmlDecode
+import uy.kohesive.injekt.injectLazy
+
+class MangaUpdatesMetadataProvider : MetadataProvider {
+    private val networkHelper: NetworkHelper by injectLazy()
+    private val json: Json by injectLazy()
+
+    override val name: String = "MangaUpdates"
+
+    override suspend fun search(
+        query: String,
+        author: String?,
+    ): List<MetadataSearchResult> {
+        val body =
+            buildJsonObject {
+                put("search", query)
+            }.toString().toRequestBody(CONTENT_TYPE)
+
+        val results =
+            with(json) {
+                networkHelper.client
+                    .newCall(POST(url = "$BASE_URL/v1/series/search", body = body))
+                    .awaitSuccess()
+                    .parseAs<MUMetadataSearchResult>()
+            }
+
+        return results.results.map { item ->
+            val record = item.record
+            MetadataSearchResult(
+                externalId = record.seriesId?.toString() ?: "",
+                title = record.title?.htmlDecode() ?: "",
+                author = null,
+                coverUrl = record.image?.url?.original,
+                year = record.year?.takeWhile { it.isDigit() }?.toIntOrNull(),
+                description = record.description?.htmlDecode(),
+            )
+        }
+    }
+
+    override suspend fun getDetails(externalId: String): MetadataDetails {
+        val series =
+            with(json) {
+                networkHelper.client
+                    .newCall(GET("$BASE_URL/v1/series/$externalId"))
+                    .awaitSuccess()
+                    .parseAs<MUSeriesDetails>()
+            }
+
+        val authors =
+            series.authors
+                ?.filter { it.type.equals("Author", ignoreCase = true) }
+                ?.mapNotNull { it.name }
+
+        val artists =
+            series.authors
+                ?.filter { it.type.equals("Artist", ignoreCase = true) }
+                ?.mapNotNull { it.name }
+
+        return MetadataDetails(
+            title = series.title?.htmlDecode(),
+            author = authors?.joinToString(", ")?.takeIf { it.isNotEmpty() },
+            artist = artists?.joinToString(", ")?.takeIf { it.isNotEmpty() },
+            description = series.description?.htmlDecode(),
+            genre = series.genres?.mapNotNull { it.genre }?.takeIf { it.isNotEmpty() },
+            status = mapStatus(series.status),
+            coverUrl = series.image?.url?.original,
+        )
+    }
+
+    private fun mapStatus(status: String?): Int =
+        when {
+            status == null -> 0
+            status.contains("Ongoing", ignoreCase = true) -> 1
+            status.contains("Complete", ignoreCase = true) -> 2
+            status.contains("Hiatus", ignoreCase = true) -> 6
+            status.contains("Cancelled", ignoreCase = true) -> 5
+            else -> 0
+        }
+
+    companion object {
+        private const val BASE_URL = "https://api.mangaupdates.com"
+        private val CONTENT_TYPE = "application/vnd.api+json".toMediaType()
+    }
+}
+
+// --- MangaUpdates Response DTOs for metadata ---
+
+@Serializable
+data class MUMetadataSearchResult(
+    val results: List<MUMetadataSearchResultItem> = emptyList(),
+)
+
+@Serializable
+data class MUMetadataSearchResultItem(
+    val record: MUMetadataRecord,
+)
+
+@Serializable
+data class MUMetadataRecord(
+    @SerialName("series_id")
+    val seriesId: Long? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val image: MUMetadataImage? = null,
+    val year: String? = null,
+)
+
+@Serializable
+data class MUMetadataImage(
+    val url: MUMetadataUrl? = null,
+)
+
+@Serializable
+data class MUMetadataUrl(
+    val original: String? = null,
+)
+
+@Serializable
+data class MUSeriesDetails(
+    @SerialName("series_id")
+    val seriesId: Long? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val image: MUMetadataImage? = null,
+    val authors: List<MUAuthor>? = null,
+    val genres: List<MUGenre>? = null,
+    val status: String? = null,
+    val year: String? = null,
+)
+
+@Serializable
+data class MUAuthor(
+    val name: String? = null,
+    val type: String? = null,
+)
+
+@Serializable
+data class MUGenre(
+    val genre: String? = null,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MetadataProvider.kt
@@ -1,0 +1,31 @@
+package suwayomi.tachidesk.manga.impl.metadata
+
+interface MetadataProvider {
+    val name: String
+
+    suspend fun search(
+        query: String,
+        author: String? = null,
+    ): List<MetadataSearchResult>
+
+    suspend fun getDetails(externalId: String): MetadataDetails
+}
+
+data class MetadataSearchResult(
+    val externalId: String,
+    val title: String,
+    val author: String?,
+    val coverUrl: String?,
+    val year: Int?,
+    val description: String?,
+)
+
+data class MetadataDetails(
+    val title: String?,
+    val author: String?,
+    val artist: String?,
+    val description: String?,
+    val genre: List<String>?,
+    val status: Int?,
+    val coverUrl: String?,
+)

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsServiceTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsServiceTest.kt
@@ -1,0 +1,209 @@
+package suwayomi.tachidesk.manga.impl
+
+import eu.kanade.tachiyomi.source.local.metadata.MangaDetails
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LocalMangaDetailsServiceTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var mangaDir: File
+    private lateinit var service: LocalMangaDetailsService
+
+    private val json =
+        Json {
+            prettyPrint = true
+            encodeDefaults = false
+        }
+
+    @BeforeEach
+    fun setup() {
+        mangaDir = File(tempDir, "Test Manga").apply { mkdirs() }
+        service = LocalMangaDetailsService(json)
+    }
+
+    @Test
+    fun `readDetails returns empty MangaDetails when no file exists`() {
+        val details = service.readDetails(mangaDir)
+        assertNull(details.title)
+        assertNull(details.author)
+        assertNull(details.artist)
+        assertNull(details.description)
+        assertNull(details.genre)
+        assertNull(details.status)
+    }
+
+    @Test
+    fun `readDetails parses existing details json`() {
+        File(mangaDir, "details.json").writeText(
+            """
+            {
+                "title": "My Manga",
+                "author": "Author A",
+                "artist": "Artist B",
+                "description": "A great story",
+                "genre": ["Action", "Drama"],
+                "status": 1
+            }
+            """.trimIndent(),
+        )
+
+        val details = service.readDetails(mangaDir)
+        assertEquals("My Manga", details.title)
+        assertEquals("Author A", details.author)
+        assertEquals("Artist B", details.artist)
+        assertEquals("A great story", details.description)
+        assertEquals(listOf("Action", "Drama"), details.genre)
+        assertEquals(1, details.status)
+    }
+
+    @Test
+    fun `readDetails returns empty MangaDetails when file is corrupt`() {
+        File(mangaDir, "details.json").writeText("not valid json {{{")
+
+        val details = service.readDetails(mangaDir)
+        assertNull(details.title)
+    }
+
+    @Test
+    fun `writeDetails creates details json with non-null fields only`() {
+        val details =
+            MangaDetails(
+                title = "New Title",
+                author = "New Author",
+                status = 2,
+            )
+
+        service.writeDetails(mangaDir, details)
+
+        val file = File(mangaDir, "details.json")
+        assertTrue(file.exists())
+        val content = file.readText()
+        assertTrue(content.contains("\"title\": \"New Title\""))
+        assertTrue(content.contains("\"author\": \"New Author\""))
+        assertTrue(content.contains("\"status\": 2"))
+        assertFalse(content.contains("\"artist\""))
+        assertFalse(content.contains("\"description\""))
+        assertFalse(content.contains("\"genre\""))
+    }
+
+    @Test
+    fun `mergeDetails applies non-null patch fields`() {
+        val existing =
+            MangaDetails(
+                title = "Old Title",
+                author = "Old Author",
+                artist = "Old Artist",
+                description = "Old Desc",
+                genre = listOf("Action"),
+                status = 0,
+            )
+
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = "New Title",
+                author = null,
+                artist = "",
+                description = null,
+                genre = listOf("Drama", "Romance"),
+                status = 1,
+            )
+
+        assertEquals("New Title", merged.title)
+        assertEquals("Old Author", merged.author)
+        assertNull(merged.artist)
+        assertEquals("Old Desc", merged.description)
+        assertEquals(listOf("Drama", "Romance"), merged.genre)
+        assertEquals(1, merged.status)
+    }
+
+    @Test
+    fun `mergeDetails clears title when empty string`() {
+        val existing = MangaDetails(title = "Old Title")
+
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = "",
+                author = null,
+                artist = null,
+                description = null,
+                genre = null,
+                status = null,
+            )
+
+        assertNull(merged.title)
+    }
+
+    @Test
+    fun `mergeDetails clears genre when empty list`() {
+        val existing = MangaDetails(genre = listOf("Action", "Drama"))
+
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = null,
+                author = null,
+                artist = null,
+                description = null,
+                genre = emptyList(),
+                status = null,
+            )
+
+        assertNull(merged.genre)
+    }
+
+    @Test
+    fun `writeDetails overwrites existing file atomically`() {
+        File(mangaDir, "details.json").writeText("""{"title": "Old"}""")
+
+        service.writeDetails(mangaDir, MangaDetails(title = "New"))
+
+        val content = File(mangaDir, "details.json").readText()
+        assertTrue(content.contains("\"title\": \"New\""))
+        assertFalse(content.contains("\"Old\""))
+    }
+
+    @Test
+    fun `full read-merge-write cycle`() {
+        File(mangaDir, "details.json").writeText(
+            """
+            {
+                "title": "Original",
+                "author": "Author",
+                "genre": ["Action"]
+            }
+            """.trimIndent(),
+        )
+
+        val existing = service.readDetails(mangaDir)
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = "Updated Title",
+                author = null,
+                artist = "New Artist",
+                description = "Added description",
+                genre = null,
+                status = 2,
+            )
+        service.writeDetails(mangaDir, merged)
+
+        val result = service.readDetails(mangaDir)
+        assertEquals("Updated Title", result.title)
+        assertEquals("Author", result.author)
+        assertEquals("New Artist", result.artist)
+        assertEquals("Added description", result.description)
+        assertEquals(listOf("Action"), result.genre)
+        assertEquals(2, result.status)
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/test/ApplicationTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/test/ApplicationTest.kt
@@ -157,7 +157,7 @@ open class ApplicationTest {
             // in-memory database, don't discard database between connections/transactions
             val db = Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", "org.h2.Driver")
 
-            databaseUp(db)
+            databaseUp()
 
             LocalSource.register()
         }


### PR DESCRIPTION
## Summary

- Adds `updateMangaDetails` GraphQL mutation for editing manga metadata (title, author, artist, description, genre, status). Updates the database for all manga and writes `details.json` for local source manga.
- Adds `uploadMangaCover` mutation for custom cover image uploads with thumbnail cache management and cache-busting.
- Introduces `MetadataProvider` interface with **AniList** and **MangaUpdates** implementations. New `searchMetadataProvider` and `applyMetadataMatch` mutations allow fetching metadata from external providers with optional cover download.
- Includes `LocalMangaDetailsService` with atomic file writes, concurrent access protection, and field clearing support.

Addresses #1340, #1009, #1185, #978

## New GraphQL Mutations

| Mutation | Description |
|----------|-------------|
| `updateMangaDetails` | Edit manga metadata fields (all manga → DB, local source → also `details.json`) |
| `uploadMangaCover` | Upload custom cover image (all manga → thumbnail cache, local source → also `cover.jpg`) |
| `searchMetadataProvider` | Search AniList or MangaUpdates by title, returns candidates |
| `applyMetadataMatch` | Apply metadata from a provider match, optionally including cover image |

## Test plan

- [x] Unit tests for `LocalMangaDetailsService` (9 tests: read/merge/write, field clearing, corrupt file handling)
- [x] Manual smoke test: `updateMangaDetails` via GraphiQL — verified DB update and `details.json` write
- [x] Manual smoke test: `uploadMangaCover` via multipart upload — verified thumbnail cache and `cover.jpg`
- [x] Manual smoke test: `searchMetadataProvider` with AniList and MangaUpdates — verified search results
- [x] Manual smoke test: `applyMetadataMatch` — verified metadata + cover applied from AniList
- [x] Build: `shadowJar` passes
- [x] Lint: `ktlintCheck` passes