### PR TITLE
Add DBUS disable (see #2170)

### DIFF
--- a/scripts/resources/pkg/suwayomi-server.sh
+++ b/scripts/resources/pkg/suwayomi-server.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 export LD_PRELOAD="/usr/share/java/suwayomi-server/bin/catch_abort.so"
+export DBUS_SESSION_BUS_ADDRESS="disabled:"
 cd /usr/share/java/suwayomi-server/
 
 if [ -z "$DISPLAY" ] && command -v Xvfb >/dev/null; then


### PR DESCRIPTION
Using `disabled:` instead of `/dev/null`, as that is the [suggested setting](https://issues.chromium.org/issues/40517562)

@manilkadev3-max please test this also on your system, since it works fine on x86 and I do not have an arm machine