### PR TITLE
Load manga details before fetching chapters in local source

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/LocalSource.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/local/LocalSource.kt
@@ -144,6 +144,7 @@ class LocalSource(
         // Fetch chapters of all the manga
         mangas.forEach { manga ->
             runBlocking {
+                getMangaDetails(manga)
                 val chapters = getChapterList(manga)
                 if (chapters.isNotEmpty()) {
                     val chapter = chapters.last()


### PR DESCRIPTION
Manga titles from details.json or ComicInfo.xml weren't showing up without a reload. Wasn't calling getMangaDetails, so the metadata never got loaded initially. Added the call before getChapterList. Fixes #1953