### PR TITLE
Fix gql "extension" "extension store" typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - .
 
 ### Fixed
-- .
+- (**Extension/API**) Fix GQL handling of extensions without an extension store
 
 ## [v2.3.2223] + [WebUI: v20260509.01] - 2026-06-30
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/ExtensionType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/ExtensionType.kt
@@ -71,8 +71,8 @@ class ExtensionType(
     fun source(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<SourceNodeList> =
         dataFetchingEnvironment.getValueFromDataLoader<String, SourceNodeList>("SourcesForExtensionDataLoader", pkgName)
 
-    fun extensionStore(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<ExtensionStoreType> =
-        dataFetchingEnvironment.getValueFromDataLoader<String, ExtensionStoreType>("ExtensionStoreDataLoader", storeIndexUrl.orEmpty())
+    fun extensionStore(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<ExtensionStoreType?> =
+        dataFetchingEnvironment.getValueFromDataLoader<String, ExtensionStoreType?>("ExtensionStoreDataLoader", storeIndexUrl.orEmpty())
 }
 
 data class ExtensionNodeList(


### PR DESCRIPTION
The local source, externally installed apks and extensions whose extension store got removed do not have a store. This caused gql to fail because the extensions "extensionStore" was expected to be non-nullable.