### PR TITLE
Fix: Add early return for unchanged directory in updateDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Tracker**) Fix Shikimori
 - (**Extension**) Fix losing installed extension in case the update fails
 - (**Source/API**) Fix graphql browse mutation (`fetchSourceManga`) with filters including nested group changes
+- (**Manga/API**) Add early return for unchanged directory in updateDir
 
 ## [v2.3.2243] - 2026-07-13
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/DirName.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/DirName.kt
@@ -122,6 +122,7 @@ private fun updateDir(
     currentDir: String,
     newDir: String,
 ): Boolean {
+    if(currentDir == newDir) return true
     val currentDirFile = File(currentDir)
     val newDirFile = File(newDir)
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/DirName.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/DirName.kt
@@ -122,7 +122,7 @@ private fun updateDir(
     currentDir: String,
     newDir: String,
 ): Boolean {
-    if(currentDir == newDir) return true
+    if (currentDir == newDir) return true
     val currentDirFile = File(currentDir)
     val newDirFile = File(newDir)
 


### PR DESCRIPTION

<img width="1501" height="619" alt="image" src="https://github.com/user-attachments/assets/fb6e62e7-3ad3-4a3d-ba08-6628bdbac321" />


When updating manga with downloaded chapters, the "downloaded" status disappears, and all chapters are marked as not downloaded (set to `false`).

This occurs when the remote title and the original title are the same.

This has been fixed by treating the operation as successful when the source and destination directories are identical.