### PR TITLE
Fix `not All/Any` filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Chapter**) Fix losing chapter data on failed chapter list update
 - (**Chapter**) Fix database error when fetching chapter updates
 - (**Manga/API**) Fix "mangas" graphql query with active sorting and using a postgresql database (QUERY "mangas")
+- (**API**) Fix GraphQL `Filter` `notAll` and `notAny` being inversed
 
 ## [v2.2.2100] + [WebUI: v20260508.01] - 2026-05-08
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/filter/Filter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/filter/Filter.kt
@@ -435,7 +435,7 @@ fun <T : String, S : T?> andFilterWithCompareString(
 
     opAnd.andWhere(filter.isNull) { if (it) column.isNull() else column.isNotNull() }
     opAnd.andWhere(filter.equalTo) { column eq it as S }
-    opAnd.andWhere(filter.notEqualTo, filter.notEqualToAll, filter.notEqualToAny) { column neq it as S }
+    opAnd.andNotWhere(filter.notEqualTo, filter.notEqualToAll, filter.notEqualToAny) { column neq it as S }
     opAnd.andWhere(
         filter.distinctFrom,
         filter.distinctFromAll,
@@ -455,36 +455,36 @@ fun <T : String, S : T?> andFilterWithCompareString(
     opAnd.andWhere(filter.greaterThanOrEqualTo) { column greaterEq it }
 
     opAnd.andWhere(filter.includes, filter.includesAll, filter.includesAny) { column like "%$it%" }
-    opAnd.andWhere(filter.notIncludes, filter.notIncludesAll, filter.notIncludesAny) { column notLike "%$it%" }
+    opAnd.andNotWhere(filter.notIncludes, filter.notIncludesAll, filter.notIncludesAny) { column notLike "%$it%" }
     opAnd.andWhere(filter.includesInsensitive, filter.includesInsensitiveAll, filter.includesInsensitiveAny) {
         ILikeEscapeOp.iLike(column, "%$it%")
     }
-    opAnd.andWhere(filter.notIncludesInsensitive, filter.notIncludesInsensitiveAll, filter.notIncludesInsensitiveAny) {
+    opAnd.andNotWhere(filter.notIncludesInsensitive, filter.notIncludesInsensitiveAll, filter.notIncludesInsensitiveAny) {
         ILikeEscapeOp.iNotLike(column, "%$it%")
     }
 
     opAnd.andWhere(filter.startsWith, filter.startsWithAll, filter.startsWithAny) { column like "$it%" }
-    opAnd.andWhere(filter.notStartsWith, filter.notStartsWithAll, filter.notStartsWithAny) { column notLike "$it%" }
+    opAnd.andNotWhere(filter.notStartsWith, filter.notStartsWithAll, filter.notStartsWithAny) { column notLike "$it%" }
     opAnd.andWhere(filter.startsWithInsensitive, filter.startsWithInsensitiveAll, filter.startsWithInsensitiveAny) {
         ILikeEscapeOp.iLike(column, "$it%")
     }
-    opAnd.andWhere(filter.notStartsWithInsensitive, filter.notStartsWithInsensitiveAll, filter.notStartsWithInsensitiveAny) {
+    opAnd.andNotWhere(filter.notStartsWithInsensitive, filter.notStartsWithInsensitiveAll, filter.notStartsWithInsensitiveAny) {
         ILikeEscapeOp.iNotLike(column, "$it%")
     }
 
     opAnd.andWhere(filter.endsWith, filter.endsWithAll, filter.endsWithAny) { column like "%$it" }
-    opAnd.andWhere(filter.notEndsWith, filter.notEndsWithAll, filter.notEndsWithAny) { column notLike "%$it" }
+    opAnd.andNotWhere(filter.notEndsWith, filter.notEndsWithAll, filter.notEndsWithAny) { column notLike "%$it" }
     opAnd.andWhere(filter.endsWithInsensitive, filter.endsWithInsensitiveAll, filter.endsWithInsensitiveAny) {
         ILikeEscapeOp.iLike(column, "%$it")
     }
-    opAnd.andWhere(filter.notEndsWithInsensitive, filter.notEndsWithInsensitiveAll, filter.notEndsWithInsensitiveAny) {
+    opAnd.andNotWhere(filter.notEndsWithInsensitive, filter.notEndsWithInsensitiveAll, filter.notEndsWithInsensitiveAny) {
         ILikeEscapeOp.iNotLike(column, "%$it")
     }
 
     opAnd.andWhere(filter.like, filter.likeAll, filter.likeAny) { column like it }
-    opAnd.andWhere(filter.notLike, filter.notLikeAll, filter.notLikeAny) { column notLike it }
+    opAnd.andNotWhere(filter.notLike, filter.notLikeAll, filter.notLikeAny) { column notLike it }
     opAnd.andWhere(filter.likeInsensitive, filter.likeInsensitiveAll, filter.likeInsensitiveAny) { ILikeEscapeOp.iLike(column, it) }
-    opAnd.andWhere(filter.notLikeInsensitive, filter.notLikeInsensitiveAll, filter.notLikeInsensitiveAny) {
+    opAnd.andNotWhere(filter.notLikeInsensitive, filter.notLikeInsensitiveAll, filter.notLikeInsensitiveAny) {
         ILikeEscapeOp.iNotLike(column, it)
     }
 
@@ -535,11 +535,30 @@ class OpAnd(
         andWhereAny(valueAny, expr)
     }
 
+    fun <T : Any> andNotWhere(
+        valueDefault: T?,
+        valueAll: List<T>?,
+        valueAny: List<T>?,
+        expr: (T) -> Op<Boolean>,
+    ) {
+        andWhere(valueDefault, expr)
+        andNotWhereAll(valueAll, expr)
+        andNotWhereAny(valueAny, expr)
+    }
+
     fun <T : Any> andWhereAll(
         values: List<T>?,
         andPart: (T) -> Op<Boolean>,
     ) {
         values?.map { andWhere(it, andPart) }
+    }
+
+    fun <T : Any> andNotWhereAll(
+        values: List<T>?,
+        andPart: (T) -> Op<Boolean>,
+    ) {
+        // Inversed all equals any
+        andWhereAny(values, andPart)
     }
 
     fun <T : Any> andWhereAny(
@@ -549,6 +568,14 @@ class OpAnd(
         values ?: return
         val expr = values.map { andPart(it) }.reduce { acc, op -> acc or op }
         op = if (op == null) expr else (op!! and expr)
+    }
+
+    fun <T : Any> andNotWhereAny(
+        values: List<T>?,
+        andPart: (T) -> Op<Boolean>,
+    ) {
+        // Inversed any equals all
+        andWhereAll(values, andPart)
     }
 
     fun <T> eq(
@@ -578,7 +605,7 @@ fun <T : Comparable<T>, S : T?> andFilterWithCompare(
     opAnd.andWhere(filter.isNull) { if (it) column.isNull() else column.isNotNull() }
 
     opAnd.andWhere(filter.equalTo) { column eq it as S }
-    opAnd.andWhere(filter.notEqualTo, filter.notEqualToAll, filter.notEqualToAny) { column neq it as S }
+    opAnd.andNotWhere(filter.notEqualTo, filter.notEqualToAll, filter.notEqualToAny) { column neq it as S }
     opAnd.andWhere(filter.distinctFrom, filter.distinctFromAll, filter.distinctFromAny) { DistinctFromOp.distinctFrom(column, it as S) }
     opAnd.andWhere(filter.notDistinctFrom) { DistinctFromOp.notDistinctFrom(column, it as S) }
     if (!filter.`in`.isNullOrEmpty()) {
@@ -606,7 +633,7 @@ fun <T : Comparable<T>> andFilterWithCompareEntity(
     opAnd.andWhere(filter.isNull) { if (it) column.isNull() else column.isNotNull() }
 
     opAnd.andWhere(filter.equalTo) { column eq it }
-    opAnd.andWhere(filter.notEqualTo, filter.notEqualToAll, filter.notEqualToAny) { column neq it }
+    opAnd.andNotWhere(filter.notEqualTo, filter.notEqualToAll, filter.notEqualToAny) { column neq it }
     opAnd.andWhere(filter.distinctFrom, filter.distinctFromAll, filter.distinctFromAny) { DistinctFromOp.distinctFrom(column, it) }
     opAnd.andWhere(filter.notDistinctFrom) { DistinctFromOp.notDistinctFrom(column, it) }
     if (!filter.`in`.isNullOrEmpty()) {


### PR DESCRIPTION
Both filters were inversed. `notAll` did what `notAny` was supposed to do and vise versa

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
