### PR TITLE
Fix chapter list update failure db rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (Startup) Crash on startup if an unrecoverable error happens
 
 ### Fixed
-- (CloudFlareInterceptor) Don't send the `cf_clearance` cookie back to Flaresolverr
-- (WebUI) Handle serving non-default webui with "bundled"
-- (WebUI) Wait until WebUI is ready to open in browser
-- (Downloads) Truncate filenames by byte length to prevent "File name too long" IO errors
-- (Extension) Do not indicate an update is available when the extension is not installed
+- (**CloudFlareInterceptor**) Don't send the `cf_clearance` cookie back to Flaresolverr
+- (**WebUI**) Handle serving non-default webui with "bundled"
+- (**WebUI**) Wait until WebUI is ready to open in browser
+- (**Downloads**) Truncate filenames by byte length to prevent "File name too long" IO errors
+- (**Extension**) Do not indicate an update is available when the extension is not installed
+- (**Chapter**) Fix losing chapter data on failed chapter list update
 
 ## [v2.2.2100] + [WebUI: v20260508.01] - 2026-05-08
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -262,16 +262,14 @@ object Chapter {
                         }
                     }
 
-                // we got some clean up due
-                if (chaptersIdsToDelete.isNotEmpty()) {
-                    DownloadManager.dequeue(chaptersIdsToDelete)
-                    transaction {
+                transaction {
+                    // we got some clean up due
+                    if (chaptersIdsToDelete.isNotEmpty()) {
+                        DownloadManager.dequeue(chaptersIdsToDelete)
                         PageTable.deleteWhere { chapter inList chaptersIdsToDelete }
                         ChapterTable.deleteWhere { id inList chaptersIdsToDelete }
                     }
-                }
 
-                transaction {
                     if (chaptersToInsert.isNotEmpty()) {
                         ChapterTable
                             .batchInsert(chaptersToInsert) { chapter ->


### PR DESCRIPTION
The deletion of chapter data was done in its own transaction. Thus, when the update or insertion failed later on, the deletion was not rolled back

fixes #2031