### PR TITLE
Match WebView and network user agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Source/API**) Fix graphql browse mutation (`fetchSourceManga`) with filters including nested group changes
 - (**HTML**) Fix HTML being sent with gibberish when using non-latin characters
 - (**OPDS**) Fix OPDS search charset
+- (**WebView**) Reuse WebView cookies with the matching network user agent
 
 ## [v2.3.2243] - 2026-07-13
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -2,6 +2,7 @@ package suwayomi.tachidesk.server.util
 
 import android.text.format.Formatter
 import com.jetbrains.cef.JCefAppConfig
+import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.ProgressListener
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.newCachelessCallWithProgress
@@ -129,6 +130,8 @@ object CEFManager {
                             cefSettings.apply {
                                 windowless_rendering_enabled = true
                                 cache_path = (Path(applicationDirs.dataRoot) / "cache/kcef").absolutePathString()
+                                // Cloudflare clearance cookies are tied to the User-Agent that obtained them.
+                                user_agent = Injekt.get<NetworkHelper>().defaultUserAgentProvider()
                                 log_severity =
                                     if (serverConfig.debugLogsEnabled.value) {
                                         LogSeverity.LOGSEVERITY_VERBOSE


### PR DESCRIPTION
## Summary

- Configure the JCEF WebView to use the same default User-Agent as network requests.
- Keep transferred Cloudflare clearance cookies associated with the User-Agent that obtained them.
- Add a changelog entry for the WebView behavior change.

## Why

Suwayomi already transfers WebView cookies into the persistent network cookie store. However, Cloudflare clearance cookies are tied to the User-Agent that obtained them. If JCEF and the network client use different User-Agents, a transferred clearance cookie can be rejected.

Related to #2241.

## Testing

- `git diff --check`
- `./gradlew.bat ktlintCheck`
- `./gradlew.bat :server:test :server:shadowJar`
- Manual isolated MangaFire test: JCEF initialized, MangaFire loaded in WebView, and the source reloaded successfully after closing WebView; the corresponding API requests returned HTTP 200.

Cloudflare did not present a challenge on the non-VPN connection during the final manual test, so the complete challenge-to-cookie recovery path could not be reproduced.
