### PR TITLE
Fix library/category count mismatch from duplicate category-manga rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Source/API**) Fix graphql browse mutation (`fetchSourceManga`) with filters including nested group changes
 - (**HTML**) Fix HTML being sent with gibberish when using non-latin characters
 - (**OPDS**) Fix OPDS search charset
+- (**Category**) Fix library/category counts not matching the actual number of manga due to duplicate category-manga rows
 
 ## [v2.3.2243] - 2026-07-13
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/CategoryManga.kt
@@ -18,7 +18,7 @@ import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.leftJoin
 import org.jetbrains.exposed.v1.core.max
 import org.jetbrains.exposed.v1.core.wrapAsExpression
-import org.jetbrains.exposed.v1.jdbc.batchInsert
+import org.jetbrains.exposed.v1.jdbc.batchUpsert
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -68,7 +68,11 @@ object CategoryManga {
             }
 
         dbTransaction {
-            CategoryMangaTable.batchInsert(newMangaCategoryMappings) { (mangaId, categoryId) ->
+            CategoryMangaTable.batchUpsert(
+                newMangaCategoryMappings,
+                CategoryMangaTable.manga,
+                CategoryMangaTable.category,
+            ) { (mangaId, categoryId) ->
                 this[CategoryMangaTable.manga] = mangaId
                 this[CategoryMangaTable.category] = categoryId
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Library.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Library.kt
@@ -15,11 +15,11 @@ import kotlinx.coroutines.launch
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.neq
-import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import org.jetbrains.exposed.v1.jdbc.upsert
 import suwayomi.tachidesk.manga.impl.Manga.getManga
 import suwayomi.tachidesk.manga.model.table.CategoryMangaTable
 import suwayomi.tachidesk.manga.model.table.CategoryTable
@@ -49,7 +49,7 @@ object Library {
 
                 if (existingCategories.isEmpty()) {
                     defaultCategories.forEach { category ->
-                        CategoryMangaTable.insert {
+                        CategoryMangaTable.upsert(CategoryMangaTable.manga, CategoryMangaTable.category) {
                             it[CategoryMangaTable.category] = category[CategoryTable.id].value
                             it[CategoryMangaTable.manga] = mangaId
                         }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0061_PreventDuplicatedCategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0061_PreventDuplicatedCategoryManga.kt
@@ -1,0 +1,32 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+import suwayomi.tachidesk.server.database.migration.helpers.toSqlName
+
+@Suppress("ClassName", "unused")
+class M0061_PreventDuplicatedCategoryManga : SQLMigration() {
+    override val sql: String by lazy {
+        val table = "CATEGORYMANGA".toSqlName()
+        val manga = "MANGA".toSqlName()
+        val category = "CATEGORY".toSqlName()
+
+        """
+        DELETE FROM $table
+        WHERE ID NOT IN (
+            SELECT MIN(ID)
+            FROM $table
+            GROUP BY $manga, $category
+        );
+
+        ALTER TABLE $table
+            ADD CONSTRAINT UC_${"CATEGORYMANGA"} UNIQUE ($manga, $category);
+        """.trimIndent()
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0062_PreventDuplicatedCategoryManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0062_PreventDuplicatedCategoryManga.kt
@@ -11,7 +11,7 @@ import de.neonew.exposed.migrations.helpers.SQLMigration
 import suwayomi.tachidesk.server.database.migration.helpers.toSqlName
 
 @Suppress("ClassName", "unused")
-class M0061_PreventDuplicatedCategoryManga : SQLMigration() {
+class M0062_PreventDuplicatedCategoryManga : SQLMigration() {
     override val sql: String by lazy {
         val table = "CATEGORYMANGA".toSqlName()
         val manga = "MANGA".toSqlName()

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/CategoryMangaTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/CategoryMangaTest.kt
@@ -7,8 +7,15 @@ package suwayomi.tachidesk.manga.impl
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import suwayomi.tachidesk.manga.impl.Category.DEFAULT_CATEGORY_ID
@@ -63,6 +70,62 @@ class CategoryMangaTest : ApplicationTest() {
             0,
             CategoryManga.getCategoryMangaList(DEFAULT_CATEGORY_ID).size,
             "Manga shouldn't be member of default category after moving",
+        )
+    }
+
+    @Test
+    fun `duplicate manga-category pairing is rejected by the unique constraint`() {
+        val mangaId = createLibraryManga("Naruto")
+        val categoryId = Category.createCategory("Shonen")
+        CategoryManga.addMangaToCategory(mangaId, categoryId)
+
+        // Bypass the application layer's own duplicate checks and attempt to insert the same
+        // (manga, category) pairing directly. This must be rejected by the DB-level unique
+        // constraint added in M0061_PreventDuplicatedCategoryManga. If that constraint is ever
+        // dropped or weakened, this insert would succeed and silently inflate category/library
+        // counts.
+        assertThrows(ExposedSQLException::class.java) {
+            transaction {
+                CategoryMangaTable.insert {
+                    it[CategoryMangaTable.manga] = mangaId
+                    it[CategoryMangaTable.category] = categoryId
+                }
+            }
+        }
+
+        val rowCount =
+            transaction {
+                CategoryMangaTable
+                    .selectAll()
+                    .where { (CategoryMangaTable.manga eq mangaId) and (CategoryMangaTable.category eq categoryId) }
+                    .count()
+            }
+        assertEquals(1, rowCount, "Only one CategoryMangaTable row should exist for a given manga/category pairing")
+    }
+
+    @Test
+    fun `adding manga to the same category twice does not create duplicate rows`() {
+        val mangaId = createLibraryManga("One Piece")
+        val categoryId = Category.createCategory("Adventure")
+
+        // addMangasToCategories catches and swallows the unique constraint violation from a
+        // duplicate (manga, category) pairing, so repeated calls should be no-ops rather than
+        // throwing or creating duplicate CategoryMangaTable rows.
+        CategoryManga.addMangasToCategories(listOf(mangaId), listOf(categoryId))
+        CategoryManga.addMangasToCategories(listOf(mangaId), listOf(categoryId))
+
+        val rowCount =
+            transaction {
+                CategoryMangaTable
+                    .selectAll()
+                    .where { (CategoryMangaTable.manga eq mangaId) and (CategoryMangaTable.category eq categoryId) }
+                    .count()
+            }
+        assertEquals(1, rowCount, "Only one CategoryMangaTable row should exist for a given manga/category pairing")
+        assertEquals(
+            1,
+            CategoryManga.getCategoryMangaList(categoryId).size,
+            "Category size should reflect a single manga even if it was added twice",
         )
     }
 


### PR DESCRIPTION
## Why

Library/category counts didn't match the number of manga actually selectable in that category, worsening as manga were moved between categories. `CategoryMangaTable` (the manga<->category join table) had no unique constraint on `(manga, category)`, so racing check-then-insert code paths could create duplicate rows. `Category.getCategorySize()` does a plain row count (inflated by duplicates), while `CategoryManga.getCategoryMangaList()` groups by manga columns (duplicates collapse) - hence the mismatch between the displayed count and what you could actually select.

## What changed

- Added migration `M0061_PreventDuplicatedCategoryManga`: dedupes any existing duplicate `(manga, category)` rows, then adds a `UNIQUE (manga, category)` constraint. This is the core fix - counts are now correct by construction.
- Hardened the insert paths (`Library.addMangaToLibrary`, `CategoryManga.addMangasToCategories`) against the underlying race using Exposed's native `upsert`/`batchUpsert` (compiles to `MERGE`/`ON CONFLICT`), keyed on the `(manga, category)` constraint. This gives real "insert if not exists" semantics on both H2 and PostgreSQL without relying on `insertIgnore` (unsupported by H2 outside MySQL compatibility mode, which this project doesn't use) or manual exception-driven retry logic.
- Added regression tests proving the unique constraint is enforced and that adding a manga to the same category twice is idempotent (no duplicate rows).

Note: a manga can still belong to many different categories - the constraint only prevents the *same* manga+category pair from being duplicated.