### PR TITLE
fix: only clear thumbnail cache when URL actually changed

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -144,7 +144,7 @@ object Manga {
                     ?: mangaEntry[MangaTable.description]
                 it[MangaTable.genre] = sManga.genre ?: mangaEntry[MangaTable.genre]
                 it[MangaTable.status] = sManga.status
-                if (!sManga.thumbnail_url.isNullOrEmpty()) {
+                if (!sManga.thumbnail_url.isNullOrEmpty() && sManga.thumbnail_url != mangaEntry[MangaTable.thumbnail_url]) {
                     it[MangaTable.thumbnail_url] = sManga.thumbnail_url
                     it[MangaTable.thumbnailUrlLastFetched] = Instant.now().epochSecond
                     clearThumbnail(mangaId)


### PR DESCRIPTION
Thumbnails were getting wiped on every library update even when the URL hadn't changed, because fetchManga() calls clearThumbnail() whenever the source returns any non-empty thumbnail URL without checking if it actually differs from the stored one. This could then in turn delete thumbnails and fail to download them if a source isn't available anymore.