### PR TITLE
config: Fix migration of extensionRepos to extensionStores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**WebView**) Fix that UI-WebView did not share user agent (background WebView unchanged)
 - (**WebView**) Fix authentication with subpath option
 - (**Category**) Fix library/category counts not matching the actual number of manga due to duplicate category-manga rows
+- (**Migration/Extension**) Fix `extensionRepos` setting not being migrated to `extensionStores`
 
 ## [v2.3.2243] - 2026-07-13
 

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -420,6 +420,7 @@ class ServerConfig(
         defaultValue = false,
         deprecated =
             SettingsRegistry.SettingDeprecated(
+                replaceWith = null,
                 message = "Removed - does not do anything",
             ),
     )

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -284,6 +284,7 @@ class ServerConfig(
         defaultValue = emptyList(),
         deprecated =
             SettingsRegistry.SettingDeprecated(
+                replaceWith = "extensionStores",
                 message = "Replaced with addExtensionStore and removeExtensionStore mutations",
                 migrateConfigValue = {
                     @Suppress("UNCHECKED_CAST")

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsRegistry.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/settings/SettingsRegistry.kt
@@ -13,7 +13,7 @@ object SettingsRegistry {
      * If neither is specified, the server will exit on startup due to being misconfigured.
      */
     data class SettingDeprecated(
-        val replaceWith: String? = null,
+        val replaceWith: String?,
         val message: String,
         /**
          * For cases which do not require custom config miration logic.


### PR DESCRIPTION
I noticed that extensions weren't getting picked up when doing the version bump.