### PR TITLE
Don't throw an exception when disabling CEF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**GraphQL**) Updated GraphiQL GraphQL Playground
 - (**Downloads**) Skip LocalSource downloading
 - (**Cloudflare/flaresolverr**) Send full `POST` json body to flaresolverr instead of empty string
+- (**Webview**) Don't throw an exception when disabling CEF
 
 ### Fixed
 - (**Tracker**) Fix Shikimori

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -93,7 +93,7 @@ object CEFManager {
             CefHelper.cefApp.value = Result.success(null)
 
             if (!serverConfig.kcefEnabled.value) {
-                logger.debug { "CEF is disabled" }
+                logger.info { "CEF is disabled" }
                 CefHelper.cefApp.value = Result.failure(CefException("CEF is disabled"))
                 return
             }

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/util/CEFManager.kt
@@ -93,7 +93,9 @@ object CEFManager {
             CefHelper.cefApp.value = Result.success(null)
 
             if (!serverConfig.kcefEnabled.value) {
-                throw CefException("CEF is disabled")
+                logger.debug { "CEF is disabled" }
+                CefHelper.cefApp.value = Result.failure(CefException("CEF is disabled"))
+                return
             }
 
             System.loadLibrary("jawt")


### PR DESCRIPTION
This was leading to scary-looking and misleading errors, which was a problem when trying to debug other issues:

```
17:44:56.776 [main] INFO de.neonew.exposed.migrations.RunMigrations -- Migrations finished successfully
17:44:56.893 [DefaultDispatcher-worker-10] INFO suwayomi.tachidesk.server.ServerSetup -- Socks Proxy changed - enabled=false address=: , username=[REDACTED], password=[REDACTED]
17:44:57.431 [DefaultDispatcher-worker-13] ERROR suwayomi.tachidesk.server.util.CEFManager -- Failed to set up CEF
suwayomi.tachidesk.server.util.CEFManager$CefException: CEF is disabled
        at suwayomi.tachidesk.server.util.CEFManager.initAsync(CEFManager.kt:96)
        at suwayomi.tachidesk.server.util.CEFManager.access$initAsync(CEFManager.kt:69)
        at suwayomi.tachidesk.server.util.CEFManager$init$1$1.invoke(CEFManager.kt:78)
        at suwayomi.tachidesk.server.util.CEFManager$init$1$1.invoke(CEFManager.kt:78)
        at suwayomi.tachidesk.server.ServerConfig$subscribeTo$2.invokeSuspend(ServerConfig.kt:1206)
        at suwayomi.tachidesk.server.ServerConfig$subscribeTo$2.invoke(ServerConfig.kt)
        at suwayomi.tachidesk.server.ServerConfig$subscribeTo$2.invoke(ServerConfig.kt)
        at suwayomi.tachidesk.server.ServerConfigKt$subscribeTo$1.invokeSuspend(ServerConfig.kt:86)
        at suwayomi.tachidesk.server.ServerConfigKt$subscribeTo$1.invoke(ServerConfig.kt)
        at suwayomi.tachidesk.server.ServerConfigKt$subscribeTo$1.invoke(ServerConfig.kt)
        at kotlinx.coroutines.flow.FlowKt__TransformKt$onEach$$inlined$unsafeTransform$1$2.emit(Emitters.kt:217)
        at kotlinx.coroutines.flow.StateFlowImpl.collect(StateFlow.kt:401)
        at kotlinx.coroutines.flow.ReadonlyStateFlow.collect(Share.kt)
        at kotlinx.coroutines.flow.FlowKt__TransformKt$onEach$$inlined$unsafeTransform$1.collect(SafeCollector.common.kt:112)
        at kotlinx.coroutines.flow.FlowKt__CollectKt.collect(Collect.kt:26)
        at kotlinx.coroutines.flow.FlowKt.collect(Unknown Source)
        at kotlinx.coroutines.flow.FlowKt__CollectKt$launchIn$1.invokeSuspend(Collect.kt:46)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:807)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
17:44:57.658 [main] INFO io.javalin.Javalin -- Static file handler added: StaticFileConfig(hostedPath=/, directory=/tmp/Tachidesk/webUI-serve, location=EXTERNAL, precompressMaxSize=-1, aliasCheck=suwayomi.tachidesk.server.util.WebInterfaceManager$$Lambda/0x000000003c505468@bbb6f0, headers={Cache-Control=max-age=0}, skipFileFunction=null, mimeTypes={}, roles=[]). File system location: 'file:///tmp/Tachidesk/webUI-serve/'
```

and now it becomes

```
13:22:54.193 [main] DEBUG de.neonew.exposed.migrations.RunMigrations -- Skipping migration version 62: PreventDuplicatedCategoryManga
13:22:54.193 [main] INFO de.neonew.exposed.migrations.RunMigrations -- Migrations finished successfully
13:22:54.239 [main] DEBUG com.zaxxer.hikari.pool.PoolBase -- Suwayomi-DB-Pool - Reset (autoCommit) on connection conn9: url=jdbc:h2:/home/eric/suwayomi-base/database user=
13:22:54.259 [DefaultDispatcher-worker-15] INFO suwayomi.tachidesk.server.ServerSetup -- Socks Proxy changed - enabled=false address=: , username=[REDACTED], password=[REDACTED]
13:22:54.419 [main] DEBUG suwayomi.tachidesk.util.HAScheduler -- schedule: Task "global-update" (421ac8c6-8b17-48ba-a1c7-30b82885919f) lastExecution= Sat Aug 15 13:21:38 UTC 2026 nextExecution= Sun Aug 16 01:21:38 UTC 2026 interval= 43200000, initialDelay= 43124070
13:22:54.457 [main] DEBUG suwayomi.tachidesk.util.HAScheduler -- scheduleCron: Task "backup" (4f0890c77fb532562b2fa4f7000001a00596f55f7ee81fc4) lastExecution= Sat Aug 15 00:00:00 UTC 2026 nextExecution= Sun Aug 16 00:00:00 UTC 2026 interval= 0 0 */1 * *
13:22:54.464 [DefaultDispatcher-worker-4] DEBUG suwayomi.tachidesk.manga.impl.download.DownloadManager -- restoreAndResumeDownloads: Restore download queue...
---> 13:22:54.480 [DefaultDispatcher-worker-3] DEBUG suwayomi.tachidesk.server.util.CEFManager -- CEF is disabled
13:22:54.539 [DefaultDispatcher-worker-6] DEBUG suwayomi.tachidesk.util.HAScheduler -- scheduleCron: Task "webUI-update-checker" (4f0890c77fb5325669669e08000001a00596f5c6767f1309) lastExecution= Sat Aug 15 00:00:00 UTC 2026 nextExecution= Sat Aug 15 23:00:00 UTC 2026 interval= 0 */23 * * *
13:22:55.710 [main] INFO io.javalin.Javalin -- Starting Javalin ...
```