### PR TITLE
Update GraphiQL GraphQL Playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - (**SystemTray**) Disable DorkBox update requests
+- (**GraphQL**) Updated GraphiQL GraphQL Playground
 
 ### Fixed
 - (**Tracker**) Fix Shikimori

--- a/server/src/main/resources/graphql-playground.html
+++ b/server/src/main/resources/graphql-playground.html
@@ -1,117 +1,111 @@
+<!--Taken from https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html -->
+
+<!--
+ *  Copyright (c) 2025 GraphQL Contributors
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *  https://github.com/graphql/graphiql/blob/main/LICENSE
+ *  MIT
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="UTF-8" />
     <title>GraphiQL</title>
     <style>
         body {
-            height: 100%;
             margin: 0;
-            width: 100%;
-            overflow: hidden;
         }
 
         #graphiql {
-            height: 100vh;
-        }
-    </style>
-
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bundler.
-    -->
-    <script
-            crossorigin="anonymous"
-            integrity="sha512-m7nhpWHotpucPI37I4lPovL28Bm2BhAMV8poF3F8Z9oOEZ3jlxGzkgvG0EMt1mVL1xydr1erlBbmN90js/ssUw=="
-            src="https://unpkg.com/react@18.2.0/umd/react.development.js"
-    ></script>
-    <script
-            crossorigin="anonymous"
-            integrity="sha512-SKTL5rMewKkHVooCoONgJHCICK1otCPqPFduipyXVLWgtHHmsQgzXXHUP+SPyL4eU/knSpDkMXKlLedcHmWJpQ=="
-            src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.development.js"
-    ></script>
-
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <link href="https://unpkg.com/graphiql@3.0.5/graphiql.min.css" rel="stylesheet"/>
-    <link href="https://unpkg.com/@graphiql/plugin-explorer@0.3.4/dist/style.css" rel="stylesheet"/>
-    <style>
-        .docExplorerWrap {
-            width: 100% !important;
-            padding-bottom: 20px;
-        }
-        .docExplorerHide {
-            display: none;
+            height: 100dvh;
         }
 
-        /*noinspection CssUnresolvedCustomProperty*/
-        .doc-explorer-title {
-            font-weight: var(--font-weight-medium);
-            font-size: var(--font-size-h2);
-            overflow-x: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-        }
-        .doc-explorer-contents {
+        .loading {
             height: 100%;
-            padding-bottom: 40px;
-        }
-        .graphiql-explorer-root {
-            padding-bottom: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 4rem;
         }
     </style>
-</head>
+    <link
+            rel="stylesheet"
+            href="https://esm.sh/graphiql@5.2.4/dist/style.css"
+            integrity="sha384-TFpQQKp325U5sd3PddH4cS0KOB3Gz/aqdEe12Mqkkq3wm2MGcDhRX5WhWf+o8akh"
+            crossorigin="anonymous"
+    />
+    <link
+            rel="stylesheet"
+            href="https://esm.sh/@graphiql/plugin-explorer@5.1.3/dist/style.css"
+            integrity="sha384-vTFGj0krVqwFXLB7kq/VHR0/j2+cCT/B63rge2mULaqnib2OX7DVLUVksTlqvMab"
+            crossorigin="anonymous"
+    />
+    <!--
+     * Note:
+     * The ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file.
+     * `@emotion/is-prop-valid` is a shim to remove the console error ` module "@emotion /is-prop-valid" not found`. Upstream issue: https://github.com/motiondivision/motion/issues/3126
+    -->
+    <script type="importmap">
+        {
+          "imports": {
+            "react": "https://esm.sh/react@19.2.8",
+            "react/": "https://esm.sh/react@19.2.8/",
+            "react-dom": "https://esm.sh/react-dom@19.2.8",
+            "react-dom/": "https://esm.sh/react-dom@19.2.8/",
+            "graphiql": "https://esm.sh/graphiql@5.2.4?standalone&external=react,react-dom,@graphiql/react,graphql",
+            "graphiql/": "https://esm.sh/graphiql@5.2.4/",
+            "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer@5.1.3?standalone&external=react,@graphiql/react,graphql",
+            "@graphiql/react": "https://esm.sh/@graphiql/react@0.37.7?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid",
+            "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit@0.12.1?standalone&external=graphql",
+            "graphql": "https://esm.sh/graphql@17.0.2",
+            "@emotion/is-prop-valid": "data:text/javascript,"
+          },
+          "integrity": {
+            "https://esm.sh/react@19.2.8": "sha384-ZLbEMZxxxJSWKr0slZZsXGR6UNzfnEk4+qYI9PLH9QSxvWWQjs3UgkzrGuo33roA",
+            "https://esm.sh/react-dom@19.2.8": "sha384-jssD0f2tUCDrNPAwM/2fFwybg7wF0K+9oVfFE0a7r0n7wb2UVP4/uYyWIZKGxG6L",
+            "https://esm.sh/graphiql@5.2.4": "sha384-3feoWeu5QZYyfhHQyP8i+VBW+tYf58tTwgBb8Fsrw2QlP/YRBR2tscNGcYyRDtHC",
+            "https://esm.sh/graphiql@5.2.4?standalone&external=react,react-dom,@graphiql/react,graphql": "sha384-n1sWmquV8wXH/vbn5Q8BaQAw8iAFku5zAs2fPBrht0L/OP4/qgZWL/v/WhMLFPBH",
+            "https://esm.sh/@graphiql/plugin-explorer@5.1.3": "sha384-aDt72jaNBi2he5K4f47qh+xnS6Za54L6vuoNt6KtToLAJfebp23zCaAl3zXGl7dV",
+            "https://esm.sh/@graphiql/react@0.37.7?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid": "sha384-U8awo9eG6M8scx4fjis/pNfYja4d5EtxOFYcmvDGG8K4Rt/bGB6Km1hxbQXZr9qH",
+            "https://esm.sh/@graphiql/toolkit@0.12.1?standalone&external=graphql": "sha384-+cNTwZgIW33q7A4E+ZoCMqzcXdfVIc2VthQvJ0uDpRXERBWYuDKPVMzvdQU8x48o",
+            "https://esm.sh/graphql@17.0.2": "sha384-IPvlcmnvWT91sKqwbg9MxPXJUuPmSdwXCp22x6hcbBkAEhlfSKkMLR3v19K9iRUp"
+          }
+        }
+    </script>
+    <script type="module">
+        import React from 'react';
+        import ReactDOM from 'react-dom/client';
+        import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
+        import { createGraphiQLFetcher } from '@graphiql/toolkit';
+        import { explorerPlugin } from '@graphiql/plugin-explorer';
+        import 'graphiql/setup-workers/esm.sh';
 
-<body>
-    <div id="graphiql">Loading...</div>
-    <script
-            src="https://unpkg.com/graphiql@3.0.5/graphiql.min.js"
-            type="application/javascript"
-    ></script>
-    <script
-            src="https://unpkg.com/@graphiql/plugin-explorer@0.3.4/dist/index.umd.js"
-            type="application/javascript"
-    ></script>
-
-    <script>
-        const root = ReactDOM.createRoot(document.getElementById('graphiql'));
-        const fetcher = GraphiQL.createFetcher({
+        const fetcher = createGraphiQLFetcher({
             url: window.location.href,
             subscriptionUrl: window.location.href.replace(/^http/,'ws')
         });
-        const explorer = GraphiQLPluginExplorer.explorerPlugin();
+        const plugins = [HISTORY_PLUGIN, explorerPlugin()];
 
-        function GraphiQLWithExplorer() {
-            const [query, setQuery] = React.useState(
-                'query AllCategories {\n' +
-                '  categories {\n' +
-                '    nodes {\n' +
-                '      mangas {\n' +
-                '        nodes {\n' +
-                '          title\n' +
-                '        }\n' +
-                '      }\n' +
-                '    }\n' +
-                '  }\n' +
-                '}',
-            );
+        function App() {
             return React.createElement(GraphiQL, {
-                fetcher: fetcher,
+                fetcher,
+                plugins,
                 defaultEditorToolsVisibility: true,
-                plugins: [explorer],
-                query: query,
-                onEditQuery: setQuery,
             });
         }
 
-        root.render(
-            React.createElement(GraphiQLWithExplorer)
-        );
+        const container = document.getElementById('graphiql');
+        const root = ReactDOM.createRoot(container);
+        root.render(React.createElement(App));
     </script>
+</head>
+<body>
+<div id="graphiql">
+    <div class="loading">Loading…</div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->

Now directly takes from [the template](https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html) with only the URL changes. As it now includes the explorer plugin by default and fixes the size issues I had previously.