### PR TITLE
Inject html base tag directly

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -206,20 +206,12 @@ object WebInterfaceManager {
 
         if (ServerSubpath.isDefined() && orgIndexHtml.exists()) {
             val originalIndexHtml = orgIndexHtml.readText()
-            val subpathInjectionScript =
-                """
-                <script>
-                    // <<suwayomi-subpath-injection>>
-                    const baseTag = document.createElement('base');
-                    baseTag.href = location.origin + "${ServerSubpath.asRootPath()}";
-                    document.head.appendChild(baseTag);
-                </script>
-                """.trimIndent()
+            val subpathInjectionBaseTag = "<base href=\"${ServerSubpath.asRootPath()}\">"
 
             val indexHtmlWithSubpathInjection =
                 originalIndexHtml.replace(
                     "<head>",
-                    "<head>$subpathInjectionScript",
+                    "<head>$subpathInjectionBaseTag",
                 )
 
             orgIndexHtml.writeText(indexHtmlWithSubpathInjection)


### PR DESCRIPTION
Using a script to inject the base tag is unnecessarily complex as well as it is introducing an issue where the initial requests will potentially fail, due to the base tag not being injected yet.

See https://github.com/Suwayomi/Suwayomi-WebUI/issues/1096, same issue applies when a subpath is set up which can't be fixed on the client side