### PR TITLE
Reset update-flag on uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (WebUI) Handle serving non-default webui with "bundled"
 - (WebUI) Wait until WebUI is ready to open in browser
 - (Downloads) Truncate filenames by byte length to prevent "File name too long" IO errors
+- (Extension) Do not indicate an update is available when the extension is not installed
 
 ## [v2.2.2100] + [WebUI: v20260508.01] - 2026-05-08
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -358,6 +358,7 @@ object Extension {
                 } else {
                     ExtensionTable.update({ ExtensionTable.pkgName eq pkgName }) {
                         it[isInstalled] = false
+                        it[hasUpdate] = false
                     }
                 }
 


### PR DESCRIPTION
If there is an update available when the extension is uninstalled, the table will still have the update flag, which makes no sense if it is not installed.

Example:
```
{
  "pkgName": "eu.kanade.tachiyomi.extension.en.comix",
  "name": "Comix",
  "lang": "en",
  "versionCode": 20,
  "versionName": "1.4.20",
  "iconUrl": "/api/v1/extension/icon/tachiyomi-en.comix-v1.4.20.apk",
  "repo": "<hidden>",
  "isNsfw": true,
  "isInstalled": false,
  "isObsolete": false,
  "hasUpdate": true,
  "__typename": "ExtensionType"
},
```

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
