### PR TITLE
Return 404 for missing downloads

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -21,7 +21,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import suwayomi.tachidesk.graphql.types.DownloadConversion
 import suwayomi.tachidesk.manga.impl.util.getChapterCachePath
-import suwayomi.tachidesk.manga.impl.util.source.GetSource.getSourceOrStub
+import suwayomi.tachidesk.manga.impl.util.source.GetSource.getSourceOrNull
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse.getImageResponse
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil
 import suwayomi.tachidesk.manga.model.table.ChapterTable
@@ -118,7 +118,7 @@ object Page {
             return imageFile.inputStream() to (ImageUtil.findImageType { imageFile.inputStream() }?.mime ?: "image/jpeg")
         }
 
-        val source = getSourceOrStub(mangaEntry[MangaTable.sourceReference])
+        val source = getSourceOrNull(mangaEntry[MangaTable.sourceReference])!!
         source as HttpSource
 
         if (pageEntry[PageTable.imageUrl] == null) {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
@@ -78,7 +78,7 @@ abstract class ChaptersFilesProvider<Type : FileType>(
         val images = getImageFiles().filter { it.getName() != COMIC_INFO_FILE }.sortedBy { it.getName() }
 
         if (images.isEmpty()) {
-            throw Exception("no downloaded images found")
+            throw NoSuchElementException("no downloaded images found")
         }
 
         val image = images[index]

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/FolderProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/FolderProvider.kt
@@ -34,7 +34,7 @@ class FolderProvider(
         val chapterFolder = File(getChapterDownloadPath(mangaId, chapterId))
 
         if (!chapterFolder.exists()) {
-            throw Exception("download folder does not exist")
+            throw NoSuchElementException("download folder does not exist")
         }
 
         return chapterFolder


### PR DESCRIPTION
I've been moving around my library, and in some cases it isn't clear to me if an error when trying to load something is because I've moved the files and not migrated in the UI, or something else

My proposal is to return 404s here, instead of 521s, which should also include the reason for clarity