### PR TITLE
Tsundoku novel support

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -26,6 +26,19 @@ interface Source {
         get() = ""
 
     /**
+     * Whether this source provides novel (text-based) content instead of manga (image-based).
+     * Novel sources return chapter content via [fetchPageText]; novel extensions override this getter.
+     */
+    val isNovelSource: Boolean
+        get() = false
+
+    /**
+     * Fetches the text content for a novel page. Only meaningful when [isNovelSource] is true; a
+     * novel chapter is a single [Page] whose text is returned here.
+     */
+    suspend fun fetchPageText(page: Page): String = throw UnsupportedOperationException("Not a novel source")
+
+    /**
      * Whether the source has support for latest updates.
      */
     val supportsLatest: Boolean

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -26,15 +26,13 @@ interface Source {
         get() = ""
 
     /**
-     * Whether this source provides novel (text-based) content instead of manga (image-based).
-     * Novel sources return chapter content via [fetchPageText]; novel extensions override this getter.
+     * Whether this source provides novel content.
      */
     val isNovelSource: Boolean
         get() = false
 
     /**
-     * Fetches the text content for a novel page. Only meaningful when [isNovelSource] is true; a
-     * novel chapter is a single [Page] whose text is returned here.
+     * Fetches the text content for a novel page.
      */
     suspend fun fetchPageText(page: Page): String = throw UnsupportedOperationException("Not a novel source")
 

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
@@ -3,8 +3,7 @@ package eu.kanade.tachiyomi.source.model
 /**
  * Context provided to a source when fetching chapter list for an existing manga.
  * Ported from the Tsundoku source-api so novel extensions that reference this type load.
- *
- * @since 1.6.0
+ * Will remove once 1.6 is released and implemented.
  */
 data class RefreshContext(
     val mangaId: Long,

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/model/RefreshContext.kt
@@ -1,0 +1,14 @@
+package eu.kanade.tachiyomi.source.model
+
+/**
+ * Context provided to a source when fetching chapter list for an existing manga.
+ * Ported from the Tsundoku source-api so novel extensions that reference this type load.
+ *
+ * @since 1.6.0
+ */
+data class RefreshContext(
+    val mangaId: Long,
+    val existingChapters: List<SChapter>,
+    val lastFetchTime: Long,
+    val forceRefresh: Boolean = false,
+)

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -336,6 +336,15 @@ abstract class HttpSource : CatalogueSource {
      * @param chapter the chapter whose page list has to be fetched.
      */
     @Suppress("DEPRECATION")
+    override suspend fun getPageList(chapter: SChapter): List<Page> {
+        // novel chapter is one text page, skip the page-list fetch
+        if (isNovelSource) {
+            return listOf(Page(0, chapter.url))
+        }
+        return fetchPageList(chapter).awaitSingle()
+    }
+
+    @Suppress("DEPRECATION")
     @Deprecated("Use the suspend API instead", ReplaceWith("getPageList"))
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> =
         client
@@ -418,10 +427,14 @@ abstract class HttpSource : CatalogueSource {
     )
     protected open fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
-    suspend fun getImage(page: Page): Response =
-        client
+    suspend fun getImage(page: Page): Response {
+        if (isNovelSource) {
+            throw UnsupportedOperationException("Novel source has no images; use fetchPageText")
+        }
+        return client
             .newCachelessCallWithProgress(imageRequest(page), page)
             .awaitSuccess()
+    }
 
     /**
      * Returns the request for getting the source image. Override only if it's needed to override

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -337,7 +337,6 @@ abstract class HttpSource : CatalogueSource {
      */
     @Suppress("DEPRECATION")
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        // novel chapter is one text page, skip the page-list fetch
         if (isNovelSource) {
             return listOf(Page(0, chapter.url))
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
@@ -247,7 +247,6 @@ class MangaQuery {
         offset: Int? = null,
         isNovel: Boolean? = null,
     ): MangaNodeList {
-        // Novels are kept out of manga results unless explicitly requested with isNovel = true.
         val novelSourceIds = Novel.novelSourceIds()
         val queryResults =
             transaction {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/queries/MangaQuery.kt
@@ -18,6 +18,8 @@ import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.notInList
+import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -45,6 +47,7 @@ import suwayomi.tachidesk.graphql.server.primitives.lessNotUnique
 import suwayomi.tachidesk.graphql.server.primitives.maybeSwap
 import suwayomi.tachidesk.graphql.types.MangaNodeList
 import suwayomi.tachidesk.graphql.types.MangaType
+import suwayomi.tachidesk.manga.impl.Novel
 import suwayomi.tachidesk.manga.model.table.CategoryMangaTable
 import suwayomi.tachidesk.manga.model.table.MangaStatus
 import suwayomi.tachidesk.manga.model.table.MangaTable
@@ -242,7 +245,10 @@ class MangaQuery {
         first: Int? = null,
         last: Int? = null,
         offset: Int? = null,
+        isNovel: Boolean? = null,
     ): MangaNodeList {
+        // Novels are kept out of manga results unless explicitly requested with isNovel = true.
+        val novelSourceIds = Novel.novelSourceIds()
         val queryResults =
             transaction {
                 val mangaIdsQuery =
@@ -252,6 +258,16 @@ class MangaQuery {
                         .withDistinct()
 
                 mangaIdsQuery.applyOps(condition, filter)
+
+                if (novelSourceIds.isNotEmpty()) {
+                    if (isNovel == true) {
+                        mangaIdsQuery.andWhere { MangaTable.sourceReference inList novelSourceIds }
+                    } else {
+                        mangaIdsQuery.andWhere { MangaTable.sourceReference notInList novelSourceIds }
+                    }
+                } else if (isNovel == true) {
+                    mangaIdsQuery.andWhere { MangaTable.sourceReference inList listOf(-1L) }
+                }
 
                 val res =
                     MangaTable.selectAll().where { MangaTable.id inSubQuery mangaIdsQuery }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SourceType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/SourceType.kt
@@ -52,6 +52,7 @@ class SourceType(
     val homeUrl: String?,
     @GraphQLDeprecated("", ReplaceWith("homeUrl"))
     val baseUrl: String?,
+    val isNovel: Boolean,
 ) : Node {
     constructor(row: ResultRow, sourceExtension: ResultRow, source: Source) : this(
         id = row[SourceTable.id].value,
@@ -65,6 +66,7 @@ class SourceType(
         displayName = source.toString(),
         homeUrl = runCatching { (source as? HttpSource)?.getHomeUrl() }.getOrNull(),
         baseUrl = runCatching { (source as? HttpSource)?.baseUrl }.getOrNull(),
+        isNovel = source.isNovelSource,
     )
 
     fun manga(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<MangaNodeList> =

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -81,8 +81,6 @@ object MangaAPI {
             get("{mangaId}/chapter/{chapterIndex}/page/{index}", MangaController.pageRetrieve)
 
             get("{mangaId}/chapter/{chapterIndex}/text", MangaController.chapterTextRetrieve)
-
-            get("{mangaId}/chapter/{chapterIndex}/read", MangaController.chapterReaderRetrieve)
         }
 
         path("chapter") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/MangaAPI.kt
@@ -79,6 +79,10 @@ object MangaAPI {
             patch("{mangaId}/chapter/{chapterIndex}/meta", MangaController.chapterMeta)
 
             get("{mangaId}/chapter/{chapterIndex}/page/{index}", MangaController.pageRetrieve)
+
+            get("{mangaId}/chapter/{chapterIndex}/text", MangaController.chapterTextRetrieve)
+
+            get("{mangaId}/chapter/{chapterIndex}/read", MangaController.chapterReaderRetrieve)
         }
 
         path("chapter") {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -20,6 +20,7 @@ import suwayomi.tachidesk.manga.impl.Chapter
 import suwayomi.tachidesk.manga.impl.ChapterDownloadHelper
 import suwayomi.tachidesk.manga.impl.Library
 import suwayomi.tachidesk.manga.impl.Manga
+import suwayomi.tachidesk.manga.impl.Novel
 import suwayomi.tachidesk.manga.impl.Page
 import suwayomi.tachidesk.manga.impl.chapter.getChapterDownloadReadyByIndex
 import suwayomi.tachidesk.manga.impl.sync.KoreaderSyncService
@@ -500,6 +501,68 @@ object MangaController {
             },
             withResults = {
                 image(HttpStatus.OK)
+                httpCode(HttpStatus.NOT_FOUND)
+            },
+        )
+
+    /** get the text/HTML body of a novel chapter */
+    val chapterTextRetrieve =
+        handler(
+            pathParam<Int>("mangaId"),
+            pathParam<Int>("chapterIndex"),
+            queryParam<Boolean?>("updateProgress"),
+            documentWith = {
+                withOperation {
+                    summary("Get a novel chapter's text")
+                    description("Get the HTML/text body of a novel chapter. Only valid for novel sources.")
+                }
+            },
+            behaviorOf = { ctx, mangaId, chapterIndex, updateProgress ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+
+                ctx.future {
+                    future {
+                        Novel.getChapterText(mangaId = mangaId, chapterIndex = chapterIndex)
+                    }.thenApply { text ->
+                        ctx.header("content-type", "text/html; charset=utf-8")
+                        ctx.result(text)
+
+                        if (updateProgress == true) {
+                            Chapter.updateChapterProgress(mangaId, chapterIndex, pageNo = 0)
+                        }
+                    }
+                }
+            },
+            withResults = {
+                httpCode(HttpStatus.OK)
+                httpCode(HttpStatus.NOT_FOUND)
+            },
+        )
+
+    /** basic self-contained HTML reader page for a novel chapter */
+    val chapterReaderRetrieve =
+        handler(
+            pathParam<Int>("mangaId"),
+            pathParam<Int>("chapterIndex"),
+            documentWith = {
+                withOperation {
+                    summary("Basic novel reader page")
+                    description("Returns a minimal standalone HTML page that displays a novel chapter. Only valid for novel sources.")
+                }
+            },
+            behaviorOf = { ctx, mangaId, chapterIndex ->
+                ctx.getAttribute(Attribute.TachideskUser).requireUser()
+                ctx.future {
+                    future {
+                        Novel.getChapterReaderHtml(mangaId = mangaId, chapterIndex = chapterIndex)
+                    }.thenApply { html ->
+                        ctx.header("content-type", "text/html; charset=utf-8")
+                        ctx.result(html)
+                    }
+                }
+            },
+            withResults = {
+                httpCode(HttpStatus.OK)
                 httpCode(HttpStatus.NOT_FOUND)
             },
         )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -505,7 +505,6 @@ object MangaController {
             },
         )
 
-    /** get the text/HTML body of a novel chapter */
     val chapterTextRetrieve =
         handler(
             pathParam<Int>("mangaId"),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/controller/MangaController.kt
@@ -539,34 +539,6 @@ object MangaController {
             },
         )
 
-    /** basic self-contained HTML reader page for a novel chapter */
-    val chapterReaderRetrieve =
-        handler(
-            pathParam<Int>("mangaId"),
-            pathParam<Int>("chapterIndex"),
-            documentWith = {
-                withOperation {
-                    summary("Basic novel reader page")
-                    description("Returns a minimal standalone HTML page that displays a novel chapter. Only valid for novel sources.")
-                }
-            },
-            behaviorOf = { ctx, mangaId, chapterIndex ->
-                ctx.getAttribute(Attribute.TachideskUser).requireUser()
-                ctx.future {
-                    future {
-                        Novel.getChapterReaderHtml(mangaId = mangaId, chapterIndex = chapterIndex)
-                    }.thenApply { html ->
-                        ctx.header("content-type", "text/html; charset=utf-8")
-                        ctx.result(html)
-                    }
-                }
-            },
-            withResults = {
-                httpCode(HttpStatus.OK)
-                httpCode(HttpStatus.NOT_FOUND)
-            },
-        )
-
     val downloadChapter =
         handler(
             pathParam<Int>("chapterId"),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -11,6 +11,7 @@ import suwayomi.tachidesk.manga.impl.download.fileProvider.impl.FolderProvider
 import suwayomi.tachidesk.manga.impl.download.model.DownloadQueueItem
 import suwayomi.tachidesk.manga.impl.util.getChapterCbzPath
 import suwayomi.tachidesk.manga.impl.util.getChapterDownloadPath
+import suwayomi.tachidesk.manga.impl.util.source.GetSource
 import suwayomi.tachidesk.manga.model.dataclass.ChapterDataClass
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
@@ -47,18 +48,20 @@ object ChapterDownloadHelper {
         scope: CoroutineScope,
         step: suspend (DownloadQueueItem?, Boolean) -> Unit,
     ): Boolean {
-        val sourceId =
-            transaction {
-                MangaTable
-                    .select(MangaTable.sourceReference)
-                    .where { MangaTable.id eq mangaId }
-                    .first()[MangaTable.sourceReference]
+        if (GetSource.hasNovelSource()) {
+            val sourceId =
+                transaction {
+                    MangaTable
+                        .select(MangaTable.sourceReference)
+                        .where { MangaTable.id eq mangaId }
+                        .first()[MangaTable.sourceReference]
+                }
+            if (Novel.isNovelSource(sourceId)) {
+                val result = Novel.downloadChapterText(mangaId, chapterId)
+                download.progress = 1f
+                step(download, false)
+                return result
             }
-        if (Novel.isNovelSource(sourceId)) {
-            val result = Novel.downloadChapterText(mangaId, chapterId)
-            download.progress = 1f
-            step(download, false)
-            return result
         }
         return provider(mangaId, chapterId).download().execute(download, scope, step)
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/ChapterDownloadHelper.kt
@@ -46,7 +46,22 @@ object ChapterDownloadHelper {
         download: DownloadQueueItem,
         scope: CoroutineScope,
         step: suspend (DownloadQueueItem?, Boolean) -> Unit,
-    ): Boolean = provider(mangaId, chapterId).download().execute(download, scope, step)
+    ): Boolean {
+        val sourceId =
+            transaction {
+                MangaTable
+                    .select(MangaTable.sourceReference)
+                    .where { MangaTable.id eq mangaId }
+                    .first()[MangaTable.sourceReference]
+            }
+        if (Novel.isNovelSource(sourceId)) {
+            val result = Novel.downloadChapterText(mangaId, chapterId)
+            download.progress = 1f
+            step(download, false)
+            return result
+        }
+        return provider(mangaId, chapterId).download().execute(download, scope, step)
+    }
 
     // return the appropriate provider based on how the download was saved. For the logic is simple but will evolve when new types of downloads are available
     private fun provider(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Novel.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Novel.kt
@@ -1,0 +1,230 @@
+package suwayomi.tachidesk.manga.impl
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import eu.kanade.tachiyomi.source.model.Page
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import suwayomi.tachidesk.manga.impl.util.getChapterDownloadPath
+import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
+import suwayomi.tachidesk.manga.model.table.ChapterTable
+import suwayomi.tachidesk.manga.model.table.MangaTable
+import suwayomi.tachidesk.manga.model.table.SourceTable
+import java.io.File
+
+/**
+ * Text-based (novel) chapter content. The image pipeline ([Page]) does not apply: a novel chapter
+ * is a single page whose body is HTML/text returned by [eu.kanade.tachiyomi.source.Source.fetchPageText].
+ */
+object Novel {
+    private val logger = KotlinLogging.logger {}
+
+    const val DOWNLOAD_FILE_NAME = "0.html"
+
+    fun isNovelSource(sourceId: Long): Boolean = getCatalogueSourceOrStub(sourceId).isNovelSource
+
+    /** Source ids whose catalogue source serves novels. Used to keep novels out of manga queries. */
+    fun novelSourceIds(): Set<Long> {
+        val ids = transaction { SourceTable.selectAll().map { it[SourceTable.id].value } }
+        return ids.filterTo(mutableSetOf()) { isNovelSource(it) }
+    }
+
+    /**
+     * Minimal self-contained HTML reader page for a novel chapter (no WebUI build required).
+     * Renders the chapter body with prev/next navigation and basic font controls.
+     */
+    suspend fun getChapterReaderHtml(
+        mangaId: Int,
+        chapterIndex: Int,
+    ): String {
+        val body = getChapterText(mangaId, chapterIndex)
+
+        val (mangaTitle, chapterName, minIdx, maxIdx) =
+            transaction {
+                val title = MangaTable.selectAll().where { MangaTable.id eq mangaId }.first()[MangaTable.title]
+                val chapters =
+                    ChapterTable
+                        .selectAll()
+                        .where { ChapterTable.manga eq mangaId }
+                        .toList()
+                val name =
+                    chapters.firstOrNull { it[ChapterTable.sourceOrder] == chapterIndex }?.get(ChapterTable.name)
+                        ?: "Chapter"
+                val orders = chapters.map { it[ChapterTable.sourceOrder] }
+                ReaderMeta(title, name, orders.minOrNull() ?: chapterIndex, orders.maxOrNull() ?: chapterIndex)
+            }
+
+        // Lower sourceOrder = newer; reading forward goes toward lower order numbers.
+        val prevIdx = (chapterIndex + 1).takeIf { it <= maxIdx }
+        val nextIdx = (chapterIndex - 1).takeIf { it >= minIdx }
+
+        fun navLink(
+            idx: Int?,
+            label: String,
+        ): String =
+            if (idx == null) {
+                "<span class=\"nav disabled\">$label</span>"
+            } else {
+                "<a class=\"nav\" href=\"/api/v1/manga/$mangaId/chapter/$idx/read\">$label</a>"
+            }
+
+        val titleEsc = htmlEscape(mangaTitle)
+        val chapterEsc = htmlEscape(chapterName)
+
+        return """
+            <!doctype html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+              <title>$titleEsc · $chapterEsc</title>
+              <style>
+                :root { --fs: 19px; }
+                body { margin: 0; background: #15171a; color: #d7dce0; font-family: Georgia, serif; }
+                header { position: sticky; top: 0; background: #1d2025; padding: 10px 16px;
+                         display: flex; gap: 12px; align-items: center; border-bottom: 1px solid #2c3036; }
+                header .t { font-family: system-ui, sans-serif; font-size: 14px; color: #9aa3ad; }
+                .nav { font-family: system-ui, sans-serif; font-size: 14px; color: #6cb6ff; text-decoration: none;
+                       padding: 6px 10px; border: 1px solid #2c3036; border-radius: 6px; }
+                .nav.disabled { color: #4a5159; border-color: #23272c; }
+                button { font-family: system-ui, sans-serif; background: #2c3036; color: #d7dce0;
+                         border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
+                article { max-width: 760px; margin: 0 auto; padding: 28px 20px 120px;
+                          font-size: var(--fs); line-height: 1.75; }
+                article p { margin: 0 0 1.1em; }
+                footer { position: fixed; bottom: 0; left: 0; right: 0; background: #1d2025;
+                         border-top: 1px solid #2c3036; padding: 10px 16px; display: flex;
+                         gap: 12px; justify-content: center; }
+              </style>
+            </head>
+            <body>
+              <header>
+                <span class="t">$titleEsc · $chapterEsc</span>
+                <span style="flex:1"></span>
+                <button onclick="adj(-1)">A-</button>
+                <button onclick="adj(1)">A+</button>
+              </header>
+              <article id="content">$body</article>
+              <footer>
+                ${navLink(prevIdx, "◀ Prev")}
+                ${navLink(nextIdx, "Next ▶")}
+              </footer>
+              <script>
+                function adj(d){var r=document.documentElement;var fs=parseFloat(getComputedStyle(r).getPropertyValue('--fs'));r.style.setProperty('--fs',(fs+d*2)+'px');}
+              </script>
+            </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun htmlEscape(s: String): String =
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+
+    private val scriptRegex = Regex("<script\\b[^<]*(?:(?!</script>)<[^<]*)*</script>", RegexOption.IGNORE_CASE)
+    private val eventHandlerRegex = Regex("\\son\\w+\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)", RegexOption.IGNORE_CASE)
+    private val jsUrlRegex = Regex("(href|src)\\s*=\\s*([\"']?)\\s*javascript:[^\"'>]*\\2", RegexOption.IGNORE_CASE)
+
+    private fun sanitize(html: String): String {
+        var out = scriptRegex.replace(html, "")
+        out = eventHandlerRegex.replace(out, "")
+        out = jsUrlRegex.replace(out, "")
+        return out
+    }
+
+    private data class ReaderMeta(
+        val mangaTitle: String,
+        val chapterName: String,
+        val minIdx: Int,
+        val maxIdx: Int,
+    )
+
+    /**
+     * Returns the HTML/text body of a novel chapter. Reads the downloaded file when present,
+     * otherwise fetches live from the source.
+     */
+    suspend fun getChapterText(
+        mangaId: Int,
+        chapterIndex: Int,
+    ): String {
+        val (chapterId, chapterUrl, isDownloaded, sourceId) =
+            transaction {
+                val chapterRow =
+                    ChapterTable
+                        .selectAll()
+                        .where { (ChapterTable.manga eq mangaId) and (ChapterTable.sourceOrder eq chapterIndex) }
+                        .first()
+                val sourceRef =
+                    MangaTable
+                        .selectAll()
+                        .where { MangaTable.id eq mangaId }
+                        .first()[MangaTable.sourceReference]
+                ChapterTextInfo(
+                    chapterId = chapterRow[ChapterTable.id].value,
+                    chapterUrl = chapterRow[ChapterTable.url],
+                    isDownloaded = chapterRow[ChapterTable.isDownloaded],
+                    sourceId = sourceRef,
+                )
+            }
+
+        if (isDownloaded) {
+            val file = File(getChapterDownloadPath(mangaId, chapterId), DOWNLOAD_FILE_NAME)
+            if (file.exists()) {
+                return sanitize(file.readText())
+            }
+            logger.warn { "novel chapter $chapterId marked downloaded but $DOWNLOAD_FILE_NAME missing, fetching live" }
+        }
+
+        val source = getCatalogueSourceOrStub(sourceId)
+        return sanitize(source.fetchPageText(Page(0, chapterUrl)))
+    }
+
+    /**
+     * Fetches and writes the novel chapter body to the download folder. Returns true on success.
+     * Marking [ChapterTable.isDownloaded] is handled by the caller (the downloader).
+     */
+    suspend fun downloadChapterText(
+        mangaId: Int,
+        chapterId: Int,
+    ): Boolean {
+        val (chapterUrl, sourceId) =
+            transaction {
+                val chapterRow =
+                    ChapterTable
+                        .selectAll()
+                        .where { ChapterTable.id eq chapterId }
+                        .first()
+                val sourceRef =
+                    MangaTable
+                        .selectAll()
+                        .where { MangaTable.id eq mangaId }
+                        .first()[MangaTable.sourceReference]
+                chapterRow[ChapterTable.url] to sourceRef
+            }
+
+        val source = getCatalogueSourceOrStub(sourceId)
+        val text = sanitize(source.fetchPageText(Page(0, chapterUrl)))
+        if (text.isBlank()) {
+            return false
+        }
+
+        val folder = File(getChapterDownloadPath(mangaId, chapterId))
+        folder.mkdirs()
+        File(folder, DOWNLOAD_FILE_NAME).writeText(text)
+        return true
+    }
+
+    private data class ChapterTextInfo(
+        val chapterId: Int,
+        val chapterUrl: String,
+        val isDownloaded: Boolean,
+        val sourceId: Long,
+    )
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Novel.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Novel.kt
@@ -22,10 +22,6 @@ import suwayomi.tachidesk.manga.model.table.SourceTable
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * Text-based (novel) chapter content. The image pipeline ([Page]) does not apply: a novel chapter
- * is a single page whose body is HTML/text returned by [eu.kanade.tachiyomi.source.Source.fetchPageText].
- */
 object Novel {
     private val logger = KotlinLogging.logger {}
 
@@ -39,16 +35,11 @@ object Novel {
         return source.isNovelSource.also { isNovelCache[sourceId] = it }
     }
 
-    /** Source ids whose catalogue source serves novels. Used to keep novels out of manga queries. */
     fun novelSourceIds(): Set<Long> {
         val ids = transaction { SourceTable.selectAll().map { it[SourceTable.id].value } }
         return ids.filterTo(mutableSetOf()) { isNovelSource(it) }
     }
 
-    /**
-     * Returns the HTML/text body of a novel chapter. Reads the downloaded file when present,
-     * otherwise fetches live from the source.
-     */
     suspend fun getChapterText(
         mangaId: Int,
         chapterIndex: Int,
@@ -88,10 +79,7 @@ object Novel {
         return source.fetchPageText(Page(0, chapterUrl))
     }
 
-    /**
-     * Fetches and writes the novel chapter body to the download folder. Returns true on success.
-     * Marking [ChapterTable.isDownloaded] is handled by the caller (the downloader).
-     */
+    /** Fetches and writes the novel chapter body to the download folder. Returns true on success. */
     suspend fun downloadChapterText(
         mangaId: Int,
         chapterId: Int,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Novel.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Novel.kt
@@ -14,11 +14,13 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import suwayomi.tachidesk.manga.impl.util.getChapterDownloadPath
-import suwayomi.tachidesk.manga.impl.util.source.GetCatalogueSource.getCatalogueSourceOrStub
+import suwayomi.tachidesk.manga.impl.util.source.GetSource.getSourceOrNull
+import suwayomi.tachidesk.manga.impl.util.source.GetSource.getSourceOrStub
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.SourceTable
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Text-based (novel) chapter content. The image pipeline ([Page]) does not apply: a novel chapter
@@ -29,122 +31,19 @@ object Novel {
 
     const val DOWNLOAD_FILE_NAME = "0.html"
 
-    fun isNovelSource(sourceId: Long): Boolean = getCatalogueSourceOrStub(sourceId).isNovelSource
+    private val isNovelCache = ConcurrentHashMap<Long, Boolean>()
+
+    fun isNovelSource(sourceId: Long): Boolean {
+        isNovelCache[sourceId]?.let { return it }
+        val source = getSourceOrNull(sourceId) ?: return false
+        return source.isNovelSource.also { isNovelCache[sourceId] = it }
+    }
 
     /** Source ids whose catalogue source serves novels. Used to keep novels out of manga queries. */
     fun novelSourceIds(): Set<Long> {
         val ids = transaction { SourceTable.selectAll().map { it[SourceTable.id].value } }
         return ids.filterTo(mutableSetOf()) { isNovelSource(it) }
     }
-
-    /**
-     * Minimal self-contained HTML reader page for a novel chapter (no WebUI build required).
-     * Renders the chapter body with prev/next navigation and basic font controls.
-     */
-    suspend fun getChapterReaderHtml(
-        mangaId: Int,
-        chapterIndex: Int,
-    ): String {
-        val body = getChapterText(mangaId, chapterIndex)
-
-        val (mangaTitle, chapterName, minIdx, maxIdx) =
-            transaction {
-                val title = MangaTable.selectAll().where { MangaTable.id eq mangaId }.first()[MangaTable.title]
-                val chapters =
-                    ChapterTable
-                        .selectAll()
-                        .where { ChapterTable.manga eq mangaId }
-                        .toList()
-                val name =
-                    chapters.firstOrNull { it[ChapterTable.sourceOrder] == chapterIndex }?.get(ChapterTable.name)
-                        ?: "Chapter"
-                val orders = chapters.map { it[ChapterTable.sourceOrder] }
-                ReaderMeta(title, name, orders.minOrNull() ?: chapterIndex, orders.maxOrNull() ?: chapterIndex)
-            }
-
-        // Lower sourceOrder = newer; reading forward goes toward lower order numbers.
-        val prevIdx = (chapterIndex + 1).takeIf { it <= maxIdx }
-        val nextIdx = (chapterIndex - 1).takeIf { it >= minIdx }
-
-        fun navLink(
-            idx: Int?,
-            label: String,
-        ): String =
-            if (idx == null) {
-                "<span class=\"nav disabled\">$label</span>"
-            } else {
-                "<a class=\"nav\" href=\"/api/v1/manga/$mangaId/chapter/$idx/read\">$label</a>"
-            }
-
-        val titleEsc = htmlEscape(mangaTitle)
-        val chapterEsc = htmlEscape(chapterName)
-
-        return """
-            <!doctype html>
-            <html lang="en">
-            <head>
-              <meta charset="utf-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1">
-              <title>$titleEsc · $chapterEsc</title>
-              <style>
-                :root { --fs: 19px; }
-                body { margin: 0; background: #15171a; color: #d7dce0; font-family: Georgia, serif; }
-                header { position: sticky; top: 0; background: #1d2025; padding: 10px 16px;
-                         display: flex; gap: 12px; align-items: center; border-bottom: 1px solid #2c3036; }
-                header .t { font-family: system-ui, sans-serif; font-size: 14px; color: #9aa3ad; }
-                .nav { font-family: system-ui, sans-serif; font-size: 14px; color: #6cb6ff; text-decoration: none;
-                       padding: 6px 10px; border: 1px solid #2c3036; border-radius: 6px; }
-                .nav.disabled { color: #4a5159; border-color: #23272c; }
-                button { font-family: system-ui, sans-serif; background: #2c3036; color: #d7dce0;
-                         border: none; border-radius: 6px; padding: 6px 10px; cursor: pointer; }
-                article { max-width: 760px; margin: 0 auto; padding: 28px 20px 120px;
-                          font-size: var(--fs); line-height: 1.75; }
-                article p { margin: 0 0 1.1em; }
-                footer { position: fixed; bottom: 0; left: 0; right: 0; background: #1d2025;
-                         border-top: 1px solid #2c3036; padding: 10px 16px; display: flex;
-                         gap: 12px; justify-content: center; }
-              </style>
-            </head>
-            <body>
-              <header>
-                <span class="t">$titleEsc · $chapterEsc</span>
-                <span style="flex:1"></span>
-                <button onclick="adj(-1)">A-</button>
-                <button onclick="adj(1)">A+</button>
-              </header>
-              <article id="content">$body</article>
-              <footer>
-                ${navLink(prevIdx, "◀ Prev")}
-                ${navLink(nextIdx, "Next ▶")}
-              </footer>
-              <script>
-                function adj(d){var r=document.documentElement;var fs=parseFloat(getComputedStyle(r).getPropertyValue('--fs'));r.style.setProperty('--fs',(fs+d*2)+'px');}
-              </script>
-            </body>
-            </html>
-        """.trimIndent()
-    }
-
-    private fun htmlEscape(s: String): String =
-        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
-
-    private val scriptRegex = Regex("<script\\b[^<]*(?:(?!</script>)<[^<]*)*</script>", RegexOption.IGNORE_CASE)
-    private val eventHandlerRegex = Regex("\\son\\w+\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)", RegexOption.IGNORE_CASE)
-    private val jsUrlRegex = Regex("(href|src)\\s*=\\s*([\"']?)\\s*javascript:[^\"'>]*\\2", RegexOption.IGNORE_CASE)
-
-    private fun sanitize(html: String): String {
-        var out = scriptRegex.replace(html, "")
-        out = eventHandlerRegex.replace(out, "")
-        out = jsUrlRegex.replace(out, "")
-        return out
-    }
-
-    private data class ReaderMeta(
-        val mangaTitle: String,
-        val chapterName: String,
-        val minIdx: Int,
-        val maxIdx: Int,
-    )
 
     /**
      * Returns the HTML/text body of a novel chapter. Reads the downloaded file when present,
@@ -160,12 +59,15 @@ object Novel {
                     ChapterTable
                         .selectAll()
                         .where { (ChapterTable.manga eq mangaId) and (ChapterTable.sourceOrder eq chapterIndex) }
-                        .first()
+                        .firstOrNull()
+                        ?: throw IllegalArgumentException("Chapter $chapterIndex not found for manga $mangaId")
                 val sourceRef =
                     MangaTable
                         .selectAll()
                         .where { MangaTable.id eq mangaId }
-                        .first()[MangaTable.sourceReference]
+                        .firstOrNull()
+                        ?.get(MangaTable.sourceReference)
+                        ?: throw IllegalArgumentException("MangaId $mangaId not found")
                 ChapterTextInfo(
                     chapterId = chapterRow[ChapterTable.id].value,
                     chapterUrl = chapterRow[ChapterTable.url],
@@ -177,13 +79,13 @@ object Novel {
         if (isDownloaded) {
             val file = File(getChapterDownloadPath(mangaId, chapterId), DOWNLOAD_FILE_NAME)
             if (file.exists()) {
-                return sanitize(file.readText())
+                return file.readText()
             }
             logger.warn { "novel chapter $chapterId marked downloaded but $DOWNLOAD_FILE_NAME missing, fetching live" }
         }
 
-        val source = getCatalogueSourceOrStub(sourceId)
-        return sanitize(source.fetchPageText(Page(0, chapterUrl)))
+        val source = getSourceOrStub(sourceId)
+        return source.fetchPageText(Page(0, chapterUrl))
     }
 
     /**
@@ -200,17 +102,20 @@ object Novel {
                     ChapterTable
                         .selectAll()
                         .where { ChapterTable.id eq chapterId }
-                        .first()
+                        .firstOrNull()
+                        ?: throw IllegalArgumentException("ChapterId $chapterId not found")
                 val sourceRef =
                     MangaTable
                         .selectAll()
                         .where { MangaTable.id eq mangaId }
-                        .first()[MangaTable.sourceReference]
+                        .firstOrNull()
+                        ?.get(MangaTable.sourceReference)
+                        ?: throw IllegalArgumentException("MangaId $mangaId not found")
                 chapterRow[ChapterTable.url] to sourceRef
             }
 
-        val source = getCatalogueSourceOrStub(sourceId)
-        val text = sanitize(source.fetchPageText(Page(0, chapterUrl)))
+        val source = getSourceOrStub(sourceId)
+        val text = source.fetchPageText(Page(0, chapterUrl))
         if (text.isBlank()) {
             return false
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/handlers/BackupMangaHandler.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/handlers/BackupMangaHandler.kt
@@ -27,6 +27,7 @@ import suwayomi.tachidesk.manga.impl.Chapter.modifyChaptersMetas
 import suwayomi.tachidesk.manga.impl.Manga
 import suwayomi.tachidesk.manga.impl.Manga.clearThumbnail
 import suwayomi.tachidesk.manga.impl.Manga.modifyMangasMetas
+import suwayomi.tachidesk.manga.impl.Novel
 import suwayomi.tachidesk.manga.impl.backup.BackupFlags
 import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupChapter
 import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupHistory
@@ -82,6 +83,8 @@ object BackupMangaHandler {
                     )
 
                 val mangaId = mangaRow[MangaTable.id].value
+
+                backupManga.isNovel = Novel.isNovelSource(mangaRow[MangaTable.sourceReference])
 
                 if (flags.includeClientData) {
                     backupManga.meta = Manga.getMangaMetaMap(mangaId)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupManga.kt
@@ -40,6 +40,8 @@ data class BackupManga(
     @ProtoNumber(109) var version: Long = 0,
     @ProtoNumber(111) var initialized: Boolean = false,
     @ProtoNumber(112) var memo: ByteArray = JsonObjectEmptyBytes,
+    // tsundoku fork fields (proto numbers 8000+); kept in sync with the Tsundoku Android app for backup interop
+    @ProtoNumber(8000) var isNovel: Boolean = false,
     // suwayomi
     @ProtoNumber(9000) var meta: Map<String, String> = emptyMap(),
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupManga.kt
@@ -40,7 +40,7 @@ data class BackupManga(
     @ProtoNumber(109) var version: Long = 0,
     @ProtoNumber(111) var initialized: Boolean = false,
     @ProtoNumber(112) var memo: ByteArray = JsonObjectEmptyBytes,
-    // tsundoku fork fields (proto numbers 8000+); kept in sync with the Tsundoku Android app for backup interop
+    // tsundoku fork fields (proto numbers 8000+)
     @ProtoNumber(8000) var isNovel: Boolean = false,
     // suwayomi
     @ProtoNumber(9000) var meta: Map<String, String> = emptyMap(),

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -36,6 +36,9 @@ import suwayomi.tachidesk.manga.impl.util.PackageTools.METADATA_EXTENSION_LIB
 import suwayomi.tachidesk.manga.impl.util.PackageTools.METADATA_NAME
 import suwayomi.tachidesk.manga.impl.util.PackageTools.METADATA_NSFW
 import suwayomi.tachidesk.manga.impl.util.PackageTools.METADATA_SOURCE_CLASS
+import suwayomi.tachidesk.manga.impl.util.PackageTools.NOVEL_EXTENSION_FEATURE
+import suwayomi.tachidesk.manga.impl.util.PackageTools.NOVEL_METADATA_NSFW
+import suwayomi.tachidesk.manga.impl.util.PackageTools.NOVEL_METADATA_SOURCE_CLASS
 import suwayomi.tachidesk.manga.impl.util.PackageTools.dex2jar
 import suwayomi.tachidesk.manga.impl.util.PackageTools.getPackageInfo
 import suwayomi.tachidesk.manga.impl.util.PackageTools.loadExtensionSources
@@ -130,7 +133,9 @@ object Extension {
         }
 
         if (!isInstalled || forceReinstall) {
-            if (!packageInfo.reqFeatures.orEmpty().any { it.name == EXTENSION_FEATURE }) {
+            val features = packageInfo.reqFeatures.orEmpty().mapNotNull { it.name }
+            val isNovelExtension = NOVEL_EXTENSION_FEATURE in features
+            if (EXTENSION_FEATURE !in features && !isNovelExtension) {
                 throw Exception("This apk is not a Tachiyomi extension")
             }
 
@@ -152,6 +157,9 @@ object Extension {
 //                throw Exception("This apk is not a signed with the official tachiyomi signature")
 //            }
 
+            val nsfwKey = if (isNovelExtension) NOVEL_METADATA_NSFW else METADATA_NSFW
+            val classKey = if (isNovelExtension) NOVEL_METADATA_SOURCE_CLASS else METADATA_SOURCE_CLASS
+
             var contentWarning = packageInfo.applicationInfo.metaData.getInt(METADATA_CONTENT_WARNING)
             if (contentWarning == 0) {
                 contentWarning = packageInfo.applicationInfo.metaData
@@ -160,14 +168,14 @@ object Extension {
                     ?: 0
                 if (contentWarning == 0) {
                     contentWarning = packageInfo.applicationInfo.metaData
-                        .getString(METADATA_NSFW)
+                        .getString(nsfwKey)
                         ?.toIntOrNull()
                         ?: 0
                 }
             }
 
             val className =
-                packageInfo.packageName + packageInfo.applicationInfo.metaData.getString(METADATA_SOURCE_CLASS)
+                packageInfo.packageName + packageInfo.applicationInfo.metaData.getString(classKey)
 
             logger.debug { "Main class for extension is $className" }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
@@ -45,7 +45,7 @@ object PackageTools {
     const val METADATA_EXTENSION_LIB = "tachiyomix.extensionLib"
     const val METADATA_CONTENT_WARNING = "tachiyomix.contentWarning"
 
-    // Tsundoku novel (text-based) extensions declare a parallel feature/metadata namespace.
+    // Tsundoku novel namespace
     const val NOVEL_EXTENSION_FEATURE = "tachiyomi.novelextension"
     const val NOVEL_METADATA_SOURCE_CLASS = "tachiyomi.novelextension.class"
     const val NOVEL_METADATA_NSFW = "tachiyomi.novelextension.nsfw"

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
@@ -45,6 +45,11 @@ object PackageTools {
     const val METADATA_EXTENSION_LIB = "tachiyomix.extensionLib"
     const val METADATA_CONTENT_WARNING = "tachiyomix.contentWarning"
 
+    // Tsundoku novel (text-based) extensions declare a parallel feature/metadata namespace.
+    const val NOVEL_EXTENSION_FEATURE = "tachiyomi.novelextension"
+    const val NOVEL_METADATA_SOURCE_CLASS = "tachiyomi.novelextension.class"
+    const val NOVEL_METADATA_NSFW = "tachiyomi.novelextension.nsfw"
+
     const val LIB_VERSION_MIN = 1.3
     const val LIB_VERSION_MAX = 1.6
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/source/GetSource.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/source/GetSource.kt
@@ -71,6 +71,8 @@ object GetSource {
 
     fun getSourceOrStub(sourceId: Long): Source = getSourceOrNull(sourceId) ?: StubSource(sourceId)
 
+    fun hasNovelSource(): Boolean = sourceCache.values.any { it.isNovelSource }
+
     fun registerSource(sourcePair: Pair<Long, Source>) {
         sourceCache += sourcePair
     }


### PR DESCRIPTION
Add support for [Tsundoku](https://github.com/tsundoku-otaku/tsundoku ) novel extensions,

- `Source`: Added `isNovelSource` 
- Added `fetchPageText(page: Page): String` for text content.
- Added `feature tachiyomi.novelextension`
- Text endpoint: GET /api/v1/manga/{mangaId}/chapter/{chapterIndex}/text
- Graphql queries: Added `isNovel` param filter.
- used Tsundoku's protonumber 8000 for isnovel to keep compatibility with backups.