### PR TITLE
Merge manga chapter stats data loader

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/dataLoaders/ChapterDataLoader.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/dataLoaders/ChapterDataLoader.kt
@@ -11,6 +11,7 @@ import com.expediagroup.graphql.dataloader.KotlinDataLoader
 import graphql.GraphQLContext
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderFactory
+import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Slf4jSqlDebugLogger
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
@@ -19,6 +20,8 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.intLiteral
+import org.jetbrains.exposed.v1.core.sum
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -68,67 +71,67 @@ class ChaptersForMangaDataLoader : KotlinDataLoader<Int, ChapterNodeList> {
         }
 }
 
-class DownloadedChapterCountForMangaDataLoader : KotlinDataLoader<Int, Int> {
-    override val dataLoaderName = "DownloadedChapterCountForMangaDataLoader"
+data class MangaChapterStats(
+    val unreadCount: Int,
+    val downloadCount: Int,
+    val bookmarkCount: Int,
+)
 
-    override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<Int, Int> =
+class ChapterFlagCountForMangaDataLoader : KotlinDataLoader<Int, MangaChapterStats> {
+    override val dataLoaderName = "ChapterFlagCountForMangaDataLoader"
+
+    override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<Int, MangaChapterStats> =
         DataLoaderFactory.newDataLoader { ids ->
             future {
                 transaction {
                     addLogger(Slf4jSqlDebugLogger)
-                    val downloadedChapterCountByMangaId =
+
+                    val unreadCount =
+                        Case()
+                            .When(ChapterTable.isRead eq false, intLiteral(1))
+                            .Else(intLiteral(0))
+                            .sum()
+
+                    val downloadCount =
+                        Case()
+                            .When(ChapterTable.isDownloaded eq true, intLiteral(1))
+                            .Else(intLiteral(0))
+                            .sum()
+
+                    val bookmarkCount =
+                        Case()
+                            .When(ChapterTable.isBookmarked eq true, intLiteral(1))
+                            .Else(intLiteral(0))
+                            .sum()
+
+                    val statsByMangaId =
                         ChapterTable
-                            .select(ChapterTable.manga, ChapterTable.isDownloaded.count())
-                            .where {
-                                (ChapterTable.manga inList ids) and
-                                    (ChapterTable.isDownloaded eq true)
+                            .select(
+                                ChapterTable.manga,
+                                unreadCount,
+                                downloadCount,
+                                bookmarkCount,
+                            ).where {
+                                ChapterTable.manga inList ids
                             }.groupBy(ChapterTable.manga)
-                            .associate { it[ChapterTable.manga].value to it[ChapterTable.isDownloaded.count()] }
-                    ids.map { downloadedChapterCountByMangaId[it]?.toInt() ?: 0 }
-                }
-            }
-        }
-}
+                            .associate {
+                                val mangaId = it[ChapterTable.manga].value
 
-class UnreadChapterCountForMangaDataLoader : KotlinDataLoader<Int, Int> {
-    override val dataLoaderName = "UnreadChapterCountForMangaDataLoader"
+                                mangaId to
+                                    MangaChapterStats(
+                                        unreadCount = it[unreadCount] ?: 0,
+                                        downloadCount = it[downloadCount] ?: 0,
+                                        bookmarkCount = it[bookmarkCount] ?: 0,
+                                    )
+                            }
 
-    override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<Int, Int> =
-        DataLoaderFactory.newDataLoader { ids ->
-            future {
-                transaction {
-                    addLogger(Slf4jSqlDebugLogger)
-                    val unreadChapterCountByMangaId =
-                        ChapterTable
-                            .select(ChapterTable.manga, ChapterTable.isRead.count())
-                            .where {
-                                (ChapterTable.manga inList ids) and
-                                    (ChapterTable.isRead eq false)
-                            }.groupBy(ChapterTable.manga)
-                            .associate { it[ChapterTable.manga].value to it[ChapterTable.isRead.count()] }
-                    ids.map { unreadChapterCountByMangaId[it]?.toInt() ?: 0 }
-                }
-            }
-        }
-}
-
-class BookmarkedChapterCountForMangaDataLoader : KotlinDataLoader<Int, Int> {
-    override val dataLoaderName = "BookmarkedChapterCountForMangaDataLoader"
-
-    override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<Int, Int> =
-        DataLoaderFactory.newDataLoader { ids ->
-            future {
-                transaction {
-                    addLogger(Slf4jSqlDebugLogger)
-                    val bookmarkedChapterCountByMangaId =
-                        ChapterTable
-                            .select(ChapterTable.manga, ChapterTable.isBookmarked.count())
-                            .where {
-                                (ChapterTable.manga inList ids) and
-                                    (ChapterTable.isBookmarked eq true)
-                            }.groupBy(ChapterTable.manga)
-                            .associate { it[ChapterTable.manga].value to it[ChapterTable.isBookmarked.count()] }
-                    ids.map { bookmarkedChapterCountByMangaId[it]?.toInt() ?: 0 }
+                    ids.map {
+                        statsByMangaId[it] ?: MangaChapterStats(
+                            unreadCount = 0,
+                            downloadCount = 0,
+                            bookmarkCount = 0,
+                        )
+                    }
                 }
             }
         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskDataLoaderRegistryFactory.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskDataLoaderRegistryFactory.kt
@@ -8,17 +8,16 @@
 package suwayomi.tachidesk.graphql.server
 
 import com.expediagroup.graphql.dataloader.KotlinDataLoaderRegistryFactory
-import suwayomi.tachidesk.graphql.dataLoaders.BookmarkedChapterCountForMangaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.CategoriesForMangaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.CategoryDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.CategoryForIdsDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.CategoryMetaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.ChapterDataLoader
+import suwayomi.tachidesk.graphql.dataLoaders.ChapterFlagCountForMangaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.ChapterMetaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.ChaptersForMangaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.DisplayScoreForTrackRecordDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.DisplayScoreForTrackSearchDataLoader
-import suwayomi.tachidesk.graphql.dataLoaders.DownloadedChapterCountForMangaDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.ExtensionDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.ExtensionForSourceDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.ExtensionStoreDataLoader
@@ -46,7 +45,6 @@ import suwayomi.tachidesk.graphql.dataLoaders.TrackerDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.TrackerScoresDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.TrackerStatusesDataLoader
 import suwayomi.tachidesk.graphql.dataLoaders.TrackerTokenExpiredDataLoader
-import suwayomi.tachidesk.graphql.dataLoaders.UnreadChapterCountForMangaDataLoader
 
 class TachideskDataLoaderRegistryFactory {
     companion object {
@@ -55,9 +53,7 @@ class TachideskDataLoaderRegistryFactory {
                 MangaDataLoader(),
                 ChapterDataLoader(),
                 ChaptersForMangaDataLoader(),
-                DownloadedChapterCountForMangaDataLoader(),
-                UnreadChapterCountForMangaDataLoader(),
-                BookmarkedChapterCountForMangaDataLoader(),
+                ChapterFlagCountForMangaDataLoader(),
                 HasDuplicateChaptersForMangaDataLoader(),
                 LastReadChapterForMangaDataLoader(),
                 LatestReadChapterForMangaDataLoader(),

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/MangaType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/MangaType.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import graphql.schema.DataFetchingEnvironment
 import org.jetbrains.exposed.v1.core.ResultRow
 import suwayomi.tachidesk.graphql.cache.CustomCacheMap
+import suwayomi.tachidesk.graphql.dataLoaders.MangaChapterStats
 import suwayomi.tachidesk.graphql.server.primitives.Cursor
 import suwayomi.tachidesk.graphql.server.primitives.Edge
 import suwayomi.tachidesk.graphql.server.primitives.Node
@@ -67,9 +68,7 @@ class MangaType(
                 ?.filter { it.contains(mangaId) }
                 ?.forEach { mangaForIdsDataLoader.clear(it) }
 
-            dataFetchingEnvironment.getDataLoader<Int, Int>("DownloadedChapterCountForMangaDataLoader")?.clear(mangaId)
-            dataFetchingEnvironment.getDataLoader<Int, Int>("UnreadChapterCountForMangaDataLoader")?.clear(mangaId)
-            dataFetchingEnvironment.getDataLoader<Int, Int>("BookmarkedChapterCountForMangaDataLoader")?.clear(mangaId)
+            dataFetchingEnvironment.getDataLoader<Int, Int>("ChapterFlagCountForMangaDataLoader")?.clear(mangaId)
             dataFetchingEnvironment.getDataLoader<Int, Int>("HasDuplicateChaptersForMangaDataLoader")?.clear(mangaId)
             dataFetchingEnvironment.getDataLoader<Int, ChapterType>("LastReadChapterForMangaDataLoader")?.clear(mangaId)
             dataFetchingEnvironment.getDataLoader<Int, ChapterType>("LatestReadChapterForMangaDataLoader")?.clear(mangaId)
@@ -128,13 +127,19 @@ class MangaType(
     )
 
     fun downloadCount(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Int> =
-        dataFetchingEnvironment.getValueFromDataLoader("DownloadedChapterCountForMangaDataLoader", id)
+        dataFetchingEnvironment.getValueFromDataLoader<Int, MangaChapterStats>("ChapterFlagCountForMangaDataLoader", id).thenApply {
+            it.downloadCount
+        }
 
     fun unreadCount(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Int> =
-        dataFetchingEnvironment.getValueFromDataLoader("UnreadChapterCountForMangaDataLoader", id)
+        dataFetchingEnvironment.getValueFromDataLoader<Int, MangaChapterStats>("ChapterFlagCountForMangaDataLoader", id).thenApply {
+            it.unreadCount
+        }
 
     fun bookmarkCount(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Int> =
-        dataFetchingEnvironment.getValueFromDataLoader("BookmarkedChapterCountForMangaDataLoader", id)
+        dataFetchingEnvironment.getValueFromDataLoader<Int, MangaChapterStats>("ChapterFlagCountForMangaDataLoader", id).thenApply {
+            it.bookmarkCount
+        }
 
     fun hasDuplicateChapters(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Boolean> =
         dataFetchingEnvironment.getValueFromDataLoader("HasDuplicateChaptersForMangaDataLoader", id)


### PR DESCRIPTION
The bigger the batch of the data loaders, the bigger the performance impact of running a data loader for each chapter stat.

E.g. the webui query to load the mangas of a category with 79 entries takes 169ms compared to 702ms

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
