### PR TITLE
Start graphql schema generation immediately on startup

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/Main.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/Main.kt
@@ -7,10 +7,13 @@ package suwayomi.tachidesk
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import suwayomi.tachidesk.graphql.server.GraphQLSchemaProvider
 import suwayomi.tachidesk.server.JavalinSetup.javalinSetup
 import suwayomi.tachidesk.server.applicationSetup
 
 fun main() {
+    // Trigger graphql schema generation as early as possible, takes multiple seconds, delaying the javalin startup otherwise
+    GraphQLSchemaProvider.init()
     applicationSetup()
     javalinSetup()
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
@@ -12,8 +12,13 @@ import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
 import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
 import com.expediagroup.graphql.generator.toSchema
+import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLType
 import io.javalin.http.UploadedFile
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import suwayomi.tachidesk.graphql.directives.RequireAuthDirectiveWiring
 import suwayomi.tachidesk.graphql.mutations.BackupMutation
 import suwayomi.tachidesk.graphql.mutations.CategoryMutation
@@ -82,57 +87,71 @@ class CustomSchemaGeneratorHooks : FlowSubscriptionSchemaGeneratorHooks() {
         }
 }
 
-val schema =
-    toSchema(
-        config =
-            SchemaGeneratorConfig(
-                supportedPackages = listOf("suwayomi.tachidesk.graphql"),
-                introspectionEnabled = true,
-                hooks = CustomSchemaGeneratorHooks(),
-            ),
-        queries =
-            listOf(
-                TopLevelObject(BackupQuery()),
-                TopLevelObject(CategoryQuery()),
-                TopLevelObject(ChapterQuery()),
-                TopLevelObject(DownloadQuery()),
-                TopLevelObject(ExtensionQuery()),
-                TopLevelObject(ExtensionStoreQuery()),
-                TopLevelObject(InfoQuery()),
-                TopLevelObject(KoreaderSyncQuery()),
-                TopLevelObject(MangaQuery()),
-                TopLevelObject(MetaQuery()),
-                TopLevelObject(SettingsQuery()),
-                TopLevelObject(SourceQuery()),
-                TopLevelObject(SyncQuery()),
-                TopLevelObject(TrackQuery()),
-                TopLevelObject(UpdateQuery()),
-            ),
-        mutations =
-            listOf(
-                TopLevelObject(BackupMutation()),
-                TopLevelObject(CategoryMutation()),
-                TopLevelObject(ChapterMutation()),
-                TopLevelObject(DownloadMutation()),
-                TopLevelObject(ExtensionMutation()),
-                TopLevelObject(ExtensionStoreMutation()),
-                TopLevelObject(ImageMutation()),
-                TopLevelObject(InfoMutation()),
-                TopLevelObject(KoreaderSyncMutation()),
-                TopLevelObject(MangaMutation()),
-                TopLevelObject(MetaMutation()),
-                TopLevelObject(SettingsMutation()),
-                TopLevelObject(SyncMutation()),
-                TopLevelObject(SourceMutation()),
-                TopLevelObject(TrackMutation()),
-                TopLevelObject(UpdateMutation()),
-                TopLevelObject(UserMutation()),
-            ),
-        subscriptions =
-            listOf(
-                TopLevelObject(DownloadSubscription()),
-                TopLevelObject(InfoSubscription()),
-                TopLevelObject(SyncSubscription()),
-                TopLevelObject(UpdateSubscription()),
-            ),
-    )
+object GraphQLSchemaProvider {
+    @OptIn(DelicateCoroutinesApi::class)
+    var schemaFuture =
+        GlobalScope.async {
+            toSchema(
+                config =
+                    SchemaGeneratorConfig(
+                        supportedPackages = listOf("suwayomi.tachidesk.graphql"),
+                        introspectionEnabled = true,
+                        hooks = CustomSchemaGeneratorHooks(),
+                    ),
+                queries =
+                    listOf(
+                        TopLevelObject(BackupQuery()),
+                        TopLevelObject(CategoryQuery()),
+                        TopLevelObject(ChapterQuery()),
+                        TopLevelObject(DownloadQuery()),
+                        TopLevelObject(ExtensionQuery()),
+                        TopLevelObject(ExtensionStoreQuery()),
+                        TopLevelObject(InfoQuery()),
+                        TopLevelObject(KoreaderSyncQuery()),
+                        TopLevelObject(MangaQuery()),
+                        TopLevelObject(MetaQuery()),
+                        TopLevelObject(SettingsQuery()),
+                        TopLevelObject(SourceQuery()),
+                        TopLevelObject(SyncQuery()),
+                        TopLevelObject(TrackQuery()),
+                        TopLevelObject(UpdateQuery()),
+                    ),
+                mutations =
+                    listOf(
+                        TopLevelObject(BackupMutation()),
+                        TopLevelObject(CategoryMutation()),
+                        TopLevelObject(ChapterMutation()),
+                        TopLevelObject(DownloadMutation()),
+                        TopLevelObject(ExtensionMutation()),
+                        TopLevelObject(ExtensionStoreMutation()),
+                        TopLevelObject(ImageMutation()),
+                        TopLevelObject(InfoMutation()),
+                        TopLevelObject(KoreaderSyncMutation()),
+                        TopLevelObject(MangaMutation()),
+                        TopLevelObject(MetaMutation()),
+                        TopLevelObject(SettingsMutation()),
+                        TopLevelObject(SyncMutation()),
+                        TopLevelObject(SourceMutation()),
+                        TopLevelObject(TrackMutation()),
+                        TopLevelObject(UpdateMutation()),
+                        TopLevelObject(UserMutation()),
+                    ),
+                subscriptions =
+                    listOf(
+                        TopLevelObject(DownloadSubscription()),
+                        TopLevelObject(InfoSubscription()),
+                        TopLevelObject(SyncSubscription()),
+                        TopLevelObject(UpdateSubscription()),
+                    ),
+            )
+        }
+
+    suspend fun getSchema(): GraphQLSchema = schemaFuture.await()
+
+    fun init() {
+        @OptIn(DelicateCoroutinesApi::class)
+        GlobalScope.launch {
+            getSchema()
+        }
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLServer.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLServer.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import suwayomi.tachidesk.graphql.server.subscriptions.ApolloSubscriptionProtocolHandler
 import suwayomi.tachidesk.server.JavalinSetup.future
 import tools.jackson.module.kotlin.jacksonObjectMapper
@@ -73,7 +74,7 @@ class TachideskGraphQLServer(
 
         private fun getGraphQLObject(): GraphQL =
             GraphQL
-                .newGraphQL(schema)
+                .newGraphQL(runBlocking { GraphQLSchemaProvider.getSchema() })
                 .queryExecutionStrategy(AsyncExecutionStrategy(exceptionHandler))
                 .mutationExecutionStrategy(AsyncExecutionStrategy(exceptionHandler))
                 .subscriptionExecutionStrategy(FlowSubscriptionExecutionStrategy(exceptionHandler))


### PR DESCRIPTION
Takes multiple seconds to generate and would otherwise delay the javalin startup, because it gets generated when setting up the api endpoints

improves #2221 (haven't found anything else besides this)

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
