### PR TITLE
Fix java.lang.VerifyError

### DIFF
--- a/AndroidCompat/src/main/java/android/widget/EditText.java
+++ b/AndroidCompat/src/main/java/android/widget/EditText.java
@@ -7,14 +7,26 @@ package android.widget;
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-public class EditText {
-    public EditText(android.content.Context context) { throw new RuntimeException("Stub!"); }
+public class EditText extends TextView {
+    public EditText(android.content.Context context) {
+        super(context);
+        throw new RuntimeException("Stub!");
+    }
 
-    public EditText(android.content.Context context, android.util.AttributeSet attrs) { throw new RuntimeException("Stub!"); }
+    public EditText(android.content.Context context, android.util.AttributeSet attrs) {
+        super(context);
+        throw new RuntimeException("Stub!");
+    }
 
-    public EditText(android.content.Context context, android.util.AttributeSet attrs, int defStyleAttr) { throw new RuntimeException("Stub!"); }
+    public EditText(android.content.Context context, android.util.AttributeSet attrs, int defStyleAttr) {
+        super(context);
+        throw new RuntimeException("Stub!");
+    }
 
-    public EditText(android.content.Context context, android.util.AttributeSet attrs, int defStyleAttr, int defStyleRes) { throw new RuntimeException("Stub!"); }
+    public EditText(android.content.Context context, android.util.AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context);
+        throw new RuntimeException("Stub!");
+    }
 
     public boolean getFreezesText() { throw new RuntimeException("Stub!"); }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Source/API**) Fix handling of nullable preference keys (TYPE "preferences")
 - (**Source**) Fix local manga thumbnails handling
 - (**Extension**) Fix missing icon for manually installed source
+- (**Extension**) Fixed a java.lang.VerifyError when installing an extension that has ProGuard enabled.
 - (**Backup**) Fix importing of backups with missing server settings
 - (**Backup**) Fix importing of backups with invalid server settings
 - (**Backup/API**) Fix missing backup creation flags (MUTATION "createBackup")


### PR DESCRIPTION

EditText stub doesn't inherit from TextView, which triggers a JVM verification error when ProGuard is enabled.

https://github.com/keiyoushi/extensions-source/pull/15400
https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/widget/EditText.java
