### PR TITLE
Make JCEF, system tray, and browser launch opt-in by default

### DIFF
--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -11,6 +11,9 @@ Suwayomi will create a default configuration file when one doesn't exist, you ca
 ### I am running Suwayomi in a headless environment (docker, NAS, VPS, etc.)
 - Set `server.systemTrayEnabled` to false, it will prevent Suwayomi to attempt to create a System Tray icon.
 - Set `server.initialOpenInBrowserEnabled`to false, it will prevent Suwayomi to attempt to open a browser on startup.
+- Set `server.kcefEnabled` to false, it will prevent native JCEF/Chromium (WebView) initialization. **Required on macOS Tahoe (26.x) ARM64** where `cef_initialize` has been observed to terminate the JVM with `SIGTRAP`/`EXC_BREAKPOINT`.
+
+These three settings default to `false` (opt-in desktop features). Existing `server.conf` files keep whatever values were already written.
 
 ### My Suwayomi data directory/downloads size is getting to big
 - Set `server.downloadsPath` to the desired path, if you only need to change where downloads are stored. You have to move/remove the existing downloads manually.
@@ -45,7 +48,7 @@ server.socksProxyPort = "8080"
 ### webUI
 ```
 server.webUIEnabled = true
-server.initialOpenInBrowserEnabled = true
+server.initialOpenInBrowserEnabled = false
 server.webUIInterface = "browser" # "browser" or "electron"
 server.electronPath = ""
 server.webUIFlavor = "WebUI" # "WebUI" or "Custom"
@@ -66,9 +69,9 @@ server.webUISubpath = ""
 
 ### webView
 ```
-server.kcefEnabled = true
+server.kcefEnabled = false
 ```
-- `server.kcefEnabled` controls if KCEF WebView provider is enabled.
+- `server.kcefEnabled` controls if KCEF WebView provider is enabled (loads native JCEF/Chromium). Default `false`. Keep disabled unless an extension requires WebView. On macOS Tahoe ARM64, enabling this can crash the process during `cef_initialize`.
 
 
 ### Downloader
@@ -155,14 +158,14 @@ server.jwtRefreshExpiry = "60d"
 ### misc
 ```
 server.debugLogsEnabled = false
-server.systemTrayEnabled = true
+server.systemTrayEnabled = false
 server.maxLogFiles = 31
 server.maxLogFileSize = "10mb"
 server.maxLogFolderSize = "100mb"
 
 ```
 - `server.debugLogsEnabled` controls whether if Suwayomi-Server should print more information while being run inside a Terminal/CMD/Powershell window. 
-- `server.systemTrayEnabled = true` whether if Suwayomi-Server should show a System Tray Icon, disabling this on headless servers is recommended.
+- `server.systemTrayEnabled = false` whether if Suwayomi-Server should show a System Tray Icon (opt-in; recommended false on headless servers).
 - `server.maxLogFiles = 31` sets the maximum number of days to keep files before they get deleted.
 - `server.maxLogFileSize = "10mb"` sets the maximum size of a log file - values are formatted like: 1 (bytes), 1KB (kilobytes), 1MB (megabytes), 1GB (gigabytes)
 - `server.maxLogFolderSize = "100mb"` sets the maximum size of all saved log files - values are formatted like: 1 (bytes), 1KB (kilobytes), 1MB (megabytes), 1GB (gigabytes)

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -171,8 +171,9 @@ class ServerConfig(
         protoNumber = 10,
         group = SettingGroup.WEB_UI,
         privacySafe = true,
-        defaultValue = true,
-        description = "Open client on startup",
+        // Opt-in: Desktop.browseURL / Electron launch is optional and not required for the HTTP API/WebUI.
+        defaultValue = false,
+        description = "Open client on startup (desktop convenience; disable for headless/server use)",
     )
 
     val webUIInterface: MutableStateFlow<WebUIInterface> by EnumSetting(
@@ -427,7 +428,9 @@ class ServerConfig(
         protoNumber = 34,
         group = SettingGroup.MISC,
         privacySafe = true,
-        defaultValue = true,
+        // Opt-in: SystemTray uses AWT/native tray APIs and is not required for the HTTP API/WebUI.
+        defaultValue = false,
+        description = "Show a system tray icon (desktop convenience; disable for headless/server use)",
     )
 
     val maxLogFiles: MutableStateFlow<Int> by IntSetting(
@@ -1039,8 +1042,11 @@ class ServerConfig(
         protoNumber = 86,
         group = SettingGroup.WEB_VIEW,
         privacySafe = true,
-        defaultValue = true,
-        description = "Enable the WebView via CEF (Chromium)"
+        // Opt-in: JCEF/CEF loads native Chromium (libjcef / Chromium Embedded Framework).
+        // On some platforms (notably macOS Tahoe ARM64) CefInitialize can raise SIGTRAP/EXC_BREAKPOINT
+        // and terminate the whole JVM — so never initialize unless the operator explicitly enables it.
+        defaultValue = false,
+        description = "Enable the WebView via CEF (Chromium). Optional; some extensions need it. Enabling loads native JCEF and can crash the process on unsupported OS/CEF combinations.",
     )
 
     val syncYomiEnabled: MutableStateFlow<Boolean> by BooleanSetting(

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -428,7 +428,7 @@ fun applicationSetup() {
         ignoreInitialValue = true,
     )
 
-    // create system tray
+    // System tray is optional desktop chrome (AWT / dorkbox). Off by default; HTTP server does not need it.
     Updates.ENABLE = false
     serverConfig.subscribeTo(
         serverConfig.systemTrayEnabled,
@@ -518,7 +518,9 @@ fun applicationSetup() {
 
     SyncManager.scheduleSyncTask()
 
-    // asynchronously initialize CEF
+    // Optionally initialize CEF/JCEF (embedded Chromium) for extension WebView.
+    // Gated by server.kcefEnabled (default false). Must stay async and behind that flag:
+    // CefInitialize can SIGTRAP and kill the JVM on macOS Tahoe ARM64.
     GlobalScope.launch {
         CEFManager.init()
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -93,9 +93,26 @@ object CEFManager {
             CefHelper.cefApp.value = Result.success(null)
 
             if (!serverConfig.kcefEnabled.value) {
-                throw CefException("CEF is disabled")
+                // Do not load jawt/jcef/Chromium at all. SIGTRAP from CefInitialize cannot be
+                // recovered from in-process on macOS (unlike Linux LD_PRELOAD catch_abort.so).
+                logger.info { "CEF/WebView is disabled (server.kcefEnabled=false); skipping native JCEF initialization" }
+                CefHelper.cefApp.value = Result.failure(CefException("CEF is disabled"))
+                return
             }
 
+            val os = Platform.current.os
+            if (os.isMacOSX) {
+                // Evidence: macOS 26.5.2 ARM64 crash reports show EXC_BREAKPOINT/SIGTRAP inside
+                // Chromium Embedded Framework cef_initialize via libjcef.dylib CefInitialize,
+                // which terminates the JVM. Native crashes are not catchable as Java exceptions.
+                logger.warn {
+                    "Enabling KCEF on macOS loads native Chromium (JCEF). " +
+                        "On macOS Tahoe (26.x) this has been observed to kill the process with SIGTRAP/EXC_BREAKPOINT " +
+                        "during cef_initialize. Prefer server.kcefEnabled=false unless you need extension WebView."
+                }
+            }
+
+            // First native touchpoint — must never run when kcef is disabled.
             System.loadLibrary("jawt")
 
             if (serverConfig.debugLogsEnabled.value) System.setProperty("jcef.log.verbose", "true")
@@ -145,7 +162,6 @@ object CEFManager {
 
                     // this is essentially https://github.com/JetBrains/jcef/blob/5b93e5b916068316f1c8e7f8a59bf958d5ffd6e1/java/org/cef/CefApp.java#L777
                     // we do this here because JCEF has no mechanism to tell us that initalization failed, they just record in an inaccessible future
-                    val os = Platform.current.os
                     when {
                         os.isLinux -> {
                             config.getLoader().loadLibrary("cef")
@@ -162,6 +178,7 @@ object CEFManager {
 
                     CefApp.setIsRemoteEnabled(config.isRemoteEnabled)
                     SystemBootstrap.setLoader(config.getLoader())
+                    // Native point of no return on macOS Tahoe: CefApp.startup → CefInitialize → cef_initialize
                     CefApp.startup(config.getAppArgs())
 
                     CefApp.getInstance(config.getAppArgs(), config.cefSettings, config.getServerExe())


### PR DESCRIPTION
## Summary
- Default `kcefEnabled`, `systemTrayEnabled`, and `initialOpenInBrowserEnabled` to `false` so HTTP/WebUI startup does not load native desktop components.
- Skip all JCEF/`jawt` native loads when KCEF is disabled; warn on macOS if it is enabled.
- Document the macOS Tahoe ARM64 `SIGTRAP`/`EXC_BREAKPOINT` crash in `cef_initialize`, and that existing `server.conf` values are unchanged.

## Context
On macOS 26.x (Tahoe) ARM64, async CEF init after Javalin start terminates the JVM inside `libjcef.dylib` → `cef_initialize`. Crash reports confirm this is native Chromium/JCEF, not Kotlin server code. Linux has `catch_abort.so` for SIGTRAP; macOS does not.

## Test plan
- [ ] Fresh install / no `kcefEnabled` in conf: server starts, log shows CEF skipped, WebUI + `/api/v1/settings/about` work
- [ ] Existing conf with `kcefEnabled=true` still enables CEF (defaults do not rewrite user conf)
- [ ] With `kcefEnabled=false` on macOS Tahoe: process stays alive (no SIGTRAP)
- [ ] Enabling tray / open-in-browser still works when set to `true`