### PR TITLE
Fix memo-dependent manga URL resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Downloader**) Skip LocalSource downloading
 
 ### Fixed
+- (**Manga/Extension**) Fix resolving manga URLs for extensions that use memo data
 - (**Tracker**) Fix Shikimori
 - (**Extension**) Fix losing installed extension in case the update fails
 - (**Source/API**) Fix graphql browse mutation (`fetchSourceManga`) with filters including nested group changes

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Manga.kt
@@ -237,6 +237,7 @@ object Manga {
                                 genre = sManga.genre ?: mangaEntry[MangaTable.genre]
                                 status = sManga.status
                                 update_strategy = sManga.update_strategy
+                                memo = sManga.memo
                             },
                         )
                     }.getOrNull()

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/MangaTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/MangaTest.kt
@@ -7,6 +7,16 @@ package suwayomi.tachidesk.manga.impl
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -19,6 +29,37 @@ import suwayomi.tachidesk.test.createLibraryManga
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MangaTest : ApplicationTest() {
+    @Test
+    fun `updateMangaDatabase passes memo to source when resolving real URL`() =
+        runTest {
+            val mangaId = createLibraryManga("MEMO_TEST")
+            val mangaEntry = transaction { MangaTable.selectAll().where { MangaTable.id eq mangaId }.single() }
+            val memo = buildJsonObject { put("slug", JsonPrimitive("memo-slug")) }
+            val expectedUrl = "https://example.com/manga/memo-slug"
+            val remoteManga =
+                SManga.create().apply {
+                    url = "MEMO_TEST"
+                    title = "MEMO_TEST"
+                    this.memo = memo
+                }
+            val source = mockk<HttpSource>()
+            every { source.getMangaUrl(any()) } answers {
+                check(firstArg<SManga>().memo == memo) { "Manga memo was not passed to the source" }
+                expectedUrl
+            }
+
+            Manga.updateMangaDatabase(mangaEntry, source, remoteManga)
+
+            val realUrl =
+                transaction {
+                    MangaTable
+                        .selectAll()
+                        .where { MangaTable.id eq mangaId }
+                        .single()[MangaTable.realUrl]
+                }
+            assertEquals(expectedUrl, realUrl)
+        }
+
     @Test
     fun getMangaMeta() {
         val metaManga = createLibraryManga("META_TEST")

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/MangaTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/MangaTest.kt
@@ -7,16 +7,6 @@ package suwayomi.tachidesk.manga.impl
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
-import io.mockk.every
-import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -29,37 +19,6 @@ import suwayomi.tachidesk.test.createLibraryManga
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MangaTest : ApplicationTest() {
-    @Test
-    fun `updateMangaDatabase passes memo to source when resolving real URL`() =
-        runTest {
-            val mangaId = createLibraryManga("MEMO_TEST")
-            val mangaEntry = transaction { MangaTable.selectAll().where { MangaTable.id eq mangaId }.single() }
-            val memo = buildJsonObject { put("slug", JsonPrimitive("memo-slug")) }
-            val expectedUrl = "https://example.com/manga/memo-slug"
-            val remoteManga =
-                SManga.create().apply {
-                    url = "MEMO_TEST"
-                    title = "MEMO_TEST"
-                    this.memo = memo
-                }
-            val source = mockk<HttpSource>()
-            every { source.getMangaUrl(any()) } answers {
-                check(firstArg<SManga>().memo == memo) { "Manga memo was not passed to the source" }
-                expectedUrl
-            }
-
-            Manga.updateMangaDatabase(mangaEntry, source, remoteManga)
-
-            val realUrl =
-                transaction {
-                    MangaTable
-                        .selectAll()
-                        .where { MangaTable.id eq mangaId }
-                        .single()[MangaTable.realUrl]
-                }
-            assertEquals(expectedUrl, realUrl)
-        }
-
     @Test
     fun getMangaMeta() {
         val metaManga = createLibraryManga("META_TEST")


### PR DESCRIPTION
﻿## What

- preserve source-specific SManga.memo data when constructing the manga passed to HttpSource.getMangaUrl
- add a regression test for memo-dependent real URL generation during metadata refreshes
- document the fix in the Unreleased changelog

## Why

updateMangaDatabase stores the refreshed memo in the database, but the temporary SManga used to resolve the real URL omitted it. Extensions that need memo data in getMangaUrl therefore threw, and the guarded call stored a null real URL.

Closes #2264

## Validation

- Gradle 9.6.1: ktlintCheck
- Gradle 9.6.1: :server:test (33 tests, 0 failures)
- Gradle 9.6.1: :server:shadowJar
- confirmed the regression test fails before the fix with the expected URL resolving to null, then passes after the fix

AI assistance was used during investigation or implementation.
