### PR TITLE
Add a simple mutation to clear cache & cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - (**Downloads**) Try to preserve downloaded files during a chapter list update for chapters with title and/or scanlator change
 - (**Logs**) Add IP location logging
+- (**Extension**) Add a way to clear cache & cookies
 
 ### Changed
 - (**SystemTray**) Disable DorkBox update requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - (**Downloads**) Try to preserve downloaded files during a chapter list update for chapters with title and/or scanlator change
 - (**Logs**) Add IP location logging
-- (**Extension**) Add a way to clear cache & cookies
+- (**Cache/API**) Add a way to clear cache & cookies
 
 ### Changed
 - (**SystemTray**) Disable DorkBox update requests

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/WebviewMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/WebviewMutation.kt
@@ -7,10 +7,10 @@ import suwayomi.tachidesk.server.ApplicationDirs
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.net.CookieHandler
+import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
 import kotlin.io.path.deleteRecursively
 import kotlin.io.path.div
-import kotlin.io.path.ExperimentalPathApi
 
 @OptIn(ExperimentalPathApi::class)
 class WebviewMutation {

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/WebviewMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/WebviewMutation.kt
@@ -1,0 +1,38 @@
+@file:Suppress("RedundantNullableReturnType", "unused")
+
+package suwayomi.tachidesk.graphql.mutations
+
+import suwayomi.tachidesk.graphql.directives.RequireAuth
+import suwayomi.tachidesk.server.ApplicationDirs
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.net.CookieHandler
+import kotlin.io.path.Path
+import kotlin.io.path.deleteRecursively
+import kotlin.io.path.div
+import kotlin.io.path.ExperimentalPathApi
+
+@OptIn(ExperimentalPathApi::class)
+class WebviewMutation {
+    private val applicationDirs by lazy { Injekt.get<ApplicationDirs>() }
+    private val cacheDir by lazy { Path(applicationDirs.dataRoot) / "cache" }
+
+    data class ClearCookiesAndCacheInput(
+        val clientMutationId: String? = null,
+    )
+
+    data class ClearCookiesAndCachePayload(
+        val clientMutationId: String?,
+    )
+
+    @RequireAuth
+    fun clearCookiesAndCache(input: ClearCookiesAndCacheInput? = null): ClearCookiesAndCachePayload {
+        val cookieHandler = CookieHandler.getDefault() as java.net.CookieManager
+        cookieHandler.cookieStore.removeAll()
+        cacheDir.deleteRecursively()
+
+        return ClearCookiesAndCachePayload(
+            clientMutationId = input?.clientMutationId,
+        )
+    }
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/WebviewMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/WebviewMutation.kt
@@ -10,12 +10,10 @@ import java.net.CookieHandler
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
 import kotlin.io.path.deleteRecursively
-import kotlin.io.path.div
 
 @OptIn(ExperimentalPathApi::class)
 class WebviewMutation {
     private val applicationDirs by lazy { Injekt.get<ApplicationDirs>() }
-    private val cacheDir by lazy { Path(applicationDirs.dataRoot) / "cache" }
 
     data class ClearCookiesAndCacheInput(
         val clientMutationId: String? = null,
@@ -29,7 +27,7 @@ class WebviewMutation {
     fun clearCookiesAndCache(input: ClearCookiesAndCacheInput? = null): ClearCookiesAndCachePayload {
         val cookieHandler = CookieHandler.getDefault() as java.net.CookieManager
         cookieHandler.cookieStore.removeAll()
-        cacheDir.deleteRecursively()
+        Path(applicationDirs.cacheDir).deleteRecursively()
 
         return ClearCookiesAndCachePayload(
             clientMutationId = input?.clientMutationId,

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLSchema.kt
@@ -37,6 +37,7 @@ import suwayomi.tachidesk.graphql.mutations.SyncMutation
 import suwayomi.tachidesk.graphql.mutations.TrackMutation
 import suwayomi.tachidesk.graphql.mutations.UpdateMutation
 import suwayomi.tachidesk.graphql.mutations.UserMutation
+import suwayomi.tachidesk.graphql.mutations.WebviewMutation
 import suwayomi.tachidesk.graphql.queries.BackupQuery
 import suwayomi.tachidesk.graphql.queries.CategoryQuery
 import suwayomi.tachidesk.graphql.queries.ChapterQuery
@@ -135,6 +136,7 @@ object GraphQLSchemaProvider {
                         TopLevelObject(TrackMutation()),
                         TopLevelObject(UpdateMutation()),
                         TopLevelObject(UserMutation()),
+                        TopLevelObject(WebviewMutation()),
                     ),
                 subscriptions =
                     listOf(

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -97,6 +97,8 @@ class ApplicationDirs(
         get() = "$downloadsRoot/thumbnails"
     val mangaDownloadsRoot
         get() = "$downloadsRoot/mangas"
+
+    val cacheDir = "$dataRoot/cache"
 }
 
 @Suppress("DEPRECATION")

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -128,7 +128,7 @@ object CEFManager {
                             )
                             cefSettings.apply {
                                 windowless_rendering_enabled = true
-                                cache_path = (Path(applicationDirs.dataRoot) / "cache/kcef").absolutePathString()
+                                cache_path = (Path(applicationDirs.cacheDir) / "kcef").absolutePathString()
                                 log_severity =
                                     if (serverConfig.debugLogsEnabled.value) {
                                         LogSeverity.LOGSEVERITY_VERBOSE


### PR DESCRIPTION
Cloudflare can get into infinite verification loops if cookies are present and the UA string changes, in which case both our cookie store as well as CEF's cache need to be cleared