### PR TITLE
dex2jar: recompute stack frames

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
@@ -75,6 +75,7 @@ object PackageTools {
             .noCode(false)
             .skipExceptions(false)
             .dontSanitizeNames(true)
+            .computeFrames(true)
             .to(jarFile)
         if (handler.hasException()) {
             val rootPath = Path(applicationDirs.extensionsRoot)


### PR DESCRIPTION
This is necessary because extensions can have optimizations enabled that require stack changes.

Note that this is *not* sufficient to load SDK26 apks. This still needs ThexXTURBOXx/dex2jar#71 and ThexXTURBOXx/dex2jar#74 just to load properly.

Edit 2: Assets seem to be post-processed by Suwayomi, so cannot easily test that.