### PR TITLE
Pause downloads during extension updates

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -60,6 +60,25 @@ import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
+internal class DownloadPauseController(
+    private val isStarted: () -> Boolean,
+    private val stop: suspend () -> Unit,
+    private val start: () -> Unit,
+) {
+    suspend fun <T> run(block: suspend () -> T): T {
+        val wasStarted = isStarted()
+
+        try {
+            stop()
+            return block()
+        } finally {
+            if (wasStarted) {
+                start()
+            }
+        }
+    }
+}
+
 @OptIn(FlowPreview::class)
 object DownloadManager {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -537,6 +556,14 @@ object DownloadManager {
         logger.debug { "start" }
 
         refreshDownloaders()
+    }
+
+    suspend fun <T> withDownloadsPaused(block: suspend () -> T): T {
+        return DownloadPauseController(
+            isStarted = { getStatus().status == Status.Started },
+            stop = ::stop,
+            start = ::start,
+        ).run(block)
     }
 
     suspend fun stop() {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadManager.kt
@@ -558,13 +558,12 @@ object DownloadManager {
         refreshDownloaders()
     }
 
-    suspend fun <T> withDownloadsPaused(block: suspend () -> T): T {
-        return DownloadPauseController(
+    suspend fun <T> withDownloadsPaused(block: suspend () -> T): T =
+        DownloadPauseController(
             isStarted = { getStatus().status == Status.Started },
             stop = ::stop,
             start = ::start,
         ).run(block)
-    }
 
     suspend fun stop() {
         logger.debug { "stop" }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -32,6 +32,7 @@ import org.jetbrains.exposed.v1.jdbc.statements.toExecutable
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.jetbrains.exposed.v1.jdbc.upsert
+import suwayomi.tachidesk.manga.impl.download.DownloadManager
 import suwayomi.tachidesk.manga.impl.util.AndroidManifestParser
 import suwayomi.tachidesk.manga.impl.util.PackageTools
 import suwayomi.tachidesk.manga.impl.util.PackageTools.EXTENSION_FEATURE
@@ -719,7 +720,9 @@ object Extension {
 
         logger.debug { "Updating $pkgName to ${targetExtension.versionName}" }
 
-        return installExtension(pkgName, true)
+        return DownloadManager.withDownloadsPaused {
+            installExtension(pkgName, true)
+        }
     }
 
     suspend fun getExtensionIcon(pkgName: String): Pair<InputStream, String> {

--- a/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadPauseControllerTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/manga/impl/download/DownloadPauseControllerTest.kt
@@ -1,0 +1,50 @@
+package suwayomi.tachidesk.manga.impl.download
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DownloadPauseControllerTest {
+    @Test
+    fun `restarts downloads after successful block when previously started`() =
+        runTest {
+            val calls = mutableListOf<String>()
+            val controller =
+                DownloadPauseController(
+                    isStarted = { true },
+                    stop = { calls += "stop" },
+                    start = { calls += "start" },
+                )
+
+            val result =
+                controller.run {
+                    calls += "block"
+                    "success"
+                }
+
+            assertEquals("success", result)
+            assertEquals(listOf("stop", "block", "start"), calls)
+        }
+
+    @Test
+    fun `does not restart downloads after failed block when previously stopped`() =
+        runTest {
+            val calls = mutableListOf<String>()
+            val controller =
+                DownloadPauseController(
+                    isStarted = { false },
+                    stop = { calls += "stop" },
+                    start = { calls += "start" },
+                )
+
+            assertFailsWith<IllegalStateException> {
+                controller.run {
+                    calls += "block"
+                    error("update failed")
+                }
+            }
+
+            assertEquals(listOf("stop", "block"), calls)
+        }
+}


### PR DESCRIPTION
## Summary

- Pause active downloads while updating extensions.
- Restore the queue only when it was running before the update.
- Add success and failure-path tests for pause/resume behavior.