### PR TITLE
feat: add cover image upload for manga

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MangaMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MangaMutation.kt
@@ -1,6 +1,11 @@
 package suwayomi.tachidesk.graphql.mutations
 
+import eu.kanade.tachiyomi.source.local.LocalSource
+import eu.kanade.tachiyomi.source.local.image.LocalCoverManager
+import eu.kanade.tachiyomi.source.local.io.LocalSourceFileSystem
+import eu.kanade.tachiyomi.source.model.SManga
 import graphql.execution.DataFetcherResult
+import io.javalin.http.UploadedFile
 import org.jetbrains.exposed.sql.LikePattern
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -19,12 +24,17 @@ import suwayomi.tachidesk.graphql.types.MangaType
 import suwayomi.tachidesk.graphql.types.MetaInput
 import suwayomi.tachidesk.manga.impl.Library
 import suwayomi.tachidesk.manga.impl.Manga
+import suwayomi.tachidesk.manga.impl.MangaList
 import suwayomi.tachidesk.manga.impl.update.IUpdater
+import suwayomi.tachidesk.manga.impl.util.getThumbnailDownloadPath
+import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
 import suwayomi.tachidesk.manga.model.table.MangaMetaTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
+import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.JavalinSetup.future
 import uy.kohesive.injekt.injectLazy
+import java.io.File
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 
@@ -35,6 +45,7 @@ import java.util.concurrent.CompletableFuture
  */
 class MangaMutation {
     private val updater: IUpdater by injectLazy()
+    private val applicationDirs: ApplicationDirs by injectLazy()
 
     data class UpdateMangaPatch(
         val inLibrary: Boolean? = null,
@@ -93,6 +104,70 @@ class MangaMutation {
                 ids.forEach {
                     Library.handleMangaThumbnail(it, patch.inLibrary)
                 }
+            }
+        }
+    }
+
+    // --- Cover Image Upload ---
+
+    data class UploadMangaCoverInput(
+        val clientMutationId: String? = null,
+        val id: Int,
+        val cover: UploadedFile,
+    )
+
+    data class UploadMangaCoverPayload(
+        val clientMutationId: String?,
+        val manga: MangaType,
+    )
+
+    @RequireAuth
+    fun uploadMangaCover(input: UploadMangaCoverInput): CompletableFuture<DataFetcherResult<UploadMangaCoverPayload?>> {
+        val (clientMutationId, id, cover) = input
+
+        return future {
+            asDataFetcherResult {
+                val imageBytes = cover.content().use { it.readBytes() }
+                val mimeType = cover.contentType()
+
+                val row =
+                    transaction {
+                        MangaTable.selectAll().where { MangaTable.id eq id }.firstOrNull()
+                            ?: throw IllegalArgumentException("Manga with id $id not found")
+                    }
+
+                Manga.clearThumbnail(id)
+
+                val thumbnailDir = applicationDirs.thumbnailDownloadsRoot
+                File(thumbnailDir).let { if (!it.exists()) it.mkdir() }
+                val filePath = getThumbnailDownloadPath(id)
+                ImageResponse.saveImage(filePath, imageBytes.inputStream(), mimeType)
+
+                transaction {
+                    MangaTable.update({ MangaTable.id eq id }) { update ->
+                        update[thumbnail_url] = MangaList.proxyThumbnailUrl(id)
+                        update[thumbnailUrlLastFetched] = System.currentTimeMillis()
+                    }
+                }
+
+                val sourceId = row[MangaTable.sourceReference]
+                if (sourceId == LocalSource.ID) {
+                    val mangaUrl = row[MangaTable.url]
+                    val fileSystem = LocalSourceFileSystem(applicationDirs)
+                    val coverManager = LocalCoverManager(fileSystem)
+                    val sManga = SManga.create().apply { url = mangaUrl }
+                    coverManager.update(sManga, imageBytes.inputStream())
+                }
+
+                val manga =
+                    transaction {
+                        MangaType(MangaTable.selectAll().where { MangaTable.id eq id }.first())
+                    }
+
+                UploadMangaCoverPayload(
+                    clientMutationId = clientMutationId,
+                    manga = manga,
+                )
             }
         }
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -415,6 +415,16 @@ object Manga {
     suspend fun getMangaThumbnail(mangaId: Int): Pair<InputStream, String> {
         val mangaEntry = transaction { MangaTable.selectAll().where { MangaTable.id eq mangaId }.first() }
 
+        // Check thumbnail cache for user-uploaded covers (any source)
+        val hasUserUploadedCover = mangaEntry[MangaTable.thumbnailUrlLastFetched] > 0
+        if (hasUserUploadedCover) {
+            try {
+                return ThumbnailDownloadHelper.getImage(mangaId)
+            } catch (_: MissingThumbnailException) {
+                // fall through to original logic
+            }
+        }
+
         if (mangaEntry[MangaTable.inLibrary] && mangaEntry[MangaTable.sourceReference] != LocalSource.ID) {
             return try {
                 ThumbnailDownloadHelper.getImage(mangaId)


### PR DESCRIPTION
## Summary

Adds `uploadMangaCover` GraphQL mutation for custom cover image uploads. Saves to the server thumbnail cache for all manga and writes `cover.jpg` for local source manga.

- Clears old cached thumbnails before saving
- Updates `thumbnailUrlLastFetched` for client cache invalidation
- Fixes `getMangaThumbnail` to serve user-uploaded covers for local source manga (checks thumbnail cache when `thumbnailUrlLastFetched > 0`)

**Part 2 of 3** — cover upload. See also:
- Part 1: Local manga editing (#1946)
- Part 3: Metadata providers (AniList, MangaUpdates)

Addresses #1009

## Test plan

- [x] Manual test: uploadMangaCover via multipart GraphQL
- [x] Manual test: thumbnail cache updated, cover.jpg written for local source
- [x] Manual test: cover displays correctly after upload
- [x] Build: `shadowJar` passes
- [x] Lint: `ktlintCheck` passes