### PR TITLE
ref(server): send full `POST` body in `CloudflareInterceptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**SystemTray**) Disable DorkBox update requests
 - (**GraphQL**) Updated GraphiQL GraphQL Playground
 - (**Downloader**) Skip LocalSource downloading
+- (**Cloudflare/flaresolverr**) Send full `POST` json body to flaresolverr instead of empty string
 
 ### Fixed
 - (**Tracker**) Fix Shikimori

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -342,8 +342,7 @@ object CFClearance {
                                                             Buffer()
                                                                 .also { body.writeTo(it) }
                                                                 .readUtf8()
-                                                        }
-                                                        .orEmpty()
+                                                        }.orEmpty()
                                                 } else {
                                                     null
                                                 },

--- a/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -16,7 +16,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Cookie
-import okhttp3.FormBody
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -338,17 +337,13 @@ object CFClearance {
                                             maxTimeout = timeout.inWholeMilliseconds.toInt(),
                                             postData =
                                                 if (originalRequest.method == "POST") {
-                                                    when (val body = originalRequest.body) {
-                                                        is FormBody -> {
+                                                    originalRequest.body
+                                                        ?.let { body ->
                                                             Buffer()
                                                                 .also { body.writeTo(it) }
                                                                 .readUtf8()
                                                         }
-
-                                                        else -> {
-                                                            ""
-                                                        }
-                                                    }
+                                                        .orEmpty()
                                                 } else {
                                                     null
                                                 },


### PR DESCRIPTION
Instead of sending an empty string. This doesn't affect current behaviour, but allows the use other implementations of the flaresolverr API that accept json in the POST requests, so a few extra extensions that require POST in sources with CF protection.


<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
