### PR TITLE
fix: recover interrupted SyncYomi H2 migration

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0056_SyncYomi.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0056_SyncYomi.kt
@@ -162,61 +162,61 @@ class M0056_SyncYomi : SQLMigration() {
     // language=h2
     fun h2Query() =
         """
-        ALTER TABLE manga ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
-        ALTER TABLE manga ADD COLUMN is_syncing BOOLEAN NOT NULL DEFAULT FALSE;
-        ALTER TABLE manga ADD COLUMN last_modified_at BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE manga ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE manga ADD COLUMN IF NOT EXISTS is_syncing BOOLEAN NOT NULL DEFAULT FALSE;
+        ALTER TABLE manga ADD COLUMN IF NOT EXISTS last_modified_at BIGINT NOT NULL DEFAULT 0;
 
-        ALTER TABLE chapter ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
-        ALTER TABLE chapter ADD COLUMN is_syncing BOOLEAN NOT NULL DEFAULT FALSE;
-        ALTER TABLE chapter ADD COLUMN last_modified_at BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE chapter ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE chapter ADD COLUMN IF NOT EXISTS is_syncing BOOLEAN NOT NULL DEFAULT FALSE;
+        ALTER TABLE chapter ADD COLUMN IF NOT EXISTS last_modified_at BIGINT NOT NULL DEFAULT 0;
 
-        ALTER TABLE category ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
-        ALTER TABLE category ADD COLUMN uid BIGINT NOT NULL DEFAULT 0;
-        ALTER TABLE category ADD COLUMN is_syncing BOOLEAN NOT NULL DEFAULT FALSE;
-        ALTER TABLE category ADD COLUMN last_modified_at BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE category ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE category ADD COLUMN IF NOT EXISTS uid BIGINT NOT NULL DEFAULT 0;
+        ALTER TABLE category ADD COLUMN IF NOT EXISTS is_syncing BOOLEAN NOT NULL DEFAULT FALSE;
+        ALTER TABLE category ADD COLUMN IF NOT EXISTS last_modified_at BIGINT NOT NULL DEFAULT 0;
         
 
-        CREATE TRIGGER update_manga_version 
+        CREATE TRIGGER IF NOT EXISTS update_manga_version
         BEFORE UPDATE ON manga
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateMangaVersionTrigger";
         
-        CREATE TRIGGER update_chapter_and_manga_version
+        CREATE TRIGGER IF NOT EXISTS update_chapter_and_manga_version
         BEFORE UPDATE ON chapter
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateChapterAndMangaVersionTrigger";
         
-        CREATE TRIGGER update_manga_last_modified_at
+        CREATE TRIGGER IF NOT EXISTS update_manga_last_modified_at
         BEFORE UPDATE ON manga
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateMangaLastModifiedAtTrigger";
         
-        CREATE TRIGGER insert_manga_last_modified_at
+        CREATE TRIGGER IF NOT EXISTS insert_manga_last_modified_at
         BEFORE INSERT ON manga
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateMangaLastModifiedAtTrigger";
         
-        CREATE TRIGGER update_chapter_last_modified_at
+        CREATE TRIGGER IF NOT EXISTS update_chapter_last_modified_at
         BEFORE UPDATE ON chapter
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateChapterLastModifiedAtTrigger";
         
-        CREATE TRIGGER insert_chapter_last_modified_at
+        CREATE TRIGGER IF NOT EXISTS insert_chapter_last_modified_at
         BEFORE INSERT ON chapter
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateChapterLastModifiedAtTrigger";
         
-        CREATE TRIGGER insert_manga_category_update_version
+        CREATE TRIGGER IF NOT EXISTS insert_manga_category_update_version
         AFTER INSERT ON categorymanga
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.InsertMangaCategoryUpdateVersionTrigger";
         
-        CREATE TRIGGER insert_category_uid
+        CREATE TRIGGER IF NOT EXISTS insert_category_uid
         BEFORE INSERT ON category
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.InsertCategoryUidTrigger";
         
-        CREATE TRIGGER update_category_version
+        CREATE TRIGGER IF NOT EXISTS update_category_version
         BEFORE UPDATE ON category
         FOR EACH ROW
         CALL "suwayomi.tachidesk.server.database.trigger.UpdateCategoryVersionTrigger";

--- a/server/src/test/kotlin/suwayomi/tachidesk/server/database/migration/M0056SyncYomiTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/server/database/migration/M0056SyncYomiTest.kt
@@ -1,0 +1,79 @@
+package suwayomi.tachidesk.server.database
+
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import suwayomi.tachidesk.server.database.migration.M0056_SyncYomi
+import suwayomi.tachidesk.test.ApplicationTest
+import java.util.UUID
+
+class M0056SyncYomiTest {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun beforeAll() {
+            ApplicationTest.testingSetup()
+        }
+    }
+
+    @Test
+    fun `resumes an interrupted H2 migration`() {
+        val database = Database.connect("jdbc:h2:mem:syncyomi-${UUID.randomUUID()};DB_CLOSE_DELAY=-1", "org.h2.Driver")
+        val migration = M0056_SyncYomi()
+
+        transaction(database) {
+            exec("CREATE TABLE manga (id BIGINT PRIMARY KEY, url VARCHAR, description VARCHAR, in_library BOOLEAN)")
+            exec("CREATE TABLE chapter (id BIGINT PRIMARY KEY, read BOOLEAN, bookmark BOOLEAN, last_page_read INT, manga BIGINT)")
+            exec("CREATE TABLE category (id BIGINT PRIMARY KEY, name VARCHAR, sort_order INT)")
+            exec("CREATE TABLE categorymanga (id BIGINT PRIMARY KEY, manga BIGINT, category BIGINT)")
+            exec("ALTER TABLE manga ADD COLUMN version BIGINT NOT NULL DEFAULT 0")
+
+            migration.run()
+        }
+
+        transaction(database) {
+            migration.run()
+
+            assertEquals(
+                10,
+                exec(
+                    """
+                    SELECT COUNT(*)
+                    FROM INFORMATION_SCHEMA.COLUMNS
+                    WHERE (TABLE_NAME = 'MANGA' AND COLUMN_NAME IN ('VERSION', 'IS_SYNCING', 'LAST_MODIFIED_AT'))
+                       OR (TABLE_NAME = 'CHAPTER' AND COLUMN_NAME IN ('VERSION', 'IS_SYNCING', 'LAST_MODIFIED_AT'))
+                       OR (TABLE_NAME = 'CATEGORY' AND COLUMN_NAME IN ('VERSION', 'UID', 'IS_SYNCING', 'LAST_MODIFIED_AT'))
+                    """.trimIndent(),
+                ) { resultSet ->
+                    resultSet.next()
+                    resultSet.getInt(1)
+                },
+            )
+            assertEquals(
+                9,
+                exec(
+                    """
+                    SELECT COUNT(*)
+                    FROM INFORMATION_SCHEMA.TRIGGERS
+                    WHERE TRIGGER_NAME IN (
+                        'UPDATE_MANGA_VERSION',
+                        'UPDATE_CHAPTER_AND_MANGA_VERSION',
+                        'UPDATE_MANGA_LAST_MODIFIED_AT',
+                        'INSERT_MANGA_LAST_MODIFIED_AT',
+                        'UPDATE_CHAPTER_LAST_MODIFIED_AT',
+                        'INSERT_CHAPTER_LAST_MODIFIED_AT',
+                        'INSERT_MANGA_CATEGORY_UPDATE_VERSION',
+                        'INSERT_CATEGORY_UID',
+                        'UPDATE_CATEGORY_VERSION'
+                    )
+                    """.trimIndent(),
+                ) { resultSet ->
+                    resultSet.next()
+                    resultSet.getInt(1)
+                },
+            )
+        }
+    }
+}


### PR DESCRIPTION
A server interrupted while SyncYomi is migrating can leave some H2 schema changes applied while migration 56 remains unrecorded. Retrying then fails on the existing `VERSION` column.

The H2 migration now treats its columns and triggers as existing schema, so a retry completes the missing changes without replacing existing trigger definitions.

Verification:
- `./gradlew ktlintCheck :server:test --tests suwayomi.tachidesk.server.database.M0056SyncYomiTest`
- The focused test starts from the partial schema reported in #2233, reruns migration 56, and verifies all ten columns and nine triggers. It fails against the original unguarded DDL with `Duplicate column name "VERSION"`.

Fixes #2233