### PR TITLE
feat: add metadata providers for fetching manga info from external sources

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MetadataMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/MetadataMutation.kt
@@ -1,0 +1,196 @@
+package suwayomi.tachidesk.graphql.mutations
+
+import eu.kanade.tachiyomi.source.local.LocalSource
+import eu.kanade.tachiyomi.source.local.image.LocalCoverManager
+import eu.kanade.tachiyomi.source.local.io.LocalSourceFileSystem
+import eu.kanade.tachiyomi.source.model.SManga
+import graphql.execution.DataFetcherResult
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import suwayomi.tachidesk.graphql.asDataFetcherResult
+import suwayomi.tachidesk.graphql.directives.RequireAuth
+import suwayomi.tachidesk.graphql.types.MangaType
+import suwayomi.tachidesk.manga.impl.Manga
+import suwayomi.tachidesk.manga.impl.MangaList
+import suwayomi.tachidesk.manga.impl.metadata.AniListMetadataProvider
+import suwayomi.tachidesk.manga.impl.metadata.MangaUpdatesMetadataProvider
+import suwayomi.tachidesk.manga.impl.metadata.MetadataProvider
+import suwayomi.tachidesk.manga.impl.util.getThumbnailDownloadPath
+import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
+import suwayomi.tachidesk.manga.model.table.MangaStatus
+import suwayomi.tachidesk.manga.model.table.MangaTable
+import suwayomi.tachidesk.server.ApplicationDirs
+import suwayomi.tachidesk.server.JavalinSetup.future
+import uy.kohesive.injekt.injectLazy
+import java.io.File
+import java.net.URI
+import java.util.concurrent.CompletableFuture
+
+class MetadataMutation {
+    private val applicationDirs: ApplicationDirs by injectLazy()
+
+    private val providers: Map<String, MetadataProvider> =
+        listOf(
+            AniListMetadataProvider(),
+            MangaUpdatesMetadataProvider(),
+        ).associateBy { it.name.lowercase() }
+
+    // --- Search ---
+
+    data class MetadataSearchResultType(
+        val externalId: String,
+        val title: String,
+        val author: String?,
+        val coverUrl: String?,
+        val year: Int?,
+        val description: String?,
+    )
+
+    data class SearchMetadataProviderInput(
+        val clientMutationId: String? = null,
+        val provider: String,
+        val query: String,
+        val author: String? = null,
+    )
+
+    data class SearchMetadataProviderPayload(
+        val clientMutationId: String?,
+        val results: List<MetadataSearchResultType>,
+    )
+
+    @RequireAuth
+    fun searchMetadataProvider(input: SearchMetadataProviderInput): CompletableFuture<DataFetcherResult<SearchMetadataProviderPayload?>> {
+        val (clientMutationId, providerName, query, author) = input
+
+        return future {
+            asDataFetcherResult {
+                val provider =
+                    providers[providerName.lowercase()]
+                        ?: throw IllegalArgumentException(
+                            "Unknown provider '$providerName'. Available: ${providers.keys.joinToString()}",
+                        )
+
+                val results =
+                    provider.search(query, author).map {
+                        MetadataSearchResultType(
+                            externalId = it.externalId,
+                            title = it.title,
+                            author = it.author,
+                            coverUrl = it.coverUrl,
+                            year = it.year,
+                            description = it.description,
+                        )
+                    }
+
+                SearchMetadataProviderPayload(
+                    clientMutationId = clientMutationId,
+                    results = results,
+                )
+            }
+        }
+    }
+
+    // --- Apply Match ---
+
+    data class ApplyMetadataMatchInput(
+        val clientMutationId: String? = null,
+        val mangaId: Int,
+        val provider: String,
+        val externalId: String,
+        val includeCover: Boolean = true,
+    )
+
+    data class ApplyMetadataMatchPayload(
+        val clientMutationId: String?,
+        val manga: MangaType,
+    )
+
+    @RequireAuth
+    fun applyMetadataMatch(input: ApplyMetadataMatchInput): CompletableFuture<DataFetcherResult<ApplyMetadataMatchPayload?>> {
+        val (clientMutationId, mangaId, providerName, externalId, includeCover) = input
+
+        return future {
+            asDataFetcherResult {
+                val provider =
+                    providers[providerName.lowercase()]
+                        ?: throw IllegalArgumentException(
+                            "Unknown provider '$providerName'. Available: ${providers.keys.joinToString()}",
+                        )
+
+                val details = provider.getDetails(externalId)
+
+                val row =
+                    transaction {
+                        MangaTable.selectAll().where { MangaTable.id eq mangaId }.firstOrNull()
+                            ?: throw IllegalArgumentException("Manga with id $mangaId not found")
+                    }
+
+                // Step 1: Update DB with text metadata
+                transaction {
+                    MangaTable.update({ MangaTable.id eq mangaId }) { update ->
+                        details.title?.let { update[title] = it }
+                        details.author?.let { update[author] = it }
+                        details.artist?.let { update[artist] = it }
+                        details.description?.let { update[description] = it }
+                        details.genre?.let { update[genre] = it.joinToString(", ") }
+                        details.status?.let { update[status] = it }
+                    }
+                }
+
+                // Step 2: Download and save cover if requested
+                val sourceId = row[MangaTable.sourceReference]
+                if (includeCover && details.coverUrl != null) {
+                    downloadAndSaveCover(mangaId, details.coverUrl, sourceId, row[MangaTable.url])
+                }
+
+                // Step 4: Return updated manga
+                val manga =
+                    transaction {
+                        MangaType(MangaTable.selectAll().where { MangaTable.id eq mangaId }.first())
+                    }
+
+                ApplyMetadataMatchPayload(
+                    clientMutationId = clientMutationId,
+                    manga = manga,
+                )
+            }
+        }
+    }
+
+    private suspend fun downloadAndSaveCover(
+        mangaId: Int,
+        coverUrl: String,
+        sourceId: Long,
+        mangaUrl: String,
+    ) {
+        val imageBytes =
+            URI(coverUrl).toURL().openStream().use { it.readBytes() }
+
+        // Clear old cache and save new thumbnail
+        Manga.clearThumbnail(mangaId)
+        val thumbnailDir = applicationDirs.thumbnailDownloadsRoot
+        File(thumbnailDir).let { if (!it.exists()) it.mkdir() }
+        ImageResponse.saveImage(
+            getThumbnailDownloadPath(mangaId),
+            imageBytes.inputStream(),
+            null,
+        )
+
+        // Update DB
+        transaction {
+            MangaTable.update({ MangaTable.id eq mangaId }) { update ->
+                update[thumbnail_url] = MangaList.proxyThumbnailUrl(mangaId)
+                update[thumbnailUrlLastFetched] = System.currentTimeMillis()
+            }
+        }
+
+        // Write cover.jpg for local source
+        if (sourceId == LocalSource.ID) {
+            val fileSystem = LocalSourceFileSystem(applicationDirs)
+            val coverManager = LocalCoverManager(fileSystem)
+            val sManga = SManga.create().apply { url = mangaUrl }
+            coverManager.update(sManga, imageBytes.inputStream())
+        }
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
@@ -25,6 +25,7 @@ import suwayomi.tachidesk.graphql.mutations.InfoMutation
 import suwayomi.tachidesk.graphql.mutations.KoreaderSyncMutation
 import suwayomi.tachidesk.graphql.mutations.MangaMutation
 import suwayomi.tachidesk.graphql.mutations.MetaMutation
+import suwayomi.tachidesk.graphql.mutations.MetadataMutation
 import suwayomi.tachidesk.graphql.mutations.SettingsMutation
 import suwayomi.tachidesk.graphql.mutations.SourceMutation
 import suwayomi.tachidesk.graphql.mutations.TrackMutation
@@ -113,6 +114,7 @@ val schema =
                 TopLevelObject(KoreaderSyncMutation()),
                 TopLevelObject(MangaMutation()),
                 TopLevelObject(MetaMutation()),
+                TopLevelObject(MetadataMutation()),
                 TopLevelObject(SettingsMutation()),
                 TopLevelObject(SourceMutation()),
                 TopLevelObject(TrackMutation()),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/AniListMetadataProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/AniListMetadataProvider.kt
@@ -1,0 +1,294 @@
+package suwayomi.tachidesk.manga.impl.metadata
+
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.jsonMime
+import eu.kanade.tachiyomi.network.parseAs
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import okhttp3.RequestBody.Companion.toRequestBody
+import uy.kohesive.injekt.injectLazy
+
+class AniListMetadataProvider : MetadataProvider {
+    private val networkHelper: NetworkHelper by injectLazy()
+    private val json: Json by injectLazy()
+    private val logger = KotlinLogging.logger {}
+
+    override val name: String = "AniList"
+
+    override suspend fun search(
+        query: String,
+        author: String?,
+    ): List<MetadataSearchResult> {
+        val variables =
+            buildJsonObject {
+                put("search", query)
+                put("type", "MANGA")
+            }
+        val body =
+            buildJsonObject {
+                put("query", SEARCH_QUERY)
+                putJsonObject("variables") {
+                    put("search", query)
+                    put("type", "MANGA")
+                }
+            }.toString().toRequestBody(jsonMime)
+
+        val response =
+            with(json) {
+                networkHelper.client
+                    .newCall(POST(API_URL, body = body))
+                    .awaitSuccess()
+                    .parseAs<AniListSearchResponse>()
+            }
+
+        return response.data.page.media.map { media ->
+            MetadataSearchResult(
+                externalId = media.id.toString(),
+                title = media.title.userPreferred ?: media.title.romaji ?: media.title.english ?: "",
+                author =
+                    media.staff
+                        ?.edges
+                        ?.firstOrNull { it.role.contains("Story", ignoreCase = true) }
+                        ?.node
+                        ?.name
+                        ?.full,
+                coverUrl = media.coverImage?.large ?: media.coverImage?.medium,
+                year = media.startDate?.year,
+                description = media.description?.stripHtml(),
+            )
+        }
+    }
+
+    override suspend fun getDetails(externalId: String): MetadataDetails {
+        val body =
+            buildJsonObject {
+                put("query", DETAILS_QUERY)
+                putJsonObject("variables") {
+                    put("id", externalId.toInt())
+                }
+            }.toString().toRequestBody(jsonMime)
+
+        val response =
+            with(json) {
+                networkHelper.client
+                    .newCall(POST(API_URL, body = body))
+                    .awaitSuccess()
+                    .parseAs<AniListDetailsResponse>()
+            }
+
+        val media = response.data.media
+        val staffEdges = media.staff?.edges.orEmpty()
+
+        val author =
+            staffEdges
+                .firstOrNull { it.role.contains("Story", ignoreCase = true) }
+                ?.node
+                ?.name
+                ?.full
+        val artist =
+            staffEdges
+                .firstOrNull { it.role.contains("Art", ignoreCase = true) }
+                ?.node
+                ?.name
+                ?.full
+
+        return MetadataDetails(
+            title = media.title.userPreferred ?: media.title.romaji ?: media.title.english,
+            author = author,
+            artist = artist,
+            description = media.description?.stripHtml(),
+            genre = media.genres?.takeIf { it.isNotEmpty() },
+            status = mapStatus(media.status),
+            coverUrl = media.coverImage?.extraLarge ?: media.coverImage?.large,
+        )
+    }
+
+    private fun mapStatus(status: String?): Int =
+        when (status) {
+            "RELEASING" -> 1
+
+            // ONGOING
+            "FINISHED" -> 2
+
+            // COMPLETED
+            "HIATUS" -> 6
+
+            // ON_HIATUS
+            "CANCELLED" -> 5
+
+            // CANCELLED
+            "NOT_YET_RELEASED" -> 0
+
+            // UNKNOWN
+            else -> 0
+        }
+
+    private fun String.stripHtml(): String =
+        this
+            .replace(Regex("<br\\s*/?>"), "\n")
+            .replace(Regex("<[^>]*>"), "")
+            .replace("&amp;", "&")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .trim()
+
+    companion object {
+        private const val API_URL = "https://graphql.anilist.co"
+
+        private val SEARCH_QUERY =
+            """
+            query (${'$'}search: String, ${'$'}type: MediaType) {
+                Page(perPage: 10) {
+                    media(search: ${'$'}search, type: ${'$'}type) {
+                        id
+                        title {
+                            romaji
+                            english
+                            userPreferred
+                        }
+                        coverImage {
+                            medium
+                            large
+                        }
+                        startDate {
+                            year
+                        }
+                        description(asHtml: false)
+                        staff(perPage: 5) {
+                            edges {
+                                role
+                                node {
+                                    name {
+                                        full
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+
+        private val DETAILS_QUERY =
+            """
+            query (${'$'}id: Int) {
+                Media(id: ${'$'}id, type: MANGA) {
+                    id
+                    title {
+                        romaji
+                        english
+                        userPreferred
+                    }
+                    coverImage {
+                        medium
+                        large
+                        extraLarge
+                    }
+                    description(asHtml: false)
+                    genres
+                    status
+                    staff(perPage: 10) {
+                        edges {
+                            role
+                            node {
+                                name {
+                                    full
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+    }
+}
+
+// --- AniList Response DTOs ---
+
+@Serializable
+data class AniListSearchResponse(
+    val data: AniListSearchData,
+)
+
+@Serializable
+data class AniListSearchData(
+    @SerialName("Page") val page: AniListPage,
+) {
+    @Serializable
+    data class AniListPage(
+        val media: List<AniListMedia> = emptyList(),
+    )
+}
+
+@Serializable
+data class AniListDetailsResponse(
+    val data: AniListDetailsData,
+)
+
+@Serializable
+data class AniListDetailsData(
+    @SerialName("Media") val media: AniListMedia,
+) {
+    constructor() : this(AniListMedia())
+}
+
+@Serializable
+data class AniListMedia(
+    val id: Int = 0,
+    val title: AniListTitle = AniListTitle(),
+    val coverImage: AniListCoverImage? = null,
+    val startDate: AniListStartDate? = null,
+    val description: String? = null,
+    val genres: List<String>? = null,
+    val status: String? = null,
+    val staff: AniListStaffConnection? = null,
+)
+
+@Serializable
+data class AniListTitle(
+    val romaji: String? = null,
+    val english: String? = null,
+    val userPreferred: String? = null,
+)
+
+@Serializable
+data class AniListCoverImage(
+    val medium: String? = null,
+    val large: String? = null,
+    val extraLarge: String? = null,
+)
+
+@Serializable
+data class AniListStartDate(
+    val year: Int? = null,
+)
+
+@Serializable
+data class AniListStaffConnection(
+    val edges: List<AniListStaffEdge> = emptyList(),
+)
+
+@Serializable
+data class AniListStaffEdge(
+    val role: String = "",
+    val node: AniListStaffNode? = null,
+)
+
+@Serializable
+data class AniListStaffNode(
+    val name: AniListStaffName? = null,
+)
+
+@Serializable
+data class AniListStaffName(
+    val full: String? = null,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MangaUpdatesMetadataProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MangaUpdatesMetadataProvider.kt
@@ -1,0 +1,154 @@
+package suwayomi.tachidesk.manga.impl.metadata
+
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import suwayomi.tachidesk.manga.impl.track.Track.htmlDecode
+import uy.kohesive.injekt.injectLazy
+
+class MangaUpdatesMetadataProvider : MetadataProvider {
+    private val networkHelper: NetworkHelper by injectLazy()
+    private val json: Json by injectLazy()
+
+    override val name: String = "MangaUpdates"
+
+    override suspend fun search(
+        query: String,
+        author: String?,
+    ): List<MetadataSearchResult> {
+        val body =
+            buildJsonObject {
+                put("search", query)
+            }.toString().toRequestBody(CONTENT_TYPE)
+
+        val results =
+            with(json) {
+                networkHelper.client
+                    .newCall(POST(url = "$BASE_URL/v1/series/search", body = body))
+                    .awaitSuccess()
+                    .parseAs<MUMetadataSearchResult>()
+            }
+
+        return results.results.map { item ->
+            val record = item.record
+            MetadataSearchResult(
+                externalId = record.seriesId?.toString() ?: "",
+                title = record.title?.htmlDecode() ?: "",
+                author = null,
+                coverUrl = record.image?.url?.original,
+                year = record.year?.takeWhile { it.isDigit() }?.toIntOrNull(),
+                description = record.description?.htmlDecode(),
+            )
+        }
+    }
+
+    override suspend fun getDetails(externalId: String): MetadataDetails {
+        val series =
+            with(json) {
+                networkHelper.client
+                    .newCall(GET("$BASE_URL/v1/series/$externalId"))
+                    .awaitSuccess()
+                    .parseAs<MUSeriesDetails>()
+            }
+
+        val authors =
+            series.authors
+                ?.filter { it.type.equals("Author", ignoreCase = true) }
+                ?.mapNotNull { it.name }
+
+        val artists =
+            series.authors
+                ?.filter { it.type.equals("Artist", ignoreCase = true) }
+                ?.mapNotNull { it.name }
+
+        return MetadataDetails(
+            title = series.title?.htmlDecode(),
+            author = authors?.joinToString(", ")?.takeIf { it.isNotEmpty() },
+            artist = artists?.joinToString(", ")?.takeIf { it.isNotEmpty() },
+            description = series.description?.htmlDecode(),
+            genre = series.genres?.mapNotNull { it.genre }?.takeIf { it.isNotEmpty() },
+            status = mapStatus(series.status),
+            coverUrl = series.image?.url?.original,
+        )
+    }
+
+    private fun mapStatus(status: String?): Int =
+        when {
+            status == null -> 0
+            status.contains("Ongoing", ignoreCase = true) -> 1
+            status.contains("Complete", ignoreCase = true) -> 2
+            status.contains("Hiatus", ignoreCase = true) -> 6
+            status.contains("Cancelled", ignoreCase = true) -> 5
+            else -> 0
+        }
+
+    companion object {
+        private const val BASE_URL = "https://api.mangaupdates.com"
+        private val CONTENT_TYPE = "application/vnd.api+json".toMediaType()
+    }
+}
+
+// --- MangaUpdates Response DTOs for metadata ---
+
+@Serializable
+data class MUMetadataSearchResult(
+    val results: List<MUMetadataSearchResultItem> = emptyList(),
+)
+
+@Serializable
+data class MUMetadataSearchResultItem(
+    val record: MUMetadataRecord,
+)
+
+@Serializable
+data class MUMetadataRecord(
+    @SerialName("series_id")
+    val seriesId: Long? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val image: MUMetadataImage? = null,
+    val year: String? = null,
+)
+
+@Serializable
+data class MUMetadataImage(
+    val url: MUMetadataUrl? = null,
+)
+
+@Serializable
+data class MUMetadataUrl(
+    val original: String? = null,
+)
+
+@Serializable
+data class MUSeriesDetails(
+    @SerialName("series_id")
+    val seriesId: Long? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val image: MUMetadataImage? = null,
+    val authors: List<MUAuthor>? = null,
+    val genres: List<MUGenre>? = null,
+    val status: String? = null,
+    val year: String? = null,
+)
+
+@Serializable
+data class MUAuthor(
+    val name: String? = null,
+    val type: String? = null,
+)
+
+@Serializable
+data class MUGenre(
+    val genre: String? = null,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MetadataProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/metadata/MetadataProvider.kt
@@ -1,0 +1,31 @@
+package suwayomi.tachidesk.manga.impl.metadata
+
+interface MetadataProvider {
+    val name: String
+
+    suspend fun search(
+        query: String,
+        author: String? = null,
+    ): List<MetadataSearchResult>
+
+    suspend fun getDetails(externalId: String): MetadataDetails
+}
+
+data class MetadataSearchResult(
+    val externalId: String,
+    val title: String,
+    val author: String?,
+    val coverUrl: String?,
+    val year: Int?,
+    val description: String?,
+)
+
+data class MetadataDetails(
+    val title: String?,
+    val author: String?,
+    val artist: String?,
+    val description: String?,
+    val genre: List<String>?,
+    val status: Int?,
+    val coverUrl: String?,
+)


### PR DESCRIPTION
## Summary

Introduces a `MetadataProvider` interface with **AniList** and **MangaUpdates** implementations for fetching manga metadata from external sources.

New GraphQL mutations:
- `searchMetadataProvider` — search by title, returns candidates with cover URL, year, author
- `applyMetadataMatch` — fetch full details from provider and apply to manga (text metadata + optional cover download)

**AniList**: Free GraphQL API, no auth. Parses staff roles for author/artist, maps status enum, strips HTML from descriptions.

**MangaUpdates**: Free REST API, no auth. Dedicated author/artist fields, genre list, status mapping.

**Part 3 of 3** — metadata providers. See also:
- Part 1: Local manga editing (#1946)
- Part 2: Cover image upload (#1947)

Addresses #1340

## Test plan

- [x] Manual test: searchMetadataProvider with AniList — returns results
- [x] Manual test: searchMetadataProvider with MangaUpdates — returns results
- [x] Manual test: applyMetadataMatch — metadata + cover applied from AniList
- [x] Build: `shadowJar` passes
- [x] Lint: `ktlintCheck` passes