### PR TITLE
Fix automatic chapter downloads

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -194,7 +194,7 @@ object Chapter {
                     }
 
                 // new chapters after they have been added to the database for auto downloads
-                val insertedChapters = mutableListOf<ChapterDataClass>()
+                val insertedChapterIds = mutableListOf<Int>()
 
                 val chaptersToInsert = mutableListOf<ChapterDataClass>() // do not yet have an ID from the database
                 val chaptersToUpdate = mutableListOf<ChapterDataClass>()
@@ -309,7 +309,7 @@ object Chapter {
                                         }
                                     }
                                 }
-                            }.forEach { insertedChapters.add(ChapterTable.toDataClass(it)) }
+                            }.forEach { insertedChapterIds.add(it[ChapterTable.id].value) }
                     }
 
                     if (chaptersToUpdate.isNotEmpty()) {
@@ -354,6 +354,13 @@ object Chapter {
                 }
 
                 if (manga.inLibrary) {
+                    // We have to query the inserted chapters to get the up-to-date data. I.e. "last_modified_at" is not returned by the insert statement, due to being set by a DB trigger
+                    val insertedChapters =
+                        transaction {
+                            ChapterTable.selectAll().where { ChapterTable.id inList insertedChapterIds }.map(
+                                ChapterTable::toDataClass,
+                            )
+                        }
                     downloadNewChapters(mangaId, currentLatestChapterNumber, numberOfCurrentChapters, insertedChapters)
                 }
 


### PR DESCRIPTION
The returned result rows of the inserted chapters did not have the up-to-date "last_modified_at". This caused "downloadNewChapters" to not be able to correctly detect unread chapters. it included the newly inserted ones, leading to exiting early due to having unread chapters.

Regression 811e15162b538338a11ce7085167244efcfff8fb

fixes #2097