### PR TITLE
Apply SOCKS proxy settings to server clients, CEF, and FlareSolverr sessions

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -20,9 +20,11 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import okhttp3.Cache
+import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import suwayomi.tachidesk.manga.impl.util.source.GetSource
+import suwayomi.tachidesk.server.network.SocksProxyManager
 import java.net.CookieHandler
 import java.net.CookieManager
 import java.net.CookiePolicy
@@ -54,6 +56,7 @@ class NetworkHelper(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         )
     val userAgentFlow = userAgent.asStateFlow()
+    private val connectionPool = ConnectionPool()
 
     fun defaultUserAgentProvider(): String = userAgent.value
 
@@ -71,6 +74,8 @@ class NetworkHelper(
             val builder =
                 OkHttpClient
                     .Builder()
+                    .proxySelector(SocksProxyManager.proxySelector)
+                    .connectionPool(connectionPool)
                     .cookieJar(PersistentCookieJar(cookieStore))
                     .connectTimeout(30, TimeUnit.SECONDS)
                     .readTimeout(30, TimeUnit.SECONDS)
@@ -123,6 +128,15 @@ class NetworkHelper(
 
 //    val client by lazy { baseClientBuilder.cache(Cache(cacheDir, cacheSize)).build() }
     val client by lazy { baseClientBuilder.build() }
+
+    init {
+        @OptIn(DelicateCoroutinesApi::class)
+        SocksProxyManager.settings
+            .drop(1)
+            .onEach {
+                connectionPool.evictAll()
+            }.launchIn(GlobalScope)
+    }
 
     @Deprecated("The regular client handles Cloudflare by default")
     @Suppress("UNUSED")

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.network.interceptor
 
+import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
@@ -24,15 +25,21 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
+import suwayomi.tachidesk.server.network.SocksProxyManager
 import suwayomi.tachidesk.server.serverConfig
 import uy.kohesive.injekt.injectLazy
 import java.io.IOException
+import java.net.Proxy
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+
+private typealias FlareSolverCommandSender =
+    suspend (String, CFClearance.FlareSolverRequest) -> CFClearance.FlareSolverCommandResponse
 
 class CloudflareInterceptor(
     private val setUserAgent: (String) -> Unit,
@@ -202,6 +209,165 @@ class CloudflareInterceptor(
     }
 }
 
+internal data class FlareSolverSessionSettings(
+    val url: String,
+    val name: String,
+    val ttlMinutes: Int,
+    val proxy: CFClearance.FlareSolverProxy?,
+)
+
+internal class FlareSolverSessionManager(
+    private val nanoTime: () -> Long = System::nanoTime,
+) {
+    private val logger = KotlinLogging.logger {}
+
+    private data class State(
+        val settings: FlareSolverSessionSettings,
+        val createdAtNanos: Long,
+    )
+
+    private var state: State? = null
+
+    suspend fun ensure(
+        settings: FlareSolverSessionSettings,
+        send: FlareSolverCommandSender,
+    ) {
+        require(settings.name.isNotBlank()) { "FlareSolverr session name must not be blank" }
+
+        val previous = state
+        val expired =
+            previous != null &&
+                settings.ttlMinutes > 0 &&
+                nanoTime() - previous.createdAtNanos >= settings.ttlMinutes.minutes.inWholeNanoseconds
+        val mustRecreate = previous == null || previous.settings != settings || expired
+
+        if (mustRecreate) {
+            recreate(settings, send)
+            return
+        }
+
+        // sessions.create is idempotent and restores the proxied session after a FlareSolverr restart.
+        send(
+            settings.url,
+            CFClearance.FlareSolverRequest(
+                cmd = "sessions.create",
+                session = settings.name,
+                proxy = settings.proxy,
+            ),
+        ).also(::checkCommandResponse)
+    }
+
+    suspend fun recreate(
+        settings: FlareSolverSessionSettings,
+        send: FlareSolverCommandSender,
+    ) {
+        require(settings.name.isNotBlank()) { "FlareSolverr session name must not be blank" }
+
+        destroy(settings, send)
+
+        send(
+            settings.url,
+            CFClearance.FlareSolverRequest(
+                cmd = "sessions.create",
+                session = settings.name,
+                proxy = settings.proxy,
+            ),
+        ).also(::checkCommandResponse)
+
+        state = State(settings, nanoTime())
+    }
+
+    suspend fun destroy(
+        settings: FlareSolverSessionSettings,
+        send: FlareSolverCommandSender,
+    ) {
+        require(settings.name.isNotBlank()) { "FlareSolverr session name must not be blank" }
+
+        val previous = state
+        state = null
+
+        val sessions =
+            send(settings.url, CFClearance.FlareSolverRequest(cmd = "sessions.list"))
+                .also(::checkCommandResponse)
+                .sessions
+                .orEmpty()
+        val namesToDestroy =
+            buildSet {
+                add(settings.name)
+                previous?.settings?.takeIf { it.url == settings.url }?.let { add(it.name) }
+            }
+
+        namesToDestroy.intersect(sessions.toSet()).forEach { sessionName ->
+            send(
+                settings.url,
+                CFClearance.FlareSolverRequest(cmd = "sessions.destroy", session = sessionName),
+            ).also(::checkCommandResponse)
+        }
+    }
+
+    suspend fun <T> execute(
+        settings: FlareSolverSessionSettings,
+        send: FlareSolverCommandSender,
+        retryOnFailure: Boolean,
+        request: suspend () -> T,
+    ): T {
+        ensure(settings, send)
+
+        return try {
+            request()
+        } catch (e: HttpException) {
+            if (e.code != 500) {
+                throw e
+            }
+
+            if (!retryOnFailure) {
+                logger.warn { "FlareSolverr request failed with HTTP 500; invalidating the session without retrying" }
+                destroyAfterFailure(settings, send, e)
+            }
+
+            // FlareSolverr's timed-out worker can keep controlling a persistent WebDriver.
+            // Replacing the session prevents that worker from racing the single retry.
+            logger.warn { "FlareSolverr request failed with HTTP 500; recreating the session and retrying once" }
+            try {
+                recreate(settings, send)
+            } catch (recreateError: Exception) {
+                recreateError.addSuppressed(e)
+                throw recreateError
+            }
+
+            try {
+                request()
+            } catch (retryError: HttpException) {
+                retryError.addSuppressed(e)
+                if (retryError.code != 500) {
+                    throw retryError
+                }
+
+                logger.warn { "FlareSolverr retry failed with HTTP 500; invalidating the session" }
+                destroyAfterFailure(settings, send, retryError)
+            }
+        }
+    }
+
+    private suspend fun destroyAfterFailure(
+        settings: FlareSolverSessionSettings,
+        send: FlareSolverCommandSender,
+        failure: HttpException,
+    ): Nothing {
+        try {
+            destroy(settings, send)
+        } catch (cleanupError: Exception) {
+            failure.addSuppressed(cleanupError)
+        }
+
+        throw failure
+    }
+
+    private fun checkCommandResponse(response: CFClearance.FlareSolverCommandResponse) {
+        check(response.status == "ok") { "FlareSolverr session command failed: ${response.message}" }
+    }
+}
+
 /*
  * This class is ported from https://github.com/vvanglro/cf-clearance
  * The original code is licensed under Apache 2.0
@@ -209,21 +375,28 @@ class CloudflareInterceptor(
 object CFClearance {
     private val logger = KotlinLogging.logger {}
     private val network: NetworkHelper by injectLazy()
+    private val directClient by lazy {
+        network.client
+            .newBuilder()
+            .proxy(Proxy.NO_PROXY)
+            .build()
+    }
     private val client by lazy {
         @Suppress("OPT_IN_USAGE")
         serverConfig.flareSolverrTimeout
             .map { timeoutInt ->
                 val timeout = timeoutInt.seconds
-                network.client
+                directClient
                     .newBuilder()
                     .callTimeout(timeout.plus(10.seconds).toJavaDuration())
                     .readTimeout(timeout.plus(5.seconds).toJavaDuration())
                     .build()
-            }.stateIn(GlobalScope, SharingStarted.Eagerly, network.client)
+            }.stateIn(GlobalScope, SharingStarted.Eagerly, directClient)
     }
     private val json: Json by injectLazy()
     private val jsonMediaType = "application/json".toMediaType()
     private val mutex = Mutex()
+    private val sessionManager = FlareSolverSessionManager()
 
     sealed class Result {
         data class CloudflareBypassed(
@@ -262,15 +435,29 @@ object CFClearance {
     @Serializable
     data class FlareSolverRequest(
         val cmd: String,
-        val url: String,
+        val url: String? = null,
         val maxTimeout: Int? = null,
         val session: String? = null,
         @SerialName("session_ttl_minutes")
         val sessionTtlMinutes: Int? = null,
         val cookies: List<FlareSolverCookie>? = null,
         val returnOnlyCookies: Boolean? = null,
-        val proxy: String? = null,
+        val proxy: FlareSolverProxy? = null,
         val postData: String? = null, // only used with cmd 'request.post'
+    )
+
+    @Serializable
+    data class FlareSolverProxy(
+        val url: String,
+        val username: String? = null,
+        val password: String? = null,
+    )
+
+    @Serializable
+    data class FlareSolverCommandResponse(
+        val status: String,
+        val message: String,
+        val sessions: List<String>? = null,
     )
 
     @Serializable
@@ -314,46 +501,104 @@ object CFClearance {
         val timeout = serverConfig.flareSolverrTimeout.value.seconds
         return with(json) {
             mutex.withLock {
-                client.value
-                    .newCall(
-                        POST(
-                            url = serverConfig.flareSolverrUrl.value.removeSuffix("/") + "/v1",
-                            body =
-                                Json
-                                    .encodeToString(
-                                        FlareSolverRequest(
-                                            "request.${originalRequest.method.lowercase()}",
-                                            originalRequest.url.toString(),
-                                            session = serverConfig.flareSolverrSessionName.value,
-                                            sessionTtlMinutes = serverConfig.flareSolverrSessionTtl.value,
-                                            cookies =
-                                                network.cookieStore
-                                                    .get(originalRequest.url)
-                                                    .filter { it.name !in CloudflareInterceptor.COOKIE_NAMES }
-                                                    .map { cookie ->
-                                                        FlareSolverCookie(cookie.name, cookie.value)
-                                                    },
-                                            returnOnlyCookies = onlyCookies,
-                                            maxTimeout = timeout.inWholeMilliseconds.toInt(),
-                                            postData =
-                                                if (originalRequest.method == "POST") {
-                                                    originalRequest.body
-                                                        ?.let { body ->
-                                                            Buffer()
-                                                                .also { body.writeTo(it) }
-                                                                .readUtf8()
-                                                        }.orEmpty()
-                                                } else {
-                                                    null
-                                                },
-                                        ),
-                                    ).toRequestBody(jsonMediaType),
-                        ),
-                    ).awaitSuccess()
-                    .parseAs<FlareSolverResponse>()
+                val sessionSettings = currentSessionSettings()
+                val manageSession = sessionSettings.proxy != null && sessionSettings.name.isNotBlank()
+                val request =
+                    FlareSolverRequest(
+                        "request.${originalRequest.method.lowercase()}",
+                        originalRequest.url.toString(),
+                        session = sessionSettings.name.ifBlank { null },
+                        sessionTtlMinutes = sessionSettings.ttlMinutes.takeUnless { manageSession },
+                        cookies =
+                            network.cookieStore
+                                .get(originalRequest.url)
+                                .filter { it.name !in CloudflareInterceptor.COOKIE_NAMES }
+                                .map { cookie ->
+                                    FlareSolverCookie(cookie.name, cookie.value)
+                                },
+                        returnOnlyCookies = onlyCookies,
+                        proxy = sessionSettings.proxy.takeIf { sessionSettings.name.isBlank() },
+                        maxTimeout = timeout.inWholeMilliseconds.toInt(),
+                        postData =
+                            if (originalRequest.method == "POST") {
+                                originalRequest.body
+                                    ?.let { body ->
+                                        Buffer()
+                                            .also { body.writeTo(it) }
+                                            .readUtf8()
+                                    }.orEmpty()
+                            } else {
+                                null
+                            },
+                    )
+
+                val sendRequest =
+                    suspend {
+                        sendFlareSolverRequest(sessionSettings.url, request)
+                    }
+
+                if (manageSession) {
+                    sessionManager.execute(
+                        sessionSettings,
+                        ::sendSessionCommand,
+                        retryOnFailure = originalRequest.method == "GET",
+                        request = sendRequest,
+                    )
+                } else {
+                    sendRequest()
+                }
             }
         }
     }
+
+    private suspend fun sendFlareSolverRequest(
+        url: String,
+        request: FlareSolverRequest,
+    ): FlareSolverResponse =
+        with(json) {
+            client.value
+                .newCall(
+                    POST(
+                        url = url,
+                        body = Json.encodeToString(request).toRequestBody(jsonMediaType),
+                    ),
+                ).awaitSuccess()
+                .parseAs<FlareSolverResponse>()
+        }
+
+    private fun currentSessionSettings(): FlareSolverSessionSettings {
+        val proxySettings = SocksProxyManager.settings.value
+        val proxy =
+            proxySettings.proxyUrl()?.let { url ->
+                FlareSolverProxy(
+                    url = url,
+                    username = proxySettings.username.ifEmpty { null },
+                    password = proxySettings.password.ifEmpty { null },
+                )
+            }
+
+        return FlareSolverSessionSettings(
+            url = serverConfig.flareSolverrUrl.value.removeSuffix("/") + "/v1",
+            name = serverConfig.flareSolverrSessionName.value,
+            ttlMinutes = serverConfig.flareSolverrSessionTtl.value,
+            proxy = proxy,
+        )
+    }
+
+    private suspend fun sendSessionCommand(
+        url: String,
+        request: FlareSolverRequest,
+    ): FlareSolverCommandResponse =
+        with(json) {
+            client.value
+                .newCall(
+                    POST(
+                        url = url,
+                        body = Json.encodeToString(request).toRequestBody(jsonMediaType),
+                    ),
+                ).awaitSuccess()
+                .parseAs<FlareSolverCommandResponse>()
+        }
 
     fun requestWithFlareSolverr(
         flareSolverResponse: FlareSolverResponse,

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -48,6 +48,8 @@ import suwayomi.tachidesk.manga.impl.update.Updater
 import suwayomi.tachidesk.manga.impl.util.lang.renameTo
 import suwayomi.tachidesk.server.database.databaseUp
 import suwayomi.tachidesk.server.generated.BuildConfig
+import suwayomi.tachidesk.server.network.SocksProxyManager
+import suwayomi.tachidesk.server.network.SocksProxySettings
 import suwayomi.tachidesk.server.settings.SettingsRegistry
 import suwayomi.tachidesk.server.util.AppMutex.handleAppMutex
 import suwayomi.tachidesk.server.util.CEFManager
@@ -69,8 +71,6 @@ import xyz.nulldev.ts.config.initLoggerConfig
 import xyz.nulldev.ts.config.setLogLevelFor
 import xyz.nulldev.ts.config.updateFileAppender
 import java.io.File
-import java.net.Authenticator
-import java.net.PasswordAuthentication
 import java.security.Security
 import java.util.Locale
 
@@ -109,15 +109,6 @@ class LooperThread : Thread() {
         Looper.loop()
     }
 }
-
-data class ProxySettings(
-    val proxyEnabled: Boolean,
-    val socksProxyVersion: Int,
-    val proxyHost: String,
-    val proxyPort: String,
-    val proxyUsername: String,
-    val proxyPassword: String,
-)
 
 data class DatabaseSettings(
     val databaseType: DatabaseType,
@@ -340,6 +331,48 @@ fun applicationSetup() {
     // Make sure only one instance of the app is running
     handleAppMutex()
 
+    // socks proxy settings
+    SocksProxyManager.update(
+        SocksProxySettings(
+            serverConfig.socksProxyEnabled.value,
+            serverConfig.socksProxyVersion.value,
+            serverConfig.socksProxyHost.value,
+            serverConfig.socksProxyPort.value,
+            serverConfig.socksProxyUsername.value,
+            serverConfig.socksProxyPassword.value,
+        ),
+    )
+    serverConfig.subscribeTo(
+        combine<Any, SocksProxySettings>(
+            serverConfig.socksProxyEnabled,
+            serverConfig.socksProxyVersion,
+            serverConfig.socksProxyHost,
+            serverConfig.socksProxyPort,
+            serverConfig.socksProxyUsername,
+            serverConfig.socksProxyPassword,
+        ) { vargs ->
+            SocksProxySettings(
+                vargs[0] as Boolean,
+                vargs[1] as Int,
+                vargs[2] as String,
+                vargs[3] as String,
+                vargs[4] as String,
+                vargs[5] as String,
+            )
+        }.distinctUntilChanged(),
+        { settings ->
+            logger.info {
+                "Socks Proxy changed - enabled=${settings.enabled} address=${settings.host}:${settings.port}, " +
+                    "username=[REDACTED], password=[REDACTED]"
+            }
+            if (!settings.isValid) {
+                logger.error { "SOCKS proxy is enabled but its host or port is invalid" }
+            }
+            SocksProxyManager.update(settings)
+        },
+        ignoreInitialValue = true,
+    )
+
     // Load Android compatibility dependencies
     AndroidCompatInitializer().init()
     // start app
@@ -451,59 +484,6 @@ fun applicationSetup() {
 
     setLogLevelFor("org.eclipse.jetty", Level.OFF)
     setLogLevelFor("com.zaxxer.hikari", Level.WARN)
-
-    // socks proxy settings
-    serverConfig.subscribeTo(
-        combine<Any, ProxySettings>(
-            serverConfig.socksProxyEnabled,
-            serverConfig.socksProxyVersion,
-            serverConfig.socksProxyHost,
-            serverConfig.socksProxyPort,
-            serverConfig.socksProxyUsername,
-            serverConfig.socksProxyPassword,
-        ) { vargs ->
-            ProxySettings(
-                vargs[0] as Boolean,
-                vargs[1] as Int,
-                vargs[2] as String,
-                vargs[3] as String,
-                vargs[4] as String,
-                vargs[5] as String,
-            )
-        }.distinctUntilChanged(),
-        { (proxyEnabled, proxyVersion, proxyHost, proxyPort, proxyUsername, proxyPassword) ->
-            logger.info {
-                "Socks Proxy changed - enabled=$proxyEnabled address=$proxyHost:$proxyPort , username=[REDACTED], password=[REDACTED]"
-            }
-            if (proxyEnabled) {
-                System.setProperty("socksProxyHost", proxyHost)
-                System.setProperty("socksProxyPort", proxyPort)
-                System.setProperty("socksProxyVersion", proxyVersion.toString())
-
-                Authenticator.setDefault(
-                    object : Authenticator() {
-                        override fun getPasswordAuthentication(): PasswordAuthentication? {
-                            if (requestingProtocol.startsWith("SOCKS", ignoreCase = true)) {
-                                return PasswordAuthentication(
-                                    proxyUsername,
-                                    proxyPassword.toCharArray(),
-                                )
-                            }
-
-                            return null
-                        }
-                    },
-                )
-            } else {
-                System.clearProperty("socksProxyHost")
-                System.clearProperty("socksProxyPort")
-                System.clearProperty("socksProxyVersion")
-
-                Authenticator.setDefault(null)
-            }
-        },
-        ignoreInitialValue = false,
-    )
 
     // AES/CBC/PKCS7Padding Cypher provider for zh.copymanga
     Security.addProvider(BouncyCastleProvider())

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/network/SocksProxyManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/network/SocksProxyManager.kt
@@ -1,0 +1,130 @@
+package suwayomi.tachidesk.server.network
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.io.IOException
+import java.net.Authenticator
+import java.net.InetSocketAddress
+import java.net.PasswordAuthentication
+import java.net.Proxy
+import java.net.ProxySelector
+import java.net.SocketAddress
+import java.net.URI
+
+data class SocksProxySettings(
+    val enabled: Boolean,
+    val version: Int,
+    val host: String,
+    val port: String,
+    val username: String,
+    val password: String,
+) {
+    val portNumber: Int?
+        get() = port.toIntOrNull()?.takeIf { it in 1..65535 }
+
+    val isValid: Boolean
+        get() = !enabled || (host.isNotBlank() && portNumber != null)
+
+    fun proxyUrl(): String? {
+        if (!enabled) return null
+        check(isValid) { "SOCKS proxy is enabled but its host or port is invalid" }
+
+        val urlHost = host.removeSurrounding("[", "]").let { if (':' in it) "[$it]" else it }
+        return "socks$version://$urlHost:$portNumber"
+    }
+
+    fun asProxy(): Proxy {
+        if (!enabled) return Proxy.NO_PROXY
+        check(isValid) { "SOCKS proxy is enabled but its host or port is invalid" }
+
+        return Proxy(
+            Proxy.Type.SOCKS,
+            InetSocketAddress.createUnresolved(host, portNumber!!),
+        )
+    }
+}
+
+class SocksProxySelector(
+    private val settings: () -> SocksProxySettings,
+) : ProxySelector() {
+    override fun select(uri: URI): List<Proxy> {
+        requireNotNull(uri) { "URI must not be null" }
+
+        if (uri.scheme.lowercase() !in SUPPORTED_SCHEMES || uri.host.isLoopbackHost()) {
+            return listOf(Proxy.NO_PROXY)
+        }
+
+        return listOf(settings().asProxy())
+    }
+
+    override fun connectFailed(
+        uri: URI?,
+        socketAddress: SocketAddress?,
+        exception: IOException?,
+    ) = Unit
+
+    private fun String?.isLoopbackHost(): Boolean =
+        this != null &&
+            (
+                equals("localhost", ignoreCase = true) ||
+                    startsWith("127.") ||
+                    this == "::1" ||
+                    this == "[::1]" ||
+                    this == "0.0.0.0"
+            )
+
+    private companion object {
+        val SUPPORTED_SCHEMES = setOf("http", "https")
+    }
+}
+
+object SocksProxyManager {
+    private val previousAuthenticator = Authenticator.getDefault()
+    private val mutableSettings =
+        MutableStateFlow(
+            SocksProxySettings(
+                enabled = false,
+                version = 5,
+                host = "",
+                port = "",
+                username = "",
+                password = "",
+            ),
+        )
+
+    val settings = mutableSettings.asStateFlow()
+    val proxySelector: ProxySelector = SocksProxySelector { mutableSettings.value }
+
+    private val authenticator =
+        object : Authenticator() {
+            override fun getPasswordAuthentication(): PasswordAuthentication? {
+                val current = mutableSettings.value
+                if (requestingProtocol.startsWith("SOCKS", ignoreCase = true)) {
+                    return PasswordAuthentication(current.username, current.password.toCharArray())
+                }
+
+                return null
+            }
+        }
+
+    fun update(settings: SocksProxySettings) {
+        mutableSettings.value = settings
+
+        if (settings.enabled) {
+            System.setProperty("socksProxyVersion", settings.version.toString())
+            Authenticator.setDefault(authenticator)
+        } else {
+            System.clearProperty("socksProxyVersion")
+            Authenticator.setDefault(previousAuthenticator)
+        }
+    }
+
+    fun currentProxy(): Proxy = mutableSettings.value.asProxy()
+}

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -25,6 +25,7 @@ import org.cef.CefSettings.LogSeverity
 import org.cef.SystemBootstrap
 import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.generated.BuildConfig
+import suwayomi.tachidesk.server.network.SocksProxyManager
 import suwayomi.tachidesk.server.serverConfig
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -126,6 +127,9 @@ object CEFManager {
                                     "--change-stack-guard-on-fork=disable",
                                 ),
                             )
+                            SocksProxyManager.settings.value.proxyUrl()?.let { proxyUrl ->
+                                appArgsAsList.add("--proxy-server=$proxyUrl")
+                            }
                             cefSettings.apply {
                                 windowless_rendering_enabled = true
                                 cache_path = (Path(applicationDirs.cacheDir) / "kcef").absolutePathString()
@@ -203,7 +207,12 @@ object CEFManager {
             throw CefException("Failed to create installation directory")
         }
 
-        val client = OkHttpClient.Builder().followRedirects(true).build()
+        val client =
+            OkHttpClient
+                .Builder()
+                .proxySelector(SocksProxyManager.proxySelector)
+                .followRedirects(true)
+                .build()
         val request =
             Request
                 .Builder()

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/WebInterfaceManager.kt
@@ -53,6 +53,7 @@ import suwayomi.tachidesk.graphql.types.WebUIUpdateInfo
 import suwayomi.tachidesk.graphql.types.WebUIUpdateStatus
 import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.generated.BuildConfig
+import suwayomi.tachidesk.server.network.SocksProxyManager
 import suwayomi.tachidesk.server.serverConfig
 import suwayomi.tachidesk.server.util.ExitCode.WebUISetupFailure
 import suwayomi.tachidesk.util.HAScheduler
@@ -779,7 +780,11 @@ object WebInterfaceManager {
 
         zipFile.outputStream().use { webUIZipFileOut ->
 
-            val connection = URI.create(url).toURL().openConnection() as HttpURLConnection
+            val connection =
+                URI
+                    .create(url)
+                    .toURL()
+                    .openConnection(SocksProxyManager.currentProxy()) as HttpURLConnection
             connection.connect()
             val contentLength = connection.contentLength
 

--- a/server/src/test/kotlin/eu/kanade/tachiyomi/network/interceptor/FlareSolverSessionManagerTest.kt
+++ b/server/src/test/kotlin/eu/kanade/tachiyomi/network/interceptor/FlareSolverSessionManagerTest.kt
@@ -1,0 +1,263 @@
+package eu.kanade.tachiyomi.network.interceptor
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import eu.kanade.tachiyomi.network.HttpException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FlareSolverSessionManagerTest {
+    @Test
+    fun `first use replaces an existing session with a proxied session`() =
+        runTest {
+            val commands = mutableListOf<CFClearance.FlareSolverRequest>()
+            val manager = FlareSolverSessionManager()
+
+            manager.ensure(settings()) { _, request ->
+                commands += request
+                when (request.cmd) {
+                    "sessions.list" -> response(sessions = listOf("suwayomi"))
+                    else -> response()
+                }
+            }
+
+            assertEquals(
+                listOf("sessions.list", "sessions.destroy", "sessions.create"),
+                commands.map { it.cmd },
+            )
+            assertEquals("socks5://proxy.example:1080", commands.last().proxy?.url)
+        }
+
+    @Test
+    fun `subsequent use keeps the configured session and recovers after solver restart`() =
+        runTest {
+            val commands = mutableListOf<CFClearance.FlareSolverRequest>()
+            var sessionExists = false
+            val manager = FlareSolverSessionManager()
+            val send: suspend (String, CFClearance.FlareSolverRequest) -> CFClearance.FlareSolverCommandResponse =
+                { _, request ->
+                    commands += request
+                    when (request.cmd) {
+                        "sessions.list" -> {
+                            response(sessions = emptyList())
+                        }
+
+                        "sessions.create" -> {
+                            val message = if (sessionExists) "Session already exists." else "Session created successfully."
+                            sessionExists = true
+                            response(message = message)
+                        }
+
+                        else -> {
+                            response()
+                        }
+                    }
+                }
+
+            manager.ensure(settings(), send)
+            manager.ensure(settings(), send)
+            sessionExists = false
+            manager.ensure(settings(), send)
+
+            assertEquals(
+                listOf("sessions.list", "sessions.create", "sessions.create", "sessions.create"),
+                commands.map { it.cmd },
+            )
+        }
+
+    @Test
+    fun `proxy changes recreate only the configured session`() =
+        runTest {
+            val commands = mutableListOf<CFClearance.FlareSolverRequest>()
+            val manager = FlareSolverSessionManager()
+
+            manager.ensure(settings()) { _, request ->
+                commands += request
+                if (request.cmd == "sessions.list") response(sessions = emptyList()) else response()
+            }
+            manager.ensure(settings(proxyUrl = "socks5://new.example:1080")) { _, request ->
+                commands += request
+                if (request.cmd == "sessions.list") {
+                    response(sessions = listOf("suwayomi", "another-client"))
+                } else {
+                    response()
+                }
+            }
+
+            assertEquals(1, commands.count { it.cmd == "sessions.destroy" })
+            assertEquals("suwayomi", commands.single { it.cmd == "sessions.destroy" }.session)
+            assertEquals("socks5://new.example:1080", commands.last().proxy?.url)
+        }
+
+    @Test
+    fun `expired session is recreated on the next use without background work`() =
+        runTest {
+            var now = 0L
+            val commands = mutableListOf<CFClearance.FlareSolverRequest>()
+            val manager = FlareSolverSessionManager { now }
+            val send: suspend (String, CFClearance.FlareSolverRequest) -> CFClearance.FlareSolverCommandResponse =
+                { _, request ->
+                    commands += request
+                    if (request.cmd == "sessions.list") response(sessions = listOf("suwayomi")) else response()
+                }
+
+            manager.ensure(settings(ttlMinutes = 10), send)
+            now = 11L * 60 * 1_000_000_000
+            manager.ensure(settings(ttlMinutes = 10), send)
+
+            assertEquals(2, commands.count { it.cmd == "sessions.destroy" })
+            assertEquals(2, commands.count { it.cmd == "sessions.create" })
+        }
+
+    @Test
+    fun `server error recreates the session and retries the request once`() =
+        runTest {
+            val solver = FakeSessionCommands()
+            var requestAttempts = 0
+            val manager = FlareSolverSessionManager()
+
+            val result =
+                manager.execute(settings(), solver::send, retryOnFailure = true) {
+                    requestAttempts++
+                    if (requestAttempts == 1) throw HttpException(500)
+                    "success"
+                }
+
+            assertEquals("success", result)
+            assertEquals(2, requestAttempts)
+            assertEquals(
+                listOf("sessions.list", "sessions.create", "sessions.list", "sessions.destroy", "sessions.create"),
+                solver.commands.map { it.cmd },
+            )
+        }
+
+    @Test
+    fun `server error invalidates the session without retrying non-idempotent requests`() =
+        runTest {
+            val solver = FakeSessionCommands()
+            var requestAttempts = 0
+            val manager = FlareSolverSessionManager()
+
+            assertFailsWith<HttpException> {
+                manager.execute(settings(), solver::send, retryOnFailure = false) {
+                    requestAttempts++
+                    throw HttpException(500)
+                }
+            }
+
+            assertEquals(1, requestAttempts)
+            assertEquals(false, solver.sessionExists)
+            assertEquals(
+                listOf("sessions.list", "sessions.create", "sessions.list", "sessions.destroy"),
+                solver.commands.map { it.cmd },
+            )
+        }
+
+    @Test
+    fun `failed retry invalidates the recreated session`() =
+        runTest {
+            val solver = FakeSessionCommands()
+            var requestAttempts = 0
+            val manager = FlareSolverSessionManager()
+
+            val error =
+                assertFailsWith<HttpException> {
+                    manager.execute(settings(), solver::send, retryOnFailure = true) {
+                        requestAttempts++
+                        throw HttpException(500)
+                    }
+                }
+
+            assertEquals(2, requestAttempts)
+            assertEquals(false, solver.sessionExists)
+            assertEquals(1, error.suppressed.size)
+            assertEquals(
+                listOf(
+                    "sessions.list",
+                    "sessions.create",
+                    "sessions.list",
+                    "sessions.destroy",
+                    "sessions.create",
+                    "sessions.list",
+                    "sessions.destroy",
+                ),
+                solver.commands.map { it.cmd },
+            )
+        }
+
+    @Test
+    fun `non-server error does not recreate or retry the session`() =
+        runTest {
+            val commands = mutableListOf<CFClearance.FlareSolverRequest>()
+            var requestAttempts = 0
+            val manager = FlareSolverSessionManager()
+
+            assertFailsWith<HttpException> {
+                manager.execute(
+                    settings(),
+                    { _, request ->
+                        commands += request
+                        if (request.cmd == "sessions.list") response(sessions = emptyList()) else response()
+                    },
+                    retryOnFailure = true,
+                ) {
+                    requestAttempts++
+                    throw HttpException(502)
+                }
+            }
+
+            assertEquals(1, requestAttempts)
+            assertEquals(listOf("sessions.list", "sessions.create"), commands.map { it.cmd })
+        }
+
+    private fun settings(
+        proxyUrl: String = "socks5://proxy.example:1080",
+        ttlMinutes: Int = 30,
+    ) = FlareSolverSessionSettings(
+        url = "http://localhost:8191/v1",
+        name = "suwayomi",
+        ttlMinutes = ttlMinutes,
+        proxy = CFClearance.FlareSolverProxy(proxyUrl),
+    )
+
+    private fun response(
+        message: String = "",
+        sessions: List<String>? = null,
+    ) = CFClearance.FlareSolverCommandResponse(
+        status = "ok",
+        message = message,
+        sessions = sessions,
+    )
+
+    private class FakeSessionCommands {
+        val commands = mutableListOf<CFClearance.FlareSolverRequest>()
+        var sessionExists = false
+
+        suspend fun send(
+            url: String,
+            request: CFClearance.FlareSolverRequest,
+        ): CFClearance.FlareSolverCommandResponse {
+            commands += request
+            return when (request.cmd) {
+                "sessions.list" -> response(sessions = if (sessionExists) listOf("suwayomi") else emptyList())
+                "sessions.create" -> response().also { sessionExists = true }
+                "sessions.destroy" -> response().also { sessionExists = false }
+                else -> response()
+            }
+        }
+
+        private fun response(sessions: List<String>? = null) =
+            CFClearance.FlareSolverCommandResponse(
+                status = "ok",
+                message = "",
+                sessions = sessions,
+            )
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/server/network/SocksProxyManagerTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/server/network/SocksProxyManagerTest.kt
@@ -1,0 +1,100 @@
+package suwayomi.tachidesk.server.network
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SocksProxyManagerTest {
+    @Test
+    fun `disabled proxy selects a direct connection`() {
+        val selector = SocksProxySelector { settings(enabled = false) }
+
+        assertEquals(listOf(Proxy.NO_PROXY), selector.select(URI("https://example.com")))
+    }
+
+    @Test
+    fun `enabled proxy selects the configured unresolved address`() {
+        val selector = SocksProxySelector { settings() }
+
+        val proxy = selector.select(URI("https://example.com")).single()
+        val address = proxy.address() as InetSocketAddress
+
+        assertEquals(Proxy.Type.SOCKS, proxy.type())
+        assertEquals("proxy.example", address.hostString)
+        assertEquals(1080, address.port)
+        assertTrue(address.isUnresolved)
+    }
+
+    @Test
+    fun `selector reads updated settings for every request`() {
+        var settings = settings(enabled = false)
+        val selector = SocksProxySelector { settings }
+
+        assertEquals(Proxy.NO_PROXY, selector.select(URI("https://example.com")).single())
+
+        settings = settings()
+        assertEquals(Proxy.Type.SOCKS, selector.select(URI("https://example.com")).single().type())
+    }
+
+    @Test
+    fun `loopback traffic remains direct`() {
+        val selector = SocksProxySelector { settings() }
+
+        listOf("localhost", "127.0.0.1", "[::1]").forEach { host ->
+            assertEquals(Proxy.NO_PROXY, selector.select(URI("http://$host:8191/v1")).single())
+        }
+    }
+
+    @Test
+    fun `invalid enabled proxy fails closed`() {
+        val selector = SocksProxySelector { settings(port = "invalid") }
+
+        assertFailsWith<IllegalStateException> {
+            selector.select(URI("https://example.com"))
+        }
+    }
+
+    @Test
+    fun `proxy settings build browser proxy URLs`() {
+        val enabled = settings(version = 4)
+        val disabled = settings(enabled = false)
+
+        assertEquals("socks4://proxy.example:1080", enabled.proxyUrl())
+        assertEquals(null, disabled.proxyUrl())
+        assertTrue(enabled.isValid)
+        assertFalse(settings(port = "70000").isValid)
+        assertFailsWith<IllegalStateException> { settings(port = "70000").proxyUrl() }
+    }
+
+    @Test
+    fun `IPv6 proxy host is bracketed in URLs`() {
+        val settings = settings().copy(host = "2001:db8::1")
+
+        assertEquals("socks5://[2001:db8::1]:1080", settings.proxyUrl())
+    }
+
+    private fun settings(
+        enabled: Boolean = true,
+        version: Int = 5,
+        port: String = "1080",
+    ) = SocksProxySettings(
+        enabled = enabled,
+        version = version,
+        host = "proxy.example",
+        port = port,
+        username = "",
+        password = "",
+    )
+}


### PR DESCRIPTION
## Summary

- Apply the configured SOCKS proxy to OkHttp, CEF, and WebUI downloads.
- Keep loopback, database, and FlareSolverr control traffic direct.
- Create and recover named FlareSolverr sessions with the same proxy.
- Fail closed when enabled proxy settings are invalid.

CEF reads the proxy when it initializes. Changing its proxy settings requires a server restart.

## Validation

- `./gradlew ktlintCheck`
- `./gradlew :server:shadowJar`
- `./gradlew :server:test`

Fixes #1827
Fixes #2198
Fixes #2023
