### PR TITLE
Use stable manga and chapter composite keys for sync matching

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncYomiSyncService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncYomiSyncService.kt
@@ -305,8 +305,7 @@ object SyncYomiSyncService {
 
         logger.debug { "Starting merge. Local list size: ${localMangaListSafe.size}, Remote list size: ${remoteMangaListSafe.size}" }
 
-        fun mangaCompositeKey(manga: BackupManga): String =
-            "${manga.source}|${manga.url}|${manga.title.lowercase().trim()}|${manga.author?.lowercase()?.trim()}"
+        fun mangaCompositeKey(manga: BackupManga): String = "${manga.source}|${manga.url}"
 
         // Create maps using composite keys
         val localMangaMap = localMangaListSafe.associateBy { mangaCompositeKey(it) }
@@ -415,7 +414,7 @@ object SyncYomiSyncService {
             return remoteChapters // If not syncing chapters, keep remote untouched
         }
 
-        fun chapterCompositeKey(chapter: BackupChapter): String = "${chapter.url}|${chapter.name}|${chapter.chapterNumber}"
+        fun chapterCompositeKey(chapter: BackupChapter): String = chapter.url
 
         val localChapterMap = localChapters.associateBy { chapterCompositeKey(it) }
         val remoteChapterMap = remoteChapters.associateBy { chapterCompositeKey(it) }


### PR DESCRIPTION
Adapted the stable manga and chapter key changes from jobobby04/TachiyomiSY#1594. The remaining changes were either already present in Suwayomi or not applicable to its implementation.