### PR TITLE
Recover interrupted CBZ downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - (**Cloudflare/flaresolverr**) Treat a bypass as successful when a `cf_clearance` cookie is returned, so non-CloudFlare source errors are correctly passed through to the extensions.
 - (**Manga/Extension**) Fix resolving manga URLs for extensions that use memo data
+- (**Downloads**) Fix retries failing after interrupted CBZ writes
 - (**Tracker**) Fix Shikimori
 - (**Extension**) Fix losing installed extension in case the update fails
 - (**Source/API**) Fix graphql browse mutation (`fetchSourceManga`) with filters including nested group changes

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProvider.kt
@@ -20,7 +20,12 @@ import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.server.ApplicationDirs
 import uy.kohesive.injekt.injectLazy
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.zip.Deflater
 
 private val applicationDirs: ApplicationDirs by injectLazy()
@@ -49,7 +54,9 @@ class ArchiveProvider(
             return
         }
 
-        extractCbzFile(outputFile, chapterDownloadFolder)
+        extractExistingCbzFile(outputFile, chapterDownloadFolder) { exception ->
+            logger.warn(exception) { "Deleting unreadable CBZ before retrying chapter download: ${outputFile.path}" }
+        }
     }
 
     override suspend fun handleSuccessfulDownload() {
@@ -59,30 +66,11 @@ class ArchiveProvider(
 
         withContext(Dispatchers.IO) {
             mangaDownloadFolder.mkdirs()
-            outputFile.createNewFile()
-        }
+            createCbzFile(outputFile, chapterCacheFolder)
 
-        ZipArchiveOutputStream(outputFile.outputStream()).use { zipOut ->
-            zipOut.setMethod(ZipArchiveOutputStream.DEFLATED)
-            zipOut.setLevel(Deflater.DEFAULT_COMPRESSION)
-            if (chapterCacheFolder.isDirectory) {
-                chapterCacheFolder.listFiles()?.sortedBy { it.name }?.forEach {
-                    val entry = ZipArchiveEntry(it.name)
-                    entry.time = 0L
-                    try {
-                        zipOut.putArchiveEntry(entry)
-                        it.inputStream().use { inputStream ->
-                            inputStream.copyTo(zipOut)
-                        }
-                    } finally {
-                        zipOut.closeArchiveEntry()
-                    }
-                }
+            if (chapterCacheFolder.exists() && chapterCacheFolder.isDirectory) {
+                chapterCacheFolder.deleteRecursively()
             }
-        }
-
-        if (chapterCacheFolder.exists() && chapterCacheFolder.isDirectory) {
-            chapterCacheFolder.deleteRecursively()
         }
     }
 
@@ -117,26 +105,102 @@ class ArchiveProvider(
         val cbzFile = File(getChapterCbzPath(mangaId, chapterId))
         return if (cbzFile.exists()) cbzFile.length() else 0L
     }
+}
 
-    private fun extractCbzFile(
-        cbzFile: File,
-        chapterFolder: File,
-    ) {
-        if (!chapterFolder.exists()) chapterFolder.mkdirs()
-        ZipArchiveInputStream(cbzFile.inputStream()).use { zipInputStream ->
-            var zipEntry = zipInputStream.nextEntry
-            while (zipEntry != null) {
-                val file = File(chapterFolder, zipEntry.name)
-                if (!file.exists()) {
-                    file.parentFile.mkdirs()
-                    file.createNewFile()
-                }
-                file.outputStream().use { outputStream ->
-                    zipInputStream.copyTo(outputStream)
-                }
-                zipEntry = zipInputStream.nextEntry
+internal fun extractExistingCbzFile(
+    cbzFile: File,
+    chapterFolder: File,
+    onInvalidArchive: (IOException) -> Unit,
+) {
+    try {
+        validateCbzFile(cbzFile)
+    } catch (exception: IOException) {
+        onInvalidArchive(exception)
+        deleteCorruptedDownload(cbzFile, chapterFolder, exception)
+        return
+    }
+
+    if (!chapterFolder.exists()) chapterFolder.mkdirs()
+    ZipArchiveInputStream(cbzFile.inputStream()).use { zipInputStream ->
+        var zipEntry = zipInputStream.nextEntry
+        while (zipEntry != null) {
+            val file = File(chapterFolder, zipEntry.name)
+            if (!file.exists()) {
+                file.parentFile.mkdirs()
+                file.createNewFile()
+            }
+            file.outputStream().use { outputStream ->
+                zipInputStream.copyTo(outputStream)
+            }
+            zipEntry = zipInputStream.nextEntry
+        }
+    }
+    cbzFile.delete()
+}
+
+private fun validateCbzFile(cbzFile: File) {
+    ZipFile.builder().setFile(cbzFile).get().use { zipFile ->
+        zipFile.entries.asSequence().filterNot { it.isDirectory }.forEach { entry ->
+            zipFile.getInputStream(entry).use { inputStream ->
+                inputStream.copyTo(OutputStream.nullOutputStream())
             }
         }
-        cbzFile.delete()
+    }
+}
+
+private fun deleteCorruptedDownload(
+    cbzFile: File,
+    chapterFolder: File,
+    cause: IOException,
+) {
+    if (chapterFolder.exists() && !chapterFolder.deleteRecursively()) {
+        throw IOException("Failed to delete partially extracted chapter folder: ${chapterFolder.path}", cause)
+    }
+    if (cbzFile.exists() && !cbzFile.delete()) {
+        throw IOException("Failed to delete corrupted CBZ: ${cbzFile.path}", cause)
+    }
+}
+
+internal fun createCbzFile(
+    outputFile: File,
+    chapterCacheFolder: File,
+) {
+    val incompleteOutputFile = File(outputFile.parentFile, "${outputFile.name}.part")
+    if (incompleteOutputFile.exists() && !incompleteOutputFile.delete()) {
+        throw IOException("Failed to delete incomplete CBZ: ${incompleteOutputFile.path}")
+    }
+
+    try {
+        ZipArchiveOutputStream(incompleteOutputFile.outputStream()).use { zipOut ->
+            zipOut.setMethod(ZipArchiveOutputStream.DEFLATED)
+            zipOut.setLevel(Deflater.DEFAULT_COMPRESSION)
+            if (chapterCacheFolder.isDirectory) {
+                chapterCacheFolder.listFiles()?.sortedBy { it.name }?.forEach {
+                    val entry = ZipArchiveEntry(it.name)
+                    entry.time = 0L
+                    try {
+                        zipOut.putArchiveEntry(entry)
+                        it.inputStream().use { inputStream ->
+                            inputStream.copyTo(zipOut)
+                        }
+                    } finally {
+                        zipOut.closeArchiveEntry()
+                    }
+                }
+            }
+        }
+
+        try {
+            Files.move(
+                incompleteOutputFile.toPath(),
+                outputFile.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(incompleteOutputFile.toPath(), outputFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    } finally {
+        incompleteOutputFile.delete()
     }
 }

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProviderTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/impl/ArchiveProviderTest.kt
@@ -1,0 +1,79 @@
+package suwayomi.tachidesk.manga.impl.download.fileProvider.impl
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ArchiveProviderTest {
+    private val temporaryDirectories = mutableListOf<File>()
+
+    @AfterTest
+    fun cleanUp() {
+        temporaryDirectories.forEach(File::deleteRecursively)
+    }
+
+    @Test
+    fun validArchiveIsExtracted() {
+        val root = createTemporaryDirectory()
+        val cacheFolder = File(root, "cache").apply { mkdirs() }
+        File(cacheFolder, "001.jpg").writeText("first page")
+        File(cacheFolder, "002.jpg").writeText("second page")
+        val cbzFile = File(root, "chapter.cbz")
+        createCbzFile(cbzFile, cacheFolder)
+        val chapterFolder = File(root, "chapter")
+        var validationFailure: IOException? = null
+
+        extractExistingCbzFile(cbzFile, chapterFolder) { validationFailure = it }
+
+        assertEquals(null, validationFailure)
+        assertFalse(cbzFile.exists())
+        assertEquals("first page", File(chapterFolder, "001.jpg").readText())
+        assertEquals("second page", File(chapterFolder, "002.jpg").readText())
+    }
+
+    @Test
+    fun corruptedArchiveAndPartialExtractionAreDeleted() {
+        val root = createTemporaryDirectory()
+        val cacheFolder = File(root, "cache").apply { mkdirs() }
+        File(cacheFolder, "001.jpg").writeBytes(ByteArray(8192) { it.toByte() })
+        val cbzFile = File(root, "chapter.cbz")
+        createCbzFile(cbzFile, cacheFolder)
+        cbzFile.writeBytes(cbzFile.readBytes().copyOf(cbzFile.length().toInt() / 2))
+        val chapterFolder = File(root, "chapter").apply { mkdirs() }
+        File(chapterFolder, "partial.jpg").writeText("partial page")
+        var validationFailure: IOException? = null
+
+        extractExistingCbzFile(cbzFile, chapterFolder) { validationFailure = it }
+
+        assertNotNull(validationFailure)
+        assertFalse(cbzFile.exists())
+        assertFalse(chapterFolder.exists())
+    }
+
+    @Test
+    fun completedArchiveReplacesIncompleteFiles() {
+        val root = createTemporaryDirectory()
+        val cacheFolder = File(root, "cache").apply { mkdirs() }
+        File(cacheFolder, "001.jpg").writeText("complete page")
+        val cbzFile = File(root, "chapter.cbz").apply { writeText("broken archive") }
+        val incompleteCbzFile = File(root, "chapter.cbz.part").apply { writeText("interrupted write") }
+
+        createCbzFile(cbzFile, cacheFolder)
+
+        assertTrue(cbzFile.exists())
+        assertFalse(incompleteCbzFile.exists())
+
+        val chapterFolder = File(root, "chapter")
+        extractExistingCbzFile(cbzFile, chapterFolder) { throw AssertionError("Completed archive should be valid", it) }
+        assertEquals("complete page", File(chapterFolder, "001.jpg").readText())
+    }
+
+    private fun createTemporaryDirectory(): File =
+        Files.createTempDirectory("archive-provider-test-").toFile().also(temporaryDirectories::add)
+}


### PR DESCRIPTION
## Summary

An interrupted CBZ write can leave a truncated archive at the final download path. Retrying the download then attempts to extract the same unreadable archive and fails repeatedly.

- Validate existing CBZ archives before extracting them during a retry.
- Delete unreadable archives and partially extracted chapter files so the download can restart cleanly.
- Write new CBZ archives to a temporary `.part` file and move them into place only after the archive is completed.
- Add regression tests covering valid archives, truncated archives, and incomplete output files.
- Document the fix in the unreleased changelog.

Fixes #1942

## Testing

- `git diff --check`
- `.\gradlew.bat :server:ktlintCheck`
- `.\gradlew.bat :server:test --tests suwayomi.tachidesk.manga.impl.download.fileProvider.impl.ArchiveProviderTest`
- `.\gradlew.bat :server:test`
- `.\gradlew.bat :server:shadowJar`
- Manually downloaded a chapter as CBZ, backed it up, and truncated the downloaded archive to half its original size.
- Queued the chapter again and confirmed that the unreadable archive was deleted and rebuilt successfully.
- Confirmed the rebuilt CBZ matched the original size and SHA-256 hash, contained all 54 readable entries, left no `.part` file, and displayed its pages normally.