### PR TITLE
fix: Do not shadow exceptions on ext install

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -264,7 +264,10 @@ object Extension {
                 PackageTools.jarLoaderMap.remove(jarFilePath)?.close()
                 File(jarFilePath).delete()
 
-                uninstallExtension(pkgName)
+                try {
+                    uninstallExtension(pkgName)
+                } catch (_: Throwable) {
+                }
                 throw e
             }
         } else {


### PR DESCRIPTION
Depending on where the exception occurred, the uninstall may fail, because the extension is not installed in the first place, which hides the actual error
