### PR TITLE
Fix preserving page count of deleted chapter

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Chapter.kt
@@ -328,7 +328,7 @@ object Chapter {
                                 addBatch(EntityID(it.id, ChapterTable))
 
                                 this[ChapterTable.isDownloaded] = true
-                                this[ChapterTable.pageCount] = it.pageCount
+                                this[ChapterTable.pageCount] = deletedDownloadedChapterByChapterNumber[it.chapterNumber]!!.pageCount
                             }
                     }
                 }


### PR DESCRIPTION
The `pageCount` of the new chapter was set instead of the old one whose download status is getting preserved

Regression 822b60f02d696b70c39070cc9727f33cf53bf75f

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
