### PR TITLE
feat(download): improve chapter download filenames

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -71,13 +71,46 @@ object ChapterDownloadHelper {
                     .select(ChapterTable.columns + MangaTable.columns)
                     .where { ChapterTable.id eq chapterId }
                     .firstOrNull() ?: throw IllegalArgumentException("ChapterId $chapterId not found")
+
             val chapter = ChapterTable.toDataClass(row)
-            val mangaTitle = row[MangaTable.title]
+            val mangaTitle = row[MangaTable.title].trim()
 
-            val scanlatorPart = chapter.scanlator?.let { "[$it] " } ?: ""
-            val fileName = "$mangaTitle - $scanlatorPart${chapter.name}.cbz"
+            val scanlatorName = chapter.scanlator?.trim()?.takeIf { it.isNotEmpty() }
+            val chapterName = chapter.name.trim().takeIf { it.isNotEmpty() }
 
-            Pair(chapter, fileName)
+            val fileName =
+                buildString {
+                    append(mangaTitle)
+                    append(" - ")
+
+                    if (chapterName != null) {
+                        append(chapterName)
+                    } else if (chapter.chapterNumber >= 0f) {
+                        // chapterNumber is stored as Float, drop .0 for whole numbers.
+                        val formatNumber =
+                            if (chapter.chapterNumber % 1 == 0f) {
+                                chapter.chapterNumber.toInt().toString()
+                            } else {
+                                chapter.chapterNumber.toString()
+                            }
+                        append("#$formatNumber")
+                    } else {
+                        // Fallback when neither name nor valid chapter number exists
+                        append("#${chapter.index}")
+                    }
+
+                    if (scanlatorName != null) {
+                        append(" [")
+                        append(scanlatorName)
+                        append("]")
+                    }
+                    append(".cbz")
+                }
+
+            // Sanitize filename for OS compatibility
+            val safeFileName = fileName.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+
+            Pair(chapter, safeFileName)
         }
 
     fun getCbzForDownload(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -16,6 +16,7 @@ import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.toDataClass
 import suwayomi.tachidesk.server.serverConfig
+import xyz.nulldev.androidcompat.util.SafePath
 import java.io.File
 import java.io.InputStream
 
@@ -108,7 +109,7 @@ object ChapterDownloadHelper {
                 }
 
             // Sanitize filename for OS compatibility
-            val safeFileName = fileName.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+            val safeFileName = SafePath.buildValidFilename(fileName)
 
             Pair(chapter, safeFileName)
         }


### PR DESCRIPTION
This pull request refactors the CBZ filename generation in `ChapterDownloadHelper.kt` to prevent file collisions. It trims whitespace, adds safe fallbacks (using the formatted chapter number or index) when a chapter name is missing, and moves the scanlator name to brackets at the end of the filename to maintain sequential file sorting on disk. Additionally, it sanitizes invalid OS characters with underscores to prevent download failures across different operating systems.