### PR TITLE
Fix sorting of gql mangas query

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
@@ -15,9 +15,11 @@ import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.like
 import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import suwayomi.tachidesk.graphql.directives.RequireAuth
 import suwayomi.tachidesk.graphql.queries.filter.BooleanFilter
@@ -243,22 +245,18 @@ class MangaQuery {
     ): MangaNodeList {
         val queryResults =
             transaction {
-                val res =
+                val mangaIdsQuery =
                     MangaTable
                         .leftJoin(CategoryMangaTable)
-                        .select(MangaTable.columns)
+                        .select(MangaTable.id)
+                        .withDistinct()
 
-                val applySorting = order != null || orderBy != null || (last != null || before != null)
+                mangaIdsQuery.applyOps(condition, filter)
 
-                if (applySorting) {
-                    res.withDistinctOn(MangaTable.id to SortOrder.ASC)
-                } else {
-                    res.withDistinctOn(MangaTable.id)
-                }
+                val res =
+                    MangaTable.selectAll().where { MangaTable.id inSubQuery mangaIdsQuery }
 
-                res.applyOps(condition, filter)
-
-                if (applySorting) {
+                if (order != null || orderBy != null || (last != null || before != null)) {
                     val baseSort = listOf(MangaOrder(MangaOrderBy.ID, SortOrder.ASC))
                     val deprecatedSort = listOfNotNull(orderBy?.let { MangaOrder(orderBy, orderByType) })
                     val actualSort = (order.orEmpty() + deprecatedSort + baseSort)


### PR DESCRIPTION
Regression fbb383b1f12d3a9447dcc54872c555b78eff526c

Broke sorting due to ordering the manga by their id first, thus, the other orderings were never applied