### PR TITLE
Fix tracker shikimori base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**SystemTray**) Disable DorkBox update requests
 
 ### Fixed
-- .
+- (**Tracker**) Fix Shikimori
 
 ## [v2.3.2243] - 2026-07-13
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/shikimori/ShikimoriApi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/track/tracker/shikimori/ShikimoriApi.kt
@@ -176,7 +176,7 @@ class ShikimoriApi(
         )
 
     companion object {
-        const val BASE_URL = "https://shikimori.one"
+        const val BASE_URL = "https://shikimori.io"
         private const val API_URL = "$BASE_URL/api"
         private const val OAUTH_URL = "$BASE_URL/oauth/token"
         private const val LOGIN_URL = "$BASE_URL/oauth/authorize"


### PR DESCRIPTION
Mihon PR https://github.com/mihonapp/mihon/pull/3497

There is a redirect from the .one domain to the .io domain but it uses code 301 for redirecting on the token POST request, meaning the followup request tries to use GET which returns a 404.

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
