### PR TITLE
Fix server not stopping on TERM signal when WebView enabled (Issue #2158)

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/JavalinSetup.kt
@@ -45,6 +45,7 @@ import suwayomi.tachidesk.server.user.getUserFromContext
 import suwayomi.tachidesk.server.user.getUserFromWsContext
 import suwayomi.tachidesk.server.util.Browser
 import suwayomi.tachidesk.server.util.ServerSubpath
+import suwayomi.tachidesk.server.util.ShutdownManager
 import suwayomi.tachidesk.server.util.WebInterfaceManager
 import java.io.IOException
 import java.net.Inet4Address
@@ -61,6 +62,7 @@ object JavalinSetup {
     private val logger = KotlinLogging.logger {}
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var javalinApp: Javalin? = null
 
     fun <T> future(block: suspend CoroutineScope.() -> T): CompletableFuture<T> = scope.future(block = block)
 
@@ -170,10 +172,32 @@ object JavalinSetup {
                 }
             }
 
-        // when JVM is prompted to shutdown, stop javalin gracefully
+        javalinApp = app
+
+        // Register Javalin shutdown with ShutdownManager for coordinated shutdown
+        ShutdownManager.registerShutdownAction(
+            name = "Javalin Server",
+            timeout = 10.seconds,
+        ) {
+            logger.info { "Stopping Javalin..." }
+            try {
+                app.stop()
+                logger.info { "Javalin stopped successfully" }
+            } catch (e: Exception) {
+                logger.error(e) { "Error stopping Javalin" }
+            }
+        }
+
+        // Also keep a runtime shutdown hook as a fallback
         Runtime.getRuntime().addShutdownHook(
             thread(start = false) {
-                app.stop()
+                if (!ShutdownManager.isShuttingDown()) {
+                    try {
+                        app.stop()
+                    } catch (e: Exception) {
+                        logger.error(e) { "Error stopping Javalin in shutdown hook" }
+                    }
+                }
             },
         )
     }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.cef.network.CefCookieManager
 import org.koin.core.context.startKoin
@@ -53,6 +54,7 @@ import suwayomi.tachidesk.server.util.AppMutex.handleAppMutex
 import suwayomi.tachidesk.server.util.CEFManager
 import suwayomi.tachidesk.server.util.ConfigTypeRegistration
 import suwayomi.tachidesk.server.util.ExitCode
+import suwayomi.tachidesk.server.util.ShutdownManager
 import suwayomi.tachidesk.server.util.SystemTray
 import suwayomi.tachidesk.server.util.shutdownApp
 import uy.kohesive.injekt.Injekt
@@ -73,6 +75,7 @@ import java.net.Authenticator
 import java.net.PasswordAuthentication
 import java.security.Security
 import java.util.Locale
+import kotlin.concurrent.thread
 
 private val logger = KotlinLogging.logger {}
 
@@ -532,4 +535,32 @@ fun applicationSetup() {
         },
         ignoreInitialValue = false,
     )
+
+    // Setup proper shutdown handling for graceful termination
+    setupShutdownHandling()
+}
+
+/**
+ * Setup shutdown handling to ensure graceful termination when receiving SIGTERM/SIGINT.
+ * This ensures CEF and other resources are properly cleaned up on first signal.
+ */
+private fun setupShutdownHandling() {
+    // Register the main shutdown hook that will trigger coordinated shutdown
+    Runtime.getRuntime().addShutdownHook(
+        thread(start = false, name = "ShutdownHook") {
+            if (!ShutdownManager.isShuttingDown()) {
+                logger.info { "Shutdown signal received, initiating graceful shutdown..." }
+                // Use runBlocking to convert suspend to blocking in the shutdown hook
+                try {
+                    kotlinx.coroutines.runBlocking {
+                        ShutdownManager.gracefulShutdown()
+                    }
+                } catch (e: Exception) {
+                    logger.error(e) { "Error during graceful shutdown" }
+                }
+            }
+        },
+    )
+
+    logger.debug { "Shutdown handling initialized" }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -39,6 +39,7 @@ import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFilePermission
 import kotlin.concurrent.thread
 import kotlin.io.path.ExperimentalPathApi
+import kotlin.time.Duration.Companion.seconds
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.absolutePathString
@@ -77,16 +78,44 @@ object CEFManager {
         scope.launch {
             serverConfig.subscribeTo(serverConfig.kcefEnabled, CEFManager::initAsync, ignoreInitialValue = false)
 
+            // Register CEF shutdown with the centralized shutdown manager
+            ShutdownManager.registerShutdownAction(
+                name = "CEF Disposal",
+                timeout = 5.seconds,
+            ) {
+                disposeCef()
+            }
+
+            // Also add a runtime shutdown hook for emergencies
             Runtime.getRuntime().addShutdownHook(
                 thread(start = false) {
-                    CefHelper.cefApp.value.getOrNull()?.let {
-                        logger.debug { "Shutting down CEF" }
-                        it.dispose()
-                        logger.debug { "CEF shutdown complete" }
+                    try {
+                        CefHelper.cefApp.value.getOrNull()?.let {
+                            logger.debug { "Emergency CEF disposal during shutdown hook" }
+                            it.dispose()
+                            logger.debug { "CEF emergency disposal complete" }
+                        }
+                    } catch (e: Exception) {
+                        logger.error(e) { "Error during emergency CEF disposal" }
                     }
                 },
             )
         }
+
+    /**
+     * Safely dispose of CEF resources
+     */
+    private suspend fun disposeCef() {
+        try {
+            CefHelper.cefApp.value.getOrNull()?.let { cefApp ->
+                logger.info { "Disposing CEF..." }
+                cefApp.dispose()
+                logger.info { "CEF disposed successfully" }
+            }
+        } catch (e: Exception) {
+            logger.warn(e) { "Error disposing CEF" }
+        }
+    }
 
     private suspend fun initAsync(): Unit =
         try {

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/ShutdownManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/ShutdownManager.kt
@@ -1,0 +1,137 @@
+package suwayomi.tachidesk.server.util
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+private val logger = KotlinLogging.logger {}
+
+object ShutdownManager {
+    private val isShuttingDown = AtomicBoolean(false)
+    private val shutdownActions = mutableListOf<ShutdownAction>()
+    private val shutdownLock = Object()
+
+    data class ShutdownAction(
+        val name: String,
+        val action: suspend () -> Unit,
+        val timeout: Duration = 10.seconds,
+    )
+
+    /**
+     * Register a shutdown action that will be executed during graceful shutdown.
+     * Actions are executed in the order they were registered.
+     */
+    fun registerShutdownAction(
+        name: String,
+        timeout: Duration = 10.seconds,
+        action: suspend () -> Unit,
+    ) {
+        synchronized(shutdownLock) {
+            if (isShuttingDown.get()) {
+                logger.warn { "Attempted to register shutdown action '$name' after shutdown already started" }
+                return
+            }
+            shutdownActions.add(ShutdownAction(name, action, timeout))
+        }
+    }
+
+    /**
+     * Perform graceful shutdown with coordinated cleanup of all registered components.
+     * Actions are executed in reverse order (LIFO).
+     * If shutdown takes longer than totalTimeout, forces exit.
+     */
+    suspend fun gracefulShutdown(totalTimeout: Duration = 30.seconds) {
+        if (!isShuttingDown.compareAndSet(false, true)) {
+            logger.info { "Shutdown already in progress" }
+            return
+        }
+
+        logger.info { "Starting graceful shutdown..." }
+
+        val startTime = System.currentTimeMillis()
+        val totalTimeoutMs = totalTimeout.inWholeMilliseconds
+        val actionsToExecute = synchronized(shutdownLock) {
+            shutdownActions.asReversed().toList()
+        }
+
+        // Execute actions in reverse order (LIFO)
+        for (shutdownAction in actionsToExecute) {
+            val elapsed = System.currentTimeMillis() - startTime
+            val remainingTime = totalTimeoutMs - elapsed
+
+            if (remainingTime <= 0) {
+                logger.warn { "Shutdown timeout exceeded, skipping remaining actions" }
+                break
+            }
+
+            try {
+                logger.info { "Executing shutdown action: ${shutdownAction.name}" }
+                val actionTimeoutMs = minOf(shutdownAction.timeout.inWholeMilliseconds, remainingTime)
+
+                val completed = executeWithTimeout(actionTimeoutMs) {
+                    shutdownAction.action()
+                }
+
+                if (completed) {
+                    logger.debug { "Shutdown action '${shutdownAction.name}' completed successfully" }
+                } else {
+                    logger.warn { "Shutdown action '${shutdownAction.name}' timed out" }
+                }
+            } catch (e: Exception) {
+                logger.error(e) { "Error during shutdown action '${shutdownAction.name}'" }
+            }
+        }
+
+        val totalElapsed = System.currentTimeMillis() - startTime
+        logger.info { "Graceful shutdown completed in ${totalElapsed}ms" }
+    }
+
+    /**
+     * Check if shutdown has been initiated
+     */
+    fun isShuttingDown(): Boolean = isShuttingDown.get()
+
+    /**
+     * Execute a suspend function with a timeout using a blocking thread
+     */
+    private fun executeWithTimeout(
+        timeoutMs: Long,
+        block: suspend () -> Unit,
+    ): Boolean {
+        return try {
+            var completed = false
+            var exception: Exception? = null
+
+            val actionThread = thread(start = false, name = "ShutdownAction") {
+                try {
+                    // Convert suspend function to blocking using runBlocking
+                    runBlocking {
+                        block()
+                    }
+                    completed = true
+                } catch (e: Exception) {
+                    exception = e
+                }
+            }
+
+            actionThread.start()
+            actionThread.join(timeoutMs)
+
+            if (actionThread.isAlive) {
+                logger.warn { "Action did not complete within timeout, thread still running" }
+                false
+            } else {
+                if (exception != null) {
+                    throw exception!!
+                }
+                completed
+            }
+        } catch (e: Exception) {
+            logger.error(e) { "Error executing action with timeout" }
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Server requires two TERM signals to stop when WebView (CEF) is enabled, instead of one.

## Root Cause

CEF spawns non-daemon threads that block JVM exit. Shutdown hooks weren't properly coordinating cleanup.

## Solution

Implemented a centralized shutdown coordination system that executes cleanup in proper order with timeouts. Components stop in reverse order (LIFO) with per-action timeouts and a total 30-second shutdown timeout.

Fixes #2158