### PR TITLE
feat: add local manga metadata editing

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MangaMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MangaMutation.kt
@@ -1,5 +1,7 @@
 package suwayomi.tachidesk.graphql.mutations
 
+import eu.kanade.tachiyomi.source.local.LocalSource
+import eu.kanade.tachiyomi.source.local.io.LocalSourceFileSystem
 import graphql.execution.DataFetcherResult
 import org.jetbrains.exposed.sql.LikePattern
 import org.jetbrains.exposed.sql.Op
@@ -18,11 +20,14 @@ import suwayomi.tachidesk.graphql.types.MangaMetaType
 import suwayomi.tachidesk.graphql.types.MangaType
 import suwayomi.tachidesk.graphql.types.MetaInput
 import suwayomi.tachidesk.manga.impl.Library
+import suwayomi.tachidesk.manga.impl.LocalMangaDetailsService
 import suwayomi.tachidesk.manga.impl.Manga
 import suwayomi.tachidesk.manga.impl.update.IUpdater
 import suwayomi.tachidesk.manga.model.table.MangaMetaTable
+import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
+import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.JavalinSetup.future
 import uy.kohesive.injekt.injectLazy
 import java.time.Instant
@@ -93,6 +98,102 @@ class MangaMutation {
                 ids.forEach {
                     Library.handleMangaThumbnail(it, patch.inLibrary)
                 }
+            }
+        }
+    }
+
+    // --- Manga Details Editing ---
+
+    data class UpdateMangaDetailsPatch(
+        val title: String? = null,
+        val author: String? = null,
+        val artist: String? = null,
+        val description: String? = null,
+        val genre: List<String>? = null,
+        val status: MangaStatus? = null,
+    )
+
+    data class UpdateMangaDetailsInput(
+        val clientMutationId: String? = null,
+        val id: Int,
+        val patch: UpdateMangaDetailsPatch,
+    )
+
+    data class UpdateMangaDetailsPayload(
+        val clientMutationId: String?,
+        val manga: MangaType,
+    )
+
+    private val applicationDirs: ApplicationDirs by injectLazy()
+    private val localMangaDetailsService = LocalMangaDetailsService()
+
+    @RequireAuth
+    fun updateMangaDetails(input: UpdateMangaDetailsInput): CompletableFuture<DataFetcherResult<UpdateMangaDetailsPayload?>> {
+        val (clientMutationId, id, patch) = input
+
+        return future {
+            asDataFetcherResult {
+                // Step 1: Update database (skip if no fields to update)
+                val hasUpdates =
+                    patch.title != null ||
+                        patch.author != null ||
+                        patch.artist != null ||
+                        patch.description != null ||
+                        patch.genre != null ||
+                        patch.status != null
+
+                if (hasUpdates) {
+                    transaction {
+                        MangaTable.update({ MangaTable.id eq id }) { update ->
+                            patch.title?.let { update[title] = it }
+                            patch.author?.let { update[author] = it }
+                            patch.artist?.let { update[artist] = it }
+                            patch.description?.let { update[description] = it }
+                            patch.genre?.let { update[genre] = it.joinToString(", ") }
+                            patch.status?.let { update[status] = it.value }
+                        }
+                    }
+                }
+
+                // Step 2: Write details.json for local source manga
+                val row =
+                    transaction {
+                        MangaTable.selectAll().where { MangaTable.id eq id }.firstOrNull()
+                            ?: throw IllegalArgumentException("Manga with id $id not found")
+                    }
+
+                val sourceId = row[MangaTable.sourceReference]
+                if (sourceId == LocalSource.ID) {
+                    val mangaUrl = row[MangaTable.url]
+                    val fileSystem = LocalSourceFileSystem(applicationDirs)
+                    val mangaDir = fileSystem.getMangaDirectory(mangaUrl)
+
+                    if (mangaDir != null) {
+                        val existing = localMangaDetailsService.readDetails(mangaDir)
+                        val merged =
+                            localMangaDetailsService.mergeDetails(
+                                existing = existing,
+                                title = patch.title,
+                                author = patch.author,
+                                artist = patch.artist,
+                                description = patch.description,
+                                genre = patch.genre,
+                                status = patch.status?.value,
+                            )
+                        localMangaDetailsService.writeDetailsWithLock(mangaDir, merged)
+                    }
+                }
+
+                // Step 3: Return updated manga
+                val manga =
+                    transaction {
+                        MangaType(MangaTable.selectAll().where { MangaTable.id eq id }.first())
+                    }
+
+                UpdateMangaDetailsPayload(
+                    clientMutationId = clientMutationId,
+                    manga = manga,
+                )
             }
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsService.kt
@@ -1,0 +1,95 @@
+package suwayomi.tachidesk.manga.impl
+
+import eu.kanade.tachiyomi.source.local.metadata.MangaDetails
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+class LocalMangaDetailsService(
+    private val json: Json =
+        Json {
+            prettyPrint = true
+            encodeDefaults = false
+            ignoreUnknownKeys = true
+        },
+) {
+    private val mutexMap = ConcurrentHashMap<String, Mutex>()
+
+    private val logger = KotlinLogging.logger {}
+
+    fun readDetails(mangaDir: File): MangaDetails {
+        val detailsFile =
+            mangaDir.listFiles()?.firstOrNull { it.extension == "json" }
+                ?: return MangaDetails()
+
+        return try {
+            json.decodeFromString<MangaDetails>(detailsFile.readText())
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse details.json in ${mangaDir.name}, starting fresh" }
+            MangaDetails()
+        }
+    }
+
+    fun mergeDetails(
+        existing: MangaDetails,
+        title: String?,
+        author: String?,
+        artist: String?,
+        description: String?,
+        genre: List<String>?,
+        status: Int?,
+    ): MangaDetails =
+        MangaDetails(
+            title = mergeStringField(existing.title, title),
+            author = mergeStringField(existing.author, author),
+            artist = mergeStringField(existing.artist, artist),
+            description = mergeStringField(existing.description, description),
+            genre =
+                when {
+                    genre == null -> existing.genre
+                    genre.isEmpty() -> null
+                    else -> genre
+                },
+            status = status ?: existing.status,
+        )
+
+    fun writeDetails(
+        mangaDir: File,
+        details: MangaDetails,
+    ) {
+        val content = json.encodeToString(details)
+        val detailsFile = File(mangaDir, DETAILS_FILE_NAME)
+        val tempFile = File(mangaDir, "$DETAILS_FILE_NAME.tmp")
+
+        tempFile.writeText(content)
+        tempFile.renameTo(detailsFile)
+    }
+
+    suspend fun writeDetailsWithLock(
+        mangaDir: File,
+        details: MangaDetails,
+    ) {
+        val mutex = mutexMap.getOrPut(mangaDir.absolutePath) { Mutex() }
+        mutex.withLock {
+            writeDetails(mangaDir, details)
+        }
+    }
+
+    private fun mergeStringField(
+        existing: String?,
+        patch: String?,
+    ): String? =
+        when {
+            patch == null -> existing
+            patch.isEmpty() -> null
+            else -> patch
+        }
+
+    companion object {
+        const val DETAILS_FILE_NAME = "details.json"
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsServiceTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/LocalMangaDetailsServiceTest.kt
@@ -1,0 +1,209 @@
+package suwayomi.tachidesk.manga.impl
+
+import eu.kanade.tachiyomi.source.local.metadata.MangaDetails
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LocalMangaDetailsServiceTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var mangaDir: File
+    private lateinit var service: LocalMangaDetailsService
+
+    private val json =
+        Json {
+            prettyPrint = true
+            encodeDefaults = false
+        }
+
+    @BeforeEach
+    fun setup() {
+        mangaDir = File(tempDir, "Test Manga").apply { mkdirs() }
+        service = LocalMangaDetailsService(json)
+    }
+
+    @Test
+    fun `readDetails returns empty MangaDetails when no file exists`() {
+        val details = service.readDetails(mangaDir)
+        assertNull(details.title)
+        assertNull(details.author)
+        assertNull(details.artist)
+        assertNull(details.description)
+        assertNull(details.genre)
+        assertNull(details.status)
+    }
+
+    @Test
+    fun `readDetails parses existing details json`() {
+        File(mangaDir, "details.json").writeText(
+            """
+            {
+                "title": "My Manga",
+                "author": "Author A",
+                "artist": "Artist B",
+                "description": "A great story",
+                "genre": ["Action", "Drama"],
+                "status": 1
+            }
+            """.trimIndent(),
+        )
+
+        val details = service.readDetails(mangaDir)
+        assertEquals("My Manga", details.title)
+        assertEquals("Author A", details.author)
+        assertEquals("Artist B", details.artist)
+        assertEquals("A great story", details.description)
+        assertEquals(listOf("Action", "Drama"), details.genre)
+        assertEquals(1, details.status)
+    }
+
+    @Test
+    fun `readDetails returns empty MangaDetails when file is corrupt`() {
+        File(mangaDir, "details.json").writeText("not valid json {{{")
+
+        val details = service.readDetails(mangaDir)
+        assertNull(details.title)
+    }
+
+    @Test
+    fun `writeDetails creates details json with non-null fields only`() {
+        val details =
+            MangaDetails(
+                title = "New Title",
+                author = "New Author",
+                status = 2,
+            )
+
+        service.writeDetails(mangaDir, details)
+
+        val file = File(mangaDir, "details.json")
+        assertTrue(file.exists())
+        val content = file.readText()
+        assertTrue(content.contains("\"title\": \"New Title\""))
+        assertTrue(content.contains("\"author\": \"New Author\""))
+        assertTrue(content.contains("\"status\": 2"))
+        assertFalse(content.contains("\"artist\""))
+        assertFalse(content.contains("\"description\""))
+        assertFalse(content.contains("\"genre\""))
+    }
+
+    @Test
+    fun `mergeDetails applies non-null patch fields`() {
+        val existing =
+            MangaDetails(
+                title = "Old Title",
+                author = "Old Author",
+                artist = "Old Artist",
+                description = "Old Desc",
+                genre = listOf("Action"),
+                status = 0,
+            )
+
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = "New Title",
+                author = null,
+                artist = "",
+                description = null,
+                genre = listOf("Drama", "Romance"),
+                status = 1,
+            )
+
+        assertEquals("New Title", merged.title)
+        assertEquals("Old Author", merged.author)
+        assertNull(merged.artist)
+        assertEquals("Old Desc", merged.description)
+        assertEquals(listOf("Drama", "Romance"), merged.genre)
+        assertEquals(1, merged.status)
+    }
+
+    @Test
+    fun `mergeDetails clears title when empty string`() {
+        val existing = MangaDetails(title = "Old Title")
+
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = "",
+                author = null,
+                artist = null,
+                description = null,
+                genre = null,
+                status = null,
+            )
+
+        assertNull(merged.title)
+    }
+
+    @Test
+    fun `mergeDetails clears genre when empty list`() {
+        val existing = MangaDetails(genre = listOf("Action", "Drama"))
+
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = null,
+                author = null,
+                artist = null,
+                description = null,
+                genre = emptyList(),
+                status = null,
+            )
+
+        assertNull(merged.genre)
+    }
+
+    @Test
+    fun `writeDetails overwrites existing file atomically`() {
+        File(mangaDir, "details.json").writeText("""{"title": "Old"}""")
+
+        service.writeDetails(mangaDir, MangaDetails(title = "New"))
+
+        val content = File(mangaDir, "details.json").readText()
+        assertTrue(content.contains("\"title\": \"New\""))
+        assertFalse(content.contains("\"Old\""))
+    }
+
+    @Test
+    fun `full read-merge-write cycle`() {
+        File(mangaDir, "details.json").writeText(
+            """
+            {
+                "title": "Original",
+                "author": "Author",
+                "genre": ["Action"]
+            }
+            """.trimIndent(),
+        )
+
+        val existing = service.readDetails(mangaDir)
+        val merged =
+            service.mergeDetails(
+                existing = existing,
+                title = "Updated Title",
+                author = null,
+                artist = "New Artist",
+                description = "Added description",
+                genre = null,
+                status = 2,
+            )
+        service.writeDetails(mangaDir, merged)
+
+        val result = service.readDetails(mangaDir)
+        assertEquals("Updated Title", result.title)
+        assertEquals("Author", result.author)
+        assertEquals("New Artist", result.artist)
+        assertEquals("Added description", result.description)
+        assertEquals(listOf("Action"), result.genre)
+        assertEquals(2, result.status)
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/test/ApplicationTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/test/ApplicationTest.kt
@@ -157,7 +157,7 @@ open class ApplicationTest {
             // in-memory database, don't discard database between connections/transactions
             val db = Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;", "org.h2.Driver")
 
-            databaseUp(db)
+            databaseUp()
 
             LocalSource.register()
         }


### PR DESCRIPTION
## Summary

Adds the ability to edit manga metadata (title, author, artist, description, genre, status) via a new `updateMangaDetails` GraphQL mutation. For local source manga, changes are persisted to `details.json`.

Includes `LocalMangaDetailsService` with atomic file writes (temp + rename), concurrent access protection (Mutex), and field clearing support (empty string = clear field, empty list = clear genres).

**Part 1 of 3** — local manga editing. See also:
- Part 2: Cover image upload
- Part 3: Metadata providers (AniList, MangaUpdates)

Addresses #1009, #1185, #978

## Test plan

- [x] 9 unit tests for LocalMangaDetailsService (read/merge/write, field clearing, corrupt file)
- [x] Manual test: updateMangaDetails via GraphiQL
- [x] Manual test: details.json written in local manga directory
- [x] Build: `shadowJar` passes
- [x] Lint: `ktlintCheck` passes