### PR TITLE
Extension API 1.6 fix: re-sync

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionStoreService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionStoreService.kt
@@ -124,27 +124,30 @@ object ExtensionStoreService {
             transaction {
                 ExtensionStoreTable.selectAll().toList()
             }
-        return stores.mapNotNull { storeRow ->
+        var needsPrefUpdate = false
+        val updateStores = stores.mapNotNull { storeRow ->
             val oldIndexUrl = storeRow[ExtensionStoreTable.indexUrl]
             val oldName = storeRow[ExtensionStoreTable.name]
             try {
                 val store = fetch(oldIndexUrl)
-                upsert(store)
                 if (store.indexUrl != oldIndexUrl) {
                     transaction {
                         ExtensionStoreTable.deleteWhere { ExtensionStoreTable.indexUrl eq oldIndexUrl }
                     }
-                    syncDbToPrefs(oldIndexUrl)
+                    needsPrefUpdate = true
                 }
+                upsert(store)
                 store
             } catch (e: Exception) {
                 logger.warn(e) { "Failed to fetch extension store '$oldName ($oldIndexUrl)'" }
                 null
             }
         }
+        if (needsPrefUpdate) syncDbToPrefs()
+        return updateStores
     }
 
-    fun syncDbToPrefs(keepRemoved: String? = null) {
+    fun syncDbToPrefs() {
         val dbStores =
             transaction {
                 ExtensionStoreTable
@@ -154,8 +157,8 @@ object ExtensionStoreService {
             }
 
         val currentPrefs = serverConfig.extensionStores.value.toSet()
-        val toAdd = (dbStores - currentPrefs - keepRemoved).filterNotNull()
-        val toRemove = (currentPrefs - dbStores + keepRemoved).filterNotNull()
+        val toAdd = dbStores - currentPrefs
+        val toRemove = currentPrefs - dbStores
 
         if (toAdd.isNotEmpty()) {
             serverConfig.extensionStores.value = (serverConfig.extensionStores.value + toAdd).distinct()
@@ -175,27 +178,32 @@ object ExtensionStoreService {
             }
 
         val toAdd = prefUrls - dbStores.keys
+        val toRemove = (dbStores.keys - prefUrls).toMutableSet()
+        var needsPrefUpdate = toRemove.isNotEmpty()
 
         toAdd.forEach { url ->
             try {
                 val store = fetch(url)
-                upsert(store)
                 if (store.indexUrl != url) {
                     transaction {
                         ExtensionStoreTable.deleteWhere { ExtensionStoreTable.indexUrl eq url }
                     }
-                    syncDbToPrefs(url)
+                    needsPrefUpdate = true
+                    toRemove -= store.indexUrl
                 }
+                upsert(store)
             } catch (e: Exception) {
                 logger.warn(e) { "Failed to sync preference store '$url' to database" }
             }
         }
 
-        val toRemove = dbStores.keys - prefUrls
         if (toRemove.isNotEmpty()) {
             transaction {
                 ExtensionStoreTable.deleteWhere { ExtensionStoreTable.indexUrl inList toRemove.toList() }
             }
+        }
+        if (needsPrefUpdate) {
+            syncDbToPrefs()
         }
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -525,7 +525,6 @@ fun applicationSetup() {
         serverConfig.extensionStores,
         { _ ->
             ExtensionStoreService.syncPrefsToDb()
-            ExtensionStoreService.syncDbToPrefs()
         },
         ignoreInitialValue = false,
     )


### PR DESCRIPTION
As discussed over discord, the current implementation does not consider when the store URL update resolves to the same URL as already in the DB (e.g. because the settings file was changed back to an older state).

Repro:
- Set `server.extensionStores = ["https://raw.githubusercontent.com/keiyoushi/extensions/repo/index.min.json"]`
- Start Suwayomi
- Close Suwayomi
- Set `server.extensionStores` back (should be updated to index.pb)