### PR TITLE
Fix `subscribeTo` sometimes not emitting initial value

### DIFF
--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -73,6 +73,24 @@ val serverConfig: ServerConfig by lazy { GlobalConfigManager.module() }
 
 private val application: Application by injectLazy()
 
+@OptIn(ExperimentalCoroutinesApi::class)
+fun <T> subscribeTo(
+    flow: Flow<T>,
+    ignoreInitialValue: Boolean = true,
+    onChange: suspend (value: T) -> Unit,
+) {
+    val actualFlow =
+        if (ignoreInitialValue) {
+            flow.drop(1)
+        } else {
+            flow
+        }
+
+    val sharedFlow = MutableSharedFlow<T>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    actualFlow.distinctUntilChanged().mapLatest { sharedFlow.emit(it) }.launchIn(mutableConfigValueScope)
+    sharedFlow.onEach { onChange(it) }.launchIn(mutableConfigValueScope)
+}
+
 // Settings are ordered by "protoNumber".
 class ServerConfig(
     getConfig: () -> Config,
@@ -1067,18 +1085,7 @@ class ServerConfig(
         flow: Flow<T>,
         onChange: suspend (value: T) -> Unit,
         ignoreInitialValue: Boolean = true,
-    ) {
-        val actualFlow =
-            if (ignoreInitialValue) {
-                flow.drop(1)
-            } else {
-                flow
-            }
-
-        val sharedFlow = MutableSharedFlow<T>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-        actualFlow.distinctUntilChanged().mapLatest { sharedFlow.emit(it) }.launchIn(mutableConfigValueScope)
-        sharedFlow.onEach { onChange(it) }.launchIn(mutableConfigValueScope)
-    }
+    ) = subscribeTo(flow, ignoreInitialValue, onChange)
 
     fun <T> subscribeTo(
         flow: Flow<T>,

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
@@ -85,10 +86,7 @@ fun <T> subscribeTo(
         } else {
             flow
         }
-
-    val sharedFlow = MutableSharedFlow<T>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    actualFlow.distinctUntilChanged().mapLatest { sharedFlow.emit(it) }.launchIn(mutableConfigValueScope)
-    sharedFlow.onEach { onChange(it) }.launchIn(mutableConfigValueScope)
+    actualFlow.distinctUntilChanged().conflate().onEach { onChange(it) }.launchIn(mutableConfigValueScope)
 }
 
 // Settings are ordered by "protoNumber".

--- a/server/src/test/kotlin/suwayomi/tachidesk/FlowTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/FlowTest.kt
@@ -1,0 +1,25 @@
+package suwayomi.tachidesk
+
+import graphql.Assert.assertTrue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import suwayomi.tachidesk.server.subscribeTo
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+class FlowTest {
+    @Test
+    fun subscribe() = runTest {
+        (1..1000).forEach { _ ->
+            val testFlow = MutableStateFlow(value = 3)
+            testFlow.first()
+            val latch = CountDownLatch(1)
+            subscribeTo(testFlow, ignoreInitialValue = false) { _ ->
+                latch.countDown()
+            }
+            assertTrue(latch.await(5, TimeUnit.SECONDS))
+        }
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/FlowTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/FlowTest.kt
@@ -11,15 +11,16 @@ import kotlin.test.Test
 
 class FlowTest {
     @Test
-    fun subscribe() = runTest {
-        (1..1000).forEach { _ ->
-            val testFlow = MutableStateFlow(value = 3)
-            testFlow.first()
-            val latch = CountDownLatch(1)
-            subscribeTo(testFlow, ignoreInitialValue = false) { _ ->
-                latch.countDown()
+    fun subscribe() =
+        runTest {
+            (1..1000).forEach { _ ->
+                val testFlow = MutableStateFlow(value = 3)
+                testFlow.first()
+                val latch = CountDownLatch(1)
+                subscribeTo(testFlow, ignoreInitialValue = false) { _ ->
+                    latch.countDown()
+                }
+                assertTrue(latch.await(5, TimeUnit.SECONDS))
             }
-            assertTrue(latch.await(5, TimeUnit.SECONDS))
         }
-    }
 }


### PR DESCRIPTION
Especially on slower devices it could happen that the initial value was not observed by `subscribeTo`, leading to WebView and Socks proxy not initializing properly.
