### PR TITLE
Clean up JCEF JavaScript handlers on client disposal

### DIFF
--- a/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefHelper.kt
+++ b/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefHelper.kt
@@ -9,10 +9,13 @@ import org.cef.browser.CefFrame
 import org.cef.browser.CefMessageRouter
 import org.cef.callback.CefQueryCallback
 import org.cef.handler.CefMessageRouterHandlerAdapter
+import java.util.Collections
+import java.util.WeakHashMap
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.random.Random
 
 private val logger = KotlinLogging.logger {}
-private val jsHandler: MutableMap<CefClient, JsHandler> = mutableMapOf()
+private val jsHandler: MutableMap<CefClient, JsHandler> = Collections.synchronizedMap(WeakHashMap())
 
 fun CefBrowser.evaluateJavaScript(
     expression: String,
@@ -25,8 +28,13 @@ fun CefBrowser.dispose() {
     close(true)
 }
 
+fun CefClient.disposeWithJsHandler() {
+    jsHandler.remove(this)
+    dispose()
+}
+
 class JsHandler : CefMessageRouterHandlerAdapter {
-    private val handler: MutableMap<String, (String?) -> Unit> = mutableMapOf()
+    private val handler = ConcurrentHashMap<String, (String?) -> Unit>()
 
     constructor(client: CefClient) {
         val config = CefMessageRouter.CefMessageRouterConfig()

--- a/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
+++ b/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/webkit/KcefWebViewProvider.kt
@@ -606,7 +606,7 @@ class KcefWebViewProvider(
         browser?.close(true)
         browser?.dispose()
         browser = null
-        kcefClient?.dispose()
+        kcefClient?.disposeWithJsHandler()
         kcefClient = null
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/KcefWebView.kt
@@ -28,6 +28,7 @@ import org.cef.network.CefRequest
 import uy.kohesive.injekt.injectLazy
 import xyz.nulldev.androidcompat.webkit.CefHelper
 import xyz.nulldev.androidcompat.webkit.dispose
+import xyz.nulldev.androidcompat.webkit.disposeWithJsHandler
 import xyz.nulldev.androidcompat.webkit.evaluateJavaScript
 import java.awt.Component
 import java.awt.HeadlessException
@@ -296,7 +297,7 @@ class KcefWebView {
         browser?.close(true)
         browser?.dispose()
         browser = null
-        kcefClient?.dispose()
+        kcefClient?.disposeWithJsHandler()
         kcefClient = null
     }
 


### PR DESCRIPTION
## Summary

- Make shared JCEF JavaScript handler state thread-safe.
- Remove each client's handler entry before disposing it.

This prevents disposed clients and pending callbacks from being retained. Existing page loading, JavaScript errors, interface injection, resource interception, proxy behavior, and browser close behavior are unchanged.

## Validation

- `./gradlew ktlintCheck`
- `./gradlew -Pkotlin.daemon.jvmargs=-Xmx2g :server:shadowJar`
