### PR TITLE
Handle unsupported source search

### DIFF
--- a/server/src/main/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/server/src/main/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -108,4 +108,19 @@ interface Source {
     fun fetchPageList(chapter: SChapter): Observable<List<Page>> = throw UnsupportedOperationException()
 }
 
+suspend fun Source.searchManga(
+    page: Int,
+    query: String,
+    filters: FilterList,
+): MangasPage =
+    try {
+        getSearchManga(page, query, filters)
+    } catch (e: UnsupportedOperationException) {
+        throw SearchNotSupportedException(e)
+    }
+
+class SearchNotSupportedException(
+    cause: UnsupportedOperationException,
+) : IllegalArgumentException("Search not supported by this source", cause)
+
 // fun Source.icon(): Drawable? = Injekt.get<ExtensionManager>().getAppIconForSource(this)

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SourceMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/SourceMutation.kt
@@ -7,6 +7,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
 import androidx.preference.SwitchPreferenceCompat
+import eu.kanade.tachiyomi.source.searchManga
 import org.jetbrains.exposed.v1.core.LikePattern
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
@@ -265,7 +266,7 @@ class SourceMutation {
             val mangasPage =
                 when (type) {
                     FetchSourceMangaType.SEARCH -> {
-                        source.getSearchManga(
+                        source.searchManga(
                             page = page,
                             query = query.orEmpty(),
                             filters = updateFilterList(source, filters),

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLServer.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/server/TachideskGraphQLServer.kt
@@ -10,6 +10,8 @@ package suwayomi.tachidesk.graphql.server
 import com.expediagroup.graphql.generator.execution.FlowSubscriptionExecutionStrategy
 import com.expediagroup.graphql.server.execution.GraphQLRequestHandler
 import com.expediagroup.graphql.server.execution.GraphQLServer
+import com.expediagroup.graphql.server.extensions.toGraphQLError
+import eu.kanade.tachiyomi.source.SearchNotSupportedException
 import graphql.ExceptionWhileDataFetching
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
@@ -58,8 +60,19 @@ class TachideskGraphQLServer(
                     val exception = handlerParameters.exception
                     val sourceLocation = handlerParameters.sourceLocation
                     val path = handlerParameters.path
+                    val searchNotSupported =
+                        generateSequence(exception) { it.cause }
+                            .filterIsInstance<SearchNotSupportedException>()
+                            .firstOrNull()
 
                     logger.error(exception) { "GraphQL execution failed due to" }
+
+                    if (searchNotSupported != null) {
+                        return@future DataFetcherExceptionHandlerResult
+                            .newResult()
+                            .error(searchNotSupported.toGraphQLError())
+                            .build()
+                    }
 
                     val error =
                         ExceptionWhileDataFetching(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Search.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Search.kt
@@ -10,6 +10,7 @@ package suwayomi.tachidesk.manga.impl
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.searchManga
 import io.javalin.json.JsonMapper
 import io.javalin.json.fromJsonString
 import kotlinx.serialization.Serializable
@@ -25,7 +26,7 @@ object Search {
         pageNum: Int,
     ): PagedMangaListDataClass {
         val source = getSourceOrStub(sourceId)
-        val searchManga = source.getSearchManga(pageNum, searchTerm, getFilterListOf(source))
+        val searchManga = source.searchManga(pageNum, searchTerm, getFilterListOf(source))
         return searchManga.processEntries(sourceId)
     }
 
@@ -36,7 +37,7 @@ object Search {
     ): PagedMangaListDataClass {
         val source = getSourceOrStub(sourceId)
         val filterList = if (filter.filter != null) buildFilterList(sourceId, filter.filter) else source.getFilterList()
-        val searchManga = source.getSearchManga(pageNum, filter.searchTerm ?: "", filterList)
+        val searchManga = source.searchManga(pageNum, filter.searchTerm ?: "", filterList)
         return searchManga.processEntries(sourceId)
     }
 

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/SearchTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/SearchTest.kt
@@ -7,6 +7,7 @@ package suwayomi.tachidesk.manga.impl
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import eu.kanade.tachiyomi.source.SearchNotSupportedException
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -33,6 +34,7 @@ import suwayomi.tachidesk.test.createSMangas
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SearchTest : ApplicationTest() {
@@ -67,6 +69,27 @@ class SearchTest : ApplicationTest() {
             }
 
         assertEquals(mangasCount, searchResults.mangaList.size, "should return all the mangas")
+    }
+
+    @Test
+    fun `unsupported search returns a clear error`() {
+        val unsupportedSource =
+            object : StubSource(2L) {
+                override suspend fun getSearchManga(
+                    page: Int,
+                    query: String,
+                    filters: FilterList,
+                ): MangasPage = throw UnsupportedOperationException()
+            }
+        registerSource(unsupportedSource.id to unsupportedSource)
+
+        val error =
+            assertFailsWith<SearchNotSupportedException> {
+                runBlocking { sourceSearch(unsupportedSource.id, "manga", 1) }
+            }
+
+        assertEquals("Search not supported by this source", error.message)
+        unregisterSource(unsupportedSource.id)
     }
 
     @AfterAll


### PR DESCRIPTION
I've noticed several sources don't support search, and in the UI it looks kind of ugly/like an error exposing the stack trace

This PR makes it return a much better error message.

<img width="279" height="107" alt="image" src="https://github.com/user-attachments/assets/3388c611-c280-4b37-8c51-5bf6dfd01f14" />
