### PR TITLE
feat(track): add manga relations & recommendations query (AniList, MyAnimeList)

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/TrackQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/TrackQuery.kt
@@ -41,6 +41,7 @@ import suwayomi.tachidesk.graphql.types.TrackRelatedMangaType
 import suwayomi.tachidesk.graphql.types.TrackSearchType
 import suwayomi.tachidesk.graphql.types.TrackerNodeList
 import suwayomi.tachidesk.graphql.types.TrackerType
+import suwayomi.tachidesk.manga.impl.track.tracker.Tracker
 import suwayomi.tachidesk.manga.impl.track.tracker.TrackerManager
 import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelatedResult
 import suwayomi.tachidesk.manga.model.table.MangaTable
@@ -562,7 +563,7 @@ class TrackQuery {
                 runCatching {
                     val remoteId =
                         getRemoteId(input.mangaId, TrackerManager.ANILIST)
-                            ?: title?.takeIf { anilist.isLoggedIn }?.let { anilist.search(it).firstOrNull()?.remote_id }
+                            ?: title?.takeIf { anilist.isLoggedIn }?.let { findRemoteIdByTitle(anilist, it) }
                     remoteId?.let { anilist.getRelated(it) }
                 }.onFailure { logger.warn(it) { "Failed to load AniList related manga for $input" } }
                     .getOrNull() ?: TrackRelatedResult()
@@ -572,7 +573,7 @@ class TrackQuery {
                 runCatching {
                     val remoteId =
                         getRemoteId(input.mangaId, TrackerManager.MYANIMELIST)
-                            ?: title?.takeIf { mal.isLoggedIn }?.let { mal.search(it).firstOrNull()?.remote_id }
+                            ?: title?.takeIf { mal.isLoggedIn }?.let { findRemoteIdByTitle(mal, it) }
                     remoteId?.let { mal.getRelated(it) }
                 }.onFailure { logger.warn(it) { "Failed to load MyAnimeList related manga for $input" } }
                     .getOrNull() ?: TrackRelatedResult()
@@ -606,7 +607,83 @@ class TrackQuery {
                 ?.get(TrackRecordTable.remoteId)
         }
 
+    /**
+     * Searches [tracker] for [title] and returns the remote id of the first result whose title is a
+     * confident match (see [isConfidentTitleMatch]). Returns `null` when no result matches well
+     * enough, so a loose/wrong top hit is never used to drive the related results.
+     */
+    private suspend fun findRemoteIdByTitle(
+        tracker: Tracker,
+        title: String,
+    ): Long? =
+        tracker
+            .search(title)
+            .firstOrNull { isConfidentTitleMatch(title, it.title) }
+            ?.remote_id
+
     companion object {
         private val logger = KotlinLogging.logger {}
+
+        private const val TITLE_MATCH_THRESHOLD = 0.9
+
+        /**
+         * Whether [candidate] is confidently the same title as [source]. Titles are normalized
+         * (lowercased, punctuation/whitespace collapsed) and considered a match when they are equal
+         * or have a Levenshtein similarity of at least [TITLE_MATCH_THRESHOLD]. This tolerates minor
+         * punctuation/spacing differences while rejecting clearly different entries.
+         */
+        private fun isConfidentTitleMatch(
+            source: String,
+            candidate: String,
+        ): Boolean {
+            val a = normalizeTitle(source)
+            val b = normalizeTitle(candidate)
+            if (a.isEmpty() || b.isEmpty()) {
+                return false
+            }
+            if (a == b) {
+                return true
+            }
+
+            val distance = levenshtein(a, b)
+            val similarity = 1.0 - distance.toDouble() / maxOf(a.length, b.length)
+            return similarity >= TITLE_MATCH_THRESHOLD
+        }
+
+        private fun normalizeTitle(title: String): String =
+            title
+                .lowercase()
+                .replace(Regex("[^\\p{L}\\p{N}]+"), " ")
+                .trim()
+
+        private fun levenshtein(
+            a: String,
+            b: String,
+        ): Int {
+            if (a == b) return 0
+            if (a.isEmpty()) return b.length
+            if (b.isEmpty()) return a.length
+
+            var previous = IntArray(b.length + 1) { it }
+            var current = IntArray(b.length + 1)
+
+            for (i in 1..a.length) {
+                current[0] = i
+                for (j in 1..b.length) {
+                    val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+                    current[j] =
+                        minOf(
+                            current[j - 1] + 1,
+                            previous[j] + 1,
+                            previous[j - 1] + cost,
+                        )
+                }
+                val temp = previous
+                previous = current
+                current = temp
+            }
+
+            return previous[b.length]
+        }
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/TrackQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/TrackQuery.kt
@@ -3,9 +3,12 @@ package suwayomi.tachidesk.graphql.queries
 import com.expediagroup.graphql.generator.annotations.GraphQLDeprecated
 import com.expediagroup.graphql.server.extensions.getValueFromDataLoader
 import graphql.schema.DataFetchingEnvironment
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -34,10 +37,13 @@ import suwayomi.tachidesk.graphql.server.primitives.lessNotUnique
 import suwayomi.tachidesk.graphql.server.primitives.maybeSwap
 import suwayomi.tachidesk.graphql.types.TrackRecordNodeList
 import suwayomi.tachidesk.graphql.types.TrackRecordType
+import suwayomi.tachidesk.graphql.types.TrackRelatedMangaType
 import suwayomi.tachidesk.graphql.types.TrackSearchType
 import suwayomi.tachidesk.graphql.types.TrackerNodeList
 import suwayomi.tachidesk.graphql.types.TrackerType
 import suwayomi.tachidesk.manga.impl.track.tracker.TrackerManager
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelatedResult
+import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.TrackRecordTable
 import suwayomi.tachidesk.manga.model.table.insertAll
 import suwayomi.tachidesk.server.JavalinSetup.future
@@ -526,4 +532,81 @@ class TrackQuery {
                 },
             )
         }
+
+    data class MangaRelatedInput(
+        val mangaId: Int,
+    )
+
+    data class MangaRelatedPayload(
+        val anilistRelations: List<TrackRelatedMangaType>,
+        val anilistRecommendations: List<TrackRelatedMangaType>,
+        val myanimelistRelations: List<TrackRelatedMangaType>,
+        val myanimelistRecommendations: List<TrackRelatedMangaType>,
+    )
+
+    /**
+     * Returns the relations and recommendations for [mangaId] from AniList and MyAnimeList.
+     *
+     * The remote media id is resolved from an existing track record when available, otherwise the
+     * manga title is searched on the (logged-in) tracker and the top hit is used. Failures for a
+     * single tracker (e.g. not logged in, no match, network error) yield an empty list for that
+     * tracker rather than failing the whole query.
+     */
+    @RequireAuth
+    fun mangaRelated(input: MangaRelatedInput): CompletableFuture<MangaRelatedPayload> =
+        future {
+            val title = getMangaTitle(input.mangaId)
+
+            val anilist = TrackerManager.aniList
+            val anilistResult =
+                runCatching {
+                    val remoteId =
+                        getRemoteId(input.mangaId, TrackerManager.ANILIST)
+                            ?: title?.takeIf { anilist.isLoggedIn }?.let { anilist.search(it).firstOrNull()?.remote_id }
+                    remoteId?.let { anilist.getRelated(it) }
+                }.onFailure { logger.warn(it) { "Failed to load AniList related manga for $input" } }
+                    .getOrNull() ?: TrackRelatedResult()
+
+            val mal = TrackerManager.myAnimeList
+            val malResult =
+                runCatching {
+                    val remoteId =
+                        getRemoteId(input.mangaId, TrackerManager.MYANIMELIST)
+                            ?: title?.takeIf { mal.isLoggedIn }?.let { mal.search(it).firstOrNull()?.remote_id }
+                    remoteId?.let { mal.getRelated(it) }
+                }.onFailure { logger.warn(it) { "Failed to load MyAnimeList related manga for $input" } }
+                    .getOrNull() ?: TrackRelatedResult()
+
+            MangaRelatedPayload(
+                anilistRelations = anilistResult.relations.map { TrackRelatedMangaType(it) },
+                anilistRecommendations = anilistResult.recommendations.map { TrackRelatedMangaType(it) },
+                myanimelistRelations = malResult.relations.map { TrackRelatedMangaType(it) },
+                myanimelistRecommendations = malResult.recommendations.map { TrackRelatedMangaType(it) },
+            )
+        }
+
+    private fun getMangaTitle(mangaId: Int): String? =
+        transaction {
+            MangaTable
+                .selectAll()
+                .where { MangaTable.id eq mangaId }
+                .firstOrNull()
+                ?.get(MangaTable.title)
+        }
+
+    private fun getRemoteId(
+        mangaId: Int,
+        trackerId: Int,
+    ): Long? =
+        transaction {
+            TrackRecordTable
+                .selectAll()
+                .where { (TrackRecordTable.mangaId eq mangaId) and (TrackRecordTable.trackerId eq trackerId) }
+                .firstOrNull()
+                ?.get(TrackRecordTable.remoteId)
+        }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/TrackQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/TrackQuery.kt
@@ -608,9 +608,11 @@ class TrackQuery {
         }
 
     /**
-     * Searches [tracker] for [title] and returns the remote id of the first result whose title is a
-     * confident match (see [isConfidentTitleMatch]). Returns `null` when no result matches well
-     * enough, so a loose/wrong top hit is never used to drive the related results.
+     * Searches [tracker] for [title] and returns the remote id of the first result that confidently
+     * matches (see [isConfidentTitleMatch]) against any of the result's titles, including
+     * alternative ones (romaji/english/native/synonyms) so a localized source title can still match
+     * a differently-named entry. Returns `null` when no result matches well enough, so a loose/wrong
+     * top hit is never used to drive the related results.
      */
     private suspend fun findRemoteIdByTitle(
         tracker: Tracker,
@@ -618,8 +620,9 @@ class TrackQuery {
     ): Long? =
         tracker
             .search(title)
-            .firstOrNull { isConfidentTitleMatch(title, it.title) }
-            ?.remote_id
+            .firstOrNull { result ->
+                (listOf(result.title) + result.alternative_titles).any { isConfidentTitleMatch(title, it) }
+            }?.remote_id
 
     companion object {
         private val logger = KotlinLogging.logger {}

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/TrackType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/TrackType.kt
@@ -11,6 +11,7 @@ import suwayomi.tachidesk.graphql.server.primitives.PageInfo
 import suwayomi.tachidesk.manga.impl.track.Track
 import suwayomi.tachidesk.manga.impl.track.tracker.DeletableTracker
 import suwayomi.tachidesk.manga.impl.track.tracker.Tracker
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelated
 import suwayomi.tachidesk.manga.model.table.TrackRecordTable
 import suwayomi.tachidesk.manga.model.table.TrackSearchTable
 import java.util.concurrent.CompletableFuture
@@ -62,6 +63,22 @@ class TrackStatusType(
     val value: Int,
     val name: String,
 )
+
+class TrackRelatedMangaType(
+    val remoteId: Long,
+    val title: String,
+    val coverUrl: String,
+    val trackingUrl: String,
+    val relationType: String?,
+) {
+    constructor(related: TrackRelated) : this(
+        related.remoteId,
+        related.title,
+        related.coverUrl,
+        related.trackingUrl,
+        related.relationType,
+    )
+}
 
 class TrackRecordType(
     val id: Int,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/Anilist.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/Anilist.kt
@@ -8,6 +8,7 @@ import suwayomi.tachidesk.manga.impl.track.tracker.Tracker
 import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALOAuth
 import suwayomi.tachidesk.manga.impl.track.tracker.extractToken
 import suwayomi.tachidesk.manga.impl.track.tracker.model.Track
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelatedResult
 import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackSearch
 import uy.kohesive.injekt.injectLazy
 import java.io.IOException
@@ -212,6 +213,8 @@ class Anilist(
     }
 
     override suspend fun search(query: String): List<TrackSearch> = api.search(query)
+
+    suspend fun getRelated(remoteId: Long): TrackRelatedResult = api.getRelated(remoteId)
 
     override suspend fun refresh(track: Track): Track {
         val remoteTrack = api.getLibManga(track, getUsername().toInt())

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/AnilistApi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/AnilistApi.kt
@@ -167,8 +167,12 @@ class AnilistApi(
                                 |}
                             |}
                         |}
+                        |synonyms
                         |title {
                             |userPreferred
+                            |romaji
+                            |english
+                            |native
                         |}
                         |coverImage {
                             |large

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/AnilistApi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/AnilistApi.kt
@@ -19,9 +19,13 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALAddMangaResult
 import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALCurrentUserResult
 import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALOAuth
+import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALRelatedNode
+import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALRelatedResult
 import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALSearchResult
 import suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto.ALUserListMangaQueryResult
 import suwayomi.tachidesk.manga.impl.track.tracker.model.Track
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelated
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelatedResult
 import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackSearch
 import uy.kohesive.injekt.injectLazy
 import java.time.Instant
@@ -204,6 +208,108 @@ class AnilistApi(
                     .map { it.toALManga().toTrack() }
             }
         }
+
+    suspend fun getRelated(mediaId: Long): TrackRelatedResult =
+        withIOContext {
+            val query =
+                """
+            |query Related(${'$'}id: Int) {
+                |Media(id: ${'$'}id, type: MANGA) {
+                    |relations {
+                        |edges {
+                            |relationType(version: 2)
+                            |node {
+                                |id
+                                |type
+                                |title {
+                                    |userPreferred
+                                |}
+                                |coverImage {
+                                    |large
+                                |}
+                            |}
+                        |}
+                    |}
+                    |recommendations(sort: RATING_DESC, perPage: 30) {
+                        |edges {
+                            |node {
+                                |mediaRecommendation {
+                                    |id
+                                    |type
+                                    |title {
+                                        |userPreferred
+                                    |}
+                                    |coverImage {
+                                        |large
+                                    |}
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            |}
+            |
+                """.trimMargin()
+            val payload =
+                buildJsonObject {
+                    put("query", query)
+                    putJsonObject("variables") {
+                        put("id", mediaId)
+                    }
+                }
+            with(json) {
+                // Relations/recommendations are public data, so the unauthenticated client is used
+                // to allow this to work even when the user is not logged in to AniList.
+                val media =
+                    client
+                        .newCall(
+                            POST(
+                                API_URL,
+                                body = payload.toString().toRequestBody(jsonMime),
+                            ),
+                        ).awaitSuccess()
+                        .parseAs<ALRelatedResult>()
+                        .data.Media
+
+                TrackRelatedResult(
+                    relations =
+                        media
+                            ?.relations
+                            ?.edges
+                            .orEmpty()
+                            .mapNotNull { edge ->
+                                edge.node?.takeIf { it.type == "MANGA" }?.toTrackRelated(formatRelationType(edge.relationType))
+                            },
+                    recommendations =
+                        media
+                            ?.recommendations
+                            ?.edges
+                            .orEmpty()
+                            .mapNotNull { edge ->
+                                edge.node
+                                    ?.mediaRecommendation
+                                    ?.takeIf { it.type == "MANGA" }
+                                    ?.toTrackRelated(null)
+                            },
+                )
+            }
+        }
+
+    private fun ALRelatedNode.toTrackRelated(relationType: String?): TrackRelated =
+        TrackRelated(
+            remoteId = id,
+            title = title.userPreferred,
+            coverUrl = coverImage.large,
+            trackingUrl = mangaUrl(id),
+            relationType = relationType,
+        )
+
+    private fun formatRelationType(relationType: String?): String? =
+        relationType
+            ?.split("_")
+            ?.joinToString(" ") { word ->
+                word.lowercase().replaceFirstChar { it.uppercase() }
+            }
 
     suspend fun findLibManga(
         track: Track,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/dto/ALManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/dto/ALManga.kt
@@ -20,11 +20,13 @@ data class ALManga(
     val totalChapters: Int,
     val averageScore: Int,
     val staff: ALStaff,
+    val alternativeTitles: List<String> = emptyList(),
 ) {
     fun toTrack() =
         TrackSearch.create(TrackerManager.ANILIST).apply {
             remote_id = remoteId
             title = this@ALManga.title
+            alternative_titles = alternativeTitles
             total_chapters = totalChapters
             cover_url = imageUrl
             summary = description?.htmlDecode() ?: ""

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/dto/ALRelatedResult.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/dto/ALRelatedResult.kt
@@ -1,0 +1,53 @@
+package suwayomi.tachidesk.manga.impl.track.tracker.anilist.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ALRelatedResult(
+    val data: ALRelatedData,
+)
+
+@Serializable
+data class ALRelatedData(
+    val Media: ALRelatedMedia?,
+)
+
+@Serializable
+data class ALRelatedMedia(
+    val relations: ALRelationConnection = ALRelationConnection(),
+    val recommendations: ALRecommendationConnection = ALRecommendationConnection(),
+)
+
+@Serializable
+data class ALRelationConnection(
+    val edges: List<ALRelationEdge> = emptyList(),
+)
+
+@Serializable
+data class ALRelationEdge(
+    val relationType: String? = null,
+    val node: ALRelatedNode?,
+)
+
+@Serializable
+data class ALRecommendationConnection(
+    val edges: List<ALRecommendationEdge> = emptyList(),
+)
+
+@Serializable
+data class ALRecommendationEdge(
+    val node: ALRecommendationNode?,
+)
+
+@Serializable
+data class ALRecommendationNode(
+    val mediaRecommendation: ALRelatedNode?,
+)
+
+@Serializable
+data class ALRelatedNode(
+    val id: Long,
+    val type: String? = null,
+    val title: ALItemTitle,
+    val coverImage: ItemCover,
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/dto/ALSearchItem.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/anilist/dto/ALSearchItem.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class ALSearchItem(
     val id: Long,
     val title: ALItemTitle,
+    val synonyms: List<String> = emptyList(),
     val coverImage: ItemCover,
     val description: String?,
     val format: String,
@@ -19,6 +20,7 @@ data class ALSearchItem(
         ALManga(
             remoteId = id,
             title = title.userPreferred,
+            alternativeTitles = title.allTitles() + synonyms,
             imageUrl = coverImage.large,
             description = description,
             format = format.replace("_", "-"),
@@ -33,7 +35,12 @@ data class ALSearchItem(
 @Serializable
 data class ALItemTitle(
     val userPreferred: String,
-)
+    val romaji: String? = null,
+    val english: String? = null,
+    val native: String? = null,
+) {
+    fun allTitles(): List<String> = listOfNotNull(userPreferred, romaji, english, native)
+}
 
 @Serializable
 data class ItemCover(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/model/TrackRelated.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/model/TrackRelated.kt
@@ -1,0 +1,20 @@
+package suwayomi.tachidesk.manga.impl.track.tracker.model
+
+/**
+ * A lightweight representation of a manga that is related to, or recommended for, another manga
+ * on a tracker site (e.g. AniList or MyAnimeList). Used to populate the "Related" modal.
+ */
+data class TrackRelated(
+    val remoteId: Long,
+    val title: String,
+    val coverUrl: String,
+    val trackingUrl: String,
+    /** For relations only, e.g. "Sequel", "Side Story". `null` for recommendations. */
+    val relationType: String? = null,
+)
+
+/** Holds the two kinds of "related" data a tracker can expose for a single manga. */
+data class TrackRelatedResult(
+    val relations: List<TrackRelated> = emptyList(),
+    val recommendations: List<TrackRelated> = emptyList(),
+)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/model/TrackSearch.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/model/TrackSearch.kt
@@ -35,6 +35,12 @@ class TrackSearch : Track {
 
     var artists: List<String> = emptyList()
 
+    /**
+     * Alternative titles for this entry (e.g. romaji/english/native/synonyms). Not persisted; used
+     * to confidently match a manga title against a search result across naming/language variants.
+     */
+    var alternative_titles: List<String> = emptyList()
+
     var cover_url: String = ""
 
     var summary: String = ""

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/MyAnimeList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/MyAnimeList.kt
@@ -7,6 +7,7 @@ import suwayomi.tachidesk.manga.impl.track.tracker.DeletableTracker
 import suwayomi.tachidesk.manga.impl.track.tracker.Tracker
 import suwayomi.tachidesk.manga.impl.track.tracker.extractToken
 import suwayomi.tachidesk.manga.impl.track.tracker.model.Track
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelatedResult
 import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackSearch
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALOAuth
 import uy.kohesive.injekt.injectLazy
@@ -130,6 +131,8 @@ class MyAnimeList(
     }
 
     override suspend fun refresh(track: Track): Track = api.findListItem(track) ?: add(track)
+
+    suspend fun getRelated(remoteId: Long): TrackRelatedResult = api.getMangaRelated(remoteId)
 
     override fun authUrl(): String = MyAnimeListApi.authUrl().toString()
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/MyAnimeListApi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/MyAnimeListApi.kt
@@ -109,7 +109,7 @@ class MyAnimeListApi(
                     .appendPath(id.toString())
                     .appendQueryParameter(
                         "fields",
-                        "id,title,synopsis,num_chapters,mean,main_picture,status,media_type,start_date",
+                        "id,title,synopsis,num_chapters,mean,main_picture,status,media_type,start_date,alternative_titles",
                     ).build()
             with(json) {
                 authClient
@@ -120,6 +120,7 @@ class MyAnimeListApi(
                         TrackSearch.create(TrackerManager.MYANIMELIST).apply {
                             remote_id = it.id
                             title = it.title
+                            alternative_titles = it.alternativeTitles?.allTitles().orEmpty()
                             summary = it.synopsis
                             total_chapters = it.numChapters
                             score = it.mean

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/MyAnimeListApi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/MyAnimeListApi.kt
@@ -19,11 +19,15 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import suwayomi.tachidesk.manga.impl.track.tracker.TrackerManager
 import suwayomi.tachidesk.manga.impl.track.tracker.model.Track
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelated
+import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackRelatedResult
 import suwayomi.tachidesk.manga.impl.track.tracker.model.TrackSearch
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALListItem
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALListItemStatus
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALManga
+import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALMangaRelated
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALOAuth
+import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALRelatedNode
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALSearchResult
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALUser
 import suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto.MALUserSearchResult
@@ -128,6 +132,39 @@ class MyAnimeListApi(
                     }
             }
         }
+
+    suspend fun getMangaRelated(id: Long): TrackRelatedResult =
+        withIOContext {
+            val url =
+                "$BASE_API_URL/manga"
+                    .toUri()
+                    .buildUpon()
+                    .appendPath(id.toString())
+                    // MAL returns each node with its default summary fields (id, title, main_picture).
+                    .appendQueryParameter("fields", "id,related_manga,recommendations")
+                    .build()
+            with(json) {
+                authClient
+                    .newCall(GET(url.toString()))
+                    .awaitSuccess()
+                    .parseAs<MALMangaRelated>()
+                    .let { result ->
+                        TrackRelatedResult(
+                            relations = result.relatedManga.map { it.node.toTrackRelated(it.relationType) },
+                            recommendations = result.recommendations.map { it.node.toTrackRelated(null) },
+                        )
+                    }
+            }
+        }
+
+    private fun MALRelatedNode.toTrackRelated(relationType: String?): TrackRelated =
+        TrackRelated(
+            remoteId = id,
+            title = title,
+            coverUrl = coverUrl,
+            trackingUrl = "https://myanimelist.net/manga/$id",
+            relationType = relationType,
+        )
 
     suspend fun updateItem(track: Track): Track =
         withIOContext {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/dto/MALManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/dto/MALManga.kt
@@ -18,9 +18,20 @@ data class MALManga(
     val mediaType: String,
     @SerialName("start_date")
     val startDate: String?,
+    @SerialName("alternative_titles")
+    val alternativeTitles: MALAlternativeTitles? = null,
 )
 
 @Serializable
 data class MALMangaCovers(
     val large: String = "",
 )
+
+@Serializable
+data class MALAlternativeTitles(
+    val synonyms: List<String> = emptyList(),
+    val en: String = "",
+    val ja: String = "",
+) {
+    fun allTitles(): List<String> = (synonyms + en + ja).filter { it.isNotBlank() }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/dto/MALMangaRelated.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/myanimelist/dto/MALMangaRelated.kt
@@ -1,0 +1,41 @@
+package suwayomi.tachidesk.manga.impl.track.tracker.myanimelist.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MALMangaRelated(
+    val id: Long,
+    @SerialName("related_manga")
+    val relatedManga: List<MALRelatedEdge> = emptyList(),
+    val recommendations: List<MALRecommendationEdge> = emptyList(),
+)
+
+@Serializable
+data class MALRelatedEdge(
+    val node: MALRelatedNode,
+    @SerialName("relation_type_formatted")
+    val relationType: String? = null,
+)
+
+@Serializable
+data class MALRecommendationEdge(
+    val node: MALRelatedNode,
+)
+
+@Serializable
+data class MALRelatedNode(
+    val id: Long,
+    val title: String,
+    @SerialName("main_picture")
+    val picture: MALRelatedPicture? = null,
+) {
+    val coverUrl: String
+        get() = picture?.large?.takeIf { it.isNotBlank() } ?: picture?.medium.orEmpty()
+}
+
+@Serializable
+data class MALRelatedPicture(
+    val medium: String = "",
+    val large: String = "",
+)


### PR DESCRIPTION
## What this does

Adds a GraphQL `mangaRelated` query that returns **relations** and **recommendations** for a manga from **AniList** and **MyAnimeList**, so clients can show a "Related" view per manga.

```graphql
mangaRelated(input: { mangaId: 42 }) {
  anilistRelations { remoteId title coverUrl trackingUrl relationType }
  anilistRecommendations { ... }
  myanimelistRelations { ... }
  myanimelistRecommendations { ... }
}
```

### How the remote media id is resolved

For each tracker, per manga:

1. **Existing track binding** — if the manga is already tracked on that site, the bound remote id is used (authoritative, user-confirmed).
2. **Title-search fallback** — otherwise, if logged in, the manga title is searched on the tracker and the first result that is a **confident title match** is used. A loose/wrong top hit is never used.

A confident match is normalized equality, or Levenshtein similarity ≥ 0.9, compared against the candidate's **primary and alternative titles** (AniList `romaji/english/native` + `synonyms`, MAL `en/ja` + `synonyms`). This lets a localized source title match an entry whose primary title is in another language (e.g. an "Attack on Titan" source matching the romaji "Shingeki no Kyojin").

Per-tracker failures (not logged in, no match, network error) yield an empty list for that tracker instead of failing the whole query.

## Implementation notes

- AniList relations/recommendations are fetched over the **public** (unauthenticated) GraphQL endpoint and filtered to `type: MANGA` (drops anime adaptations).
- MyAnimeList uses the `related_manga` and `recommendations` fields of the manga details endpoint.
- Alternative titles ride on the in-memory `TrackSearch` model only — not persisted to the DB and not exposed in the tracking GraphQL types.

## Testing

- Builds, `ktlintCheck` clean.
- Verified the query end-to-end against a running server (empty path + live data).
- Verified the AniList and MyAnimeList request/response shapes against the live APIs.

## Companion PR

The WebUI side (the "Related" button + modal) is Suwayomi/Suwayomi-WebUI#1122 and depends on this query being available.
