### PR TITLE
Use Github hosted H2MigrationTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - (**SystemTray**) Disable DorkBox update requests
+- (**Database/H2**) Use Github hosted version of H2MigrationTool for reliable downloads
 
 ### Fixed
 - (**Tracker**) Fix Shikimori

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/H2Migration.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/H2Migration.kt
@@ -31,7 +31,7 @@ object H2Migration {
     private const val TOOL_VERSION = "1.8"
 
     private const val TOOL_URL =
-        "https://manticore-projects.com/download/H2MigrationTool-$TOOL_VERSION/H2MigrationTool-$TOOL_VERSION-all.jar"
+        "https://github.com/Suwayomi/exposed-migrations/releases/download/0.99/H2MigrationTool-$TOOL_VERSION-all.jar"
 
     private const val MAVEN_BASE =
         "https://repo1.maven.org/maven2/com/h2database/h2"


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->

- Should me more reliable than the authors custom website.
- Removed excess drivers from the H2Migration tool, since we download them ourselves. Takes the 40MB file to 1MB