### PR TITLE
Add JXL container format support

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageUtil.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageUtil.kt
@@ -71,6 +71,9 @@ object ImageUtil {
             if (bytes.compareWith(charByteArrayOf(0xFF, 0x0A))) {
                 return JXL
             }
+            if (bytes.compareWith(charByteArrayOf(0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A))) {
+                return JXL
+            }
         } catch (_: Exception) {
         }
         return null


### PR DESCRIPTION
JXL images can either be a raw codestream or a container. From the [libjxl docs](https://github.com/libjxl/libjxl/blob/main/doc/format_overview.md#file-format):
>The JPEG XL file format can take two forms:
>*   A 'naked' codestream. In this case, only the image/animation data itself is
stored, and no additional metadata can be included. Such a file starts with the
bytes `0xFF0A` (the JPEG marker for "start of JPEG XL codestream").
>*   An ISOBMFF-based container. This is a box-based container that includes a
JPEG XL codestream box (`jxlc`), and can optionally include other boxes with
additional information, such as Exif metadata. In this case, the file starts with
the bytes `0x0000000C 4A584C20 0D0A870A`.

Currently, the server only recognizes the naked codestream variant as jxl images, resulting in the container variant not being recognized as images. This adds a check for the magic bytes of the latter.

Before:
<img width="1920" height="1045" alt="Screenshot From 2026-04-08 18-39-45" src="https://github.com/user-attachments/assets/15796f3a-6a9f-4fd3-b175-cf95eb2a6c2c" />
After:
<img width="1920" height="1045" alt="Screenshot From 2026-04-08 18-40-00" src="https://github.com/user-attachments/assets/a7981b3b-4faf-489e-b3dc-76180c966ca8" />

