### PR TITLE
Add option to split tall images when downloading chapters

### DIFF
--- a/docs/Configuring-Suwayomi‐Server.md
+++ b/docs/Configuring-Suwayomi‐Server.md
@@ -80,6 +80,7 @@ server.excludeEntryWithUnreadChapters = true
 server.autoDownloadNewChaptersLimit = 0
 server.autoDownloadIgnoreReUploads = false
 server.downloadConversions = {}
+server.splitTallImages = false
 ```
 - `server.downloadAsCbz = true` configures Suwayomi to automatically compress chapters into CBZ.
 - `server.downloadsPath = ""` the path where manga downloads will be stored, if the value is empty, the default directory `downloads` inside [the data directory](https://github.com/Suwayomi/Suwayomi-Server/wiki/The-Data-Directory) will be used. If you are on Windows the slashes `\` needs to be doubled(`\\`) or replaced with `/`
@@ -114,6 +115,7 @@ server.downloadConversions = {}
   
   This is an example curl command for what Suwayomi-Server will send to the conversion url: `curl -X POST "http://localhost:9999/convert" -F "image=@cat.png;type=image/png"`
 - `server.serveConversions = {}` configures optional image conversions before serving the image to the client. It follows the same format as `server.downloadConversions`.
+- `server.splitTallImages = false` controls if Suwayomi should split overly tall "long strip" pages into several smaller images after downloading a chapter, to improve reader performance.
 
 
 ### Updater

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -219,14 +219,6 @@ class ServerConfig(
         defaultValue = false,
     )
 
-    val splitTallImages: MutableStateFlow<Boolean> by BooleanSetting(
-        protoNumber = 98,
-        group = SettingGroup.DOWNLOADER,
-        privacySafe = true,
-        defaultValue = false,
-        description = "Split long images into smaller pages after downloading a chapter",
-    )
-
     val downloadsPath: MutableStateFlow<String> by PathSetting(
         protoNumber = 16,
         group = SettingGroup.DOWNLOADER,
@@ -1145,6 +1137,14 @@ class ServerConfig(
                 specificType = "List<String>",
             ),
         description = "List of extension store index URLs",
+    )
+
+    val splitTallImages: MutableStateFlow<Boolean> by BooleanSetting(
+        protoNumber = 98,
+        group = SettingGroup.DOWNLOADER,
+        privacySafe = true,
+        defaultValue = false,
+        description = "Split long images into smaller pages after downloading a chapter",
     )
 
     /** ****************************************************************** **/

--- a/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
+++ b/server/server-config/src/main/kotlin/suwayomi/tachidesk/server/ServerConfig.kt
@@ -219,6 +219,14 @@ class ServerConfig(
         defaultValue = false,
     )
 
+    val splitTallImages: MutableStateFlow<Boolean> by BooleanSetting(
+        protoNumber = 98,
+        group = SettingGroup.DOWNLOADER,
+        privacySafe = true,
+        defaultValue = false,
+        description = "Split long images into smaller pages after downloading a chapter",
+    )
+
     val downloadsPath: MutableStateFlow<String> by PathSetting(
         protoNumber = 16,
         group = SettingGroup.DOWNLOADER,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -24,6 +24,7 @@ import suwayomi.tachidesk.manga.impl.util.getChapterCachePath
 import suwayomi.tachidesk.manga.impl.util.source.GetSource.getSourceOrNull
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse.getImageResponse
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil
+import suwayomi.tachidesk.manga.impl.util.storage.TallImageSplitter
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.PageTable
@@ -195,6 +196,7 @@ object Page {
         val conversions = serverConfig.downloadConversions.value
         if (conversions.isEmpty() || !downloadCacheFolder.exists()) {
             inputStream.close()
+            splitTallImageIfNeeded(downloadCacheFolder, fileName)
             return
         }
         val defaultConversion = conversions["default"]
@@ -203,6 +205,7 @@ object Page {
                 ?: defaultConversion
         if (conversion == null) {
             inputStream.close()
+            splitTallImageIfNeeded(downloadCacheFolder, fileName)
             return
         }
 
@@ -248,6 +251,15 @@ object Page {
         } catch (e: Exception) {
             logger.warn(e) { "Error while post-processing image" }
         }
+        splitTallImageIfNeeded(downloadCacheFolder, fileName)
+    }
+
+    private fun splitTallImageIfNeeded(
+        downloadCacheFolder: File,
+        fileName: String,
+    ) {
+        if (!serverConfig.splitTallImages.value) return
+        TallImageSplitter.splitIfNeeded(downloadCacheFolder, fileName)
     }
 
     private suspend fun convertImageResponse(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/TallImageSplitter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/TallImageSplitter.kt
@@ -10,7 +10,12 @@ package suwayomi.tachidesk.manga.impl.util.storage
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.awt.image.BufferedImage
 import java.io.File
+import javax.imageio.IIOImage
 import javax.imageio.ImageIO
+import javax.imageio.ImageReader
+import javax.imageio.ImageTypeSpecifier
+import javax.imageio.ImageWriteParam
+import javax.imageio.ImageWriter
 
 /**
  * Splits overly tall "long strip" page images into several smaller images, similar to Mihon's
@@ -19,26 +24,48 @@ import javax.imageio.ImageIO
 object TallImageSplitter {
     private val logger = KotlinLogging.logger {}
 
-    /** Target height (px) for each split part. There's no device screen to size against on the server, so this is fixed. */
-    private const val OPTIMAL_HEIGHT = 5000
+    /** Matches Mihon's `Bitmap.compress(JPEG, 100, ...)`, used only for the JPEG fallback path below */
+    private const val JPEG_QUALITY = 1.0f
 
-    /** -1 so that a height exactly equal to a multiple of [OPTIMAL_HEIGHT] doesn't produce an extra empty part */
-    internal fun calculatePartCount(imageHeight: Int): Int {
+    /**
+     * There's no device screen to size against on the server (Mihon targets `2 * screenHeight`),
+     * so instead the target height is scaled off the image's own width: the height a very tall
+     * 21:9 screen of that width would have, doubled just like Mihon's "2 screens" heuristic.
+     */
+    internal fun computeOptimalHeight(imageWidth: Int): Int {
+        require(imageWidth > 0) { "imageWidth must be positive" }
+        val singleScreenHeight = imageWidth * 21 / 9
+        return singleScreenHeight * 2
+    }
+
+    /** -1 so it doesn't try to split when imageHeight == optimalImageHeight */
+    internal fun calculatePartCount(
+        imageHeight: Int,
+        optimalImageHeight: Int,
+    ): Int {
         require(imageHeight > 0) { "imageHeight must be positive" }
-        return (imageHeight - 1) / OPTIMAL_HEIGHT + 1
+        require(optimalImageHeight > 0) { "optimalImageHeight must be positive" }
+        return (imageHeight - 1) / optimalImageHeight + 1
     }
 
     internal fun shouldSplit(
         imageWidth: Int,
         imageHeight: Int,
+        optimalImageHeight: Int,
     ): Boolean {
         require(imageWidth > 0) { "imageWidth must be positive" }
-        return imageHeight > imageWidth * 3 && calculatePartCount(imageHeight) > 1
+        return imageHeight > imageWidth * 3 && calculatePartCount(imageHeight, optimalImageHeight) > 1
     }
 
     /**
      * Looks for a page file named `fileName.*` inside [directory] and, if it's a tall enough
-     * still image, replaces it with several `fileName.NNN.jpg` files stacked in reading order.
+     * still image, replaces it with several `fileName.NNN` files stacked in reading order.
+     *
+     * Each part is written back in the exact same format as the source image whenever a writer
+     * for it is available on the classpath (PNG stays lossless, WEBP stays WEBP, etc.), using
+     * that format's own default encoding parameters. Only when no matching writer exists does
+     * this fall back to Mihon's own choice of JPEG at 100% quality - there's no reliable way to
+     * recover an arbitrary source JPEG's original quality setting either way.
      *
      * No-ops (and logs a warning) if anything goes wrong, leaving the original file untouched -
      * a failed split must never cause a page to go missing.
@@ -63,11 +90,13 @@ object TallImageSplitter {
 
                     val width = reader.getWidth(0)
                     val height = reader.getHeight(0)
-                    if (!shouldSplit(width, height)) return
+                    val optimalImageHeight = computeOptimalHeight(width)
+                    if (!shouldSplit(width, height, optimalImageHeight)) return
 
-                    val partCount = calculatePartCount(height)
+                    val partCount = calculatePartCount(height, optimalImageHeight)
                     val partHeight = height / partCount
                     val image = reader.read(0)
+                    val splitWriter = prepareWriter(image, reader)
 
                     val splitFiles = mutableListOf<File>()
                     try {
@@ -79,13 +108,17 @@ object TallImageSplitter {
                                 thisPartHeight += height - (topOffset + thisPartHeight)
                             }
 
-                            val splitFile = File(directory, "$fileName.${"%03d".format(index + 1)}.jpg")
-                            writeAsJpeg(image, topOffset, thisPartHeight, width, splitFile)
+                            val splitFile = File(directory, "$fileName.${"%03d".format(index + 1)}.${splitWriter.extension}")
+                            val subImage = image.getSubimage(0, topOffset, width, thisPartHeight)
+                            val outputImage = if (splitWriter.flattenAlpha) flattenToOpaqueRgb(subImage) else subImage
+                            writePart(splitWriter, outputImage, splitFile)
                             splitFiles.add(splitFile)
                         }
                     } catch (e: Exception) {
                         splitFiles.forEach { it.delete() }
                         throw e
+                    } finally {
+                        splitWriter.writer.dispose()
                     }
 
                     originalFile.delete()
@@ -98,22 +131,59 @@ object TallImageSplitter {
         }
     }
 
-    private fun writeAsJpeg(
-        source: BufferedImage,
-        topOffset: Int,
-        partHeight: Int,
-        width: Int,
+    private class SplitWriter(
+        val writer: ImageWriter,
+        val param: ImageWriteParam,
+        val extension: String,
+        val flattenAlpha: Boolean,
+    )
+
+    private fun prepareWriter(
+        image: BufferedImage,
+        reader: ImageReader,
+    ): SplitWriter {
+        val typeSpecifier = ImageTypeSpecifier.createFromRenderedImage(image)
+        val nativeWriters = ImageIO.getImageWriters(typeSpecifier, reader.formatName)
+        if (nativeWriters.hasNext()) {
+            val writer = nativeWriters.next()
+            val extension =
+                reader.originatingProvider
+                    ?.fileSuffixes
+                    ?.firstOrNull()
+                    ?.lowercase()
+                    ?: reader.formatName.lowercase()
+            return SplitWriter(writer, writer.defaultWriteParam, extension, flattenAlpha = false)
+        }
+
+        val jpegWriter = ImageIO.getImageWritersByFormatName("jpg").next()
+        val jpegParam =
+            jpegWriter.defaultWriteParam.apply {
+                if (canWriteCompressed()) {
+                    compressionMode = ImageWriteParam.MODE_EXPLICIT
+                    compressionQuality = JPEG_QUALITY
+                }
+            }
+        return SplitWriter(jpegWriter, jpegParam, "jpg", flattenAlpha = true)
+    }
+
+    private fun writePart(
+        splitWriter: SplitWriter,
+        image: BufferedImage,
         outFile: File,
     ) {
-        val subImage = source.getSubimage(0, topOffset, width, partHeight)
+        ImageIO.createImageOutputStream(outFile).use { output ->
+            splitWriter.writer.output = output
+            splitWriter.writer.write(null, IIOImage(image, null, null), splitWriter.param)
+        }
+    }
+
+    private fun flattenToOpaqueRgb(image: BufferedImage): BufferedImage {
         // JPEG doesn't support an alpha channel, so flatten onto an opaque RGB image regardless of source format
-        val rgbImage = BufferedImage(width, partHeight, BufferedImage.TYPE_INT_RGB)
+        val rgbImage = BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB)
         rgbImage.createGraphics().apply {
-            drawImage(subImage, 0, 0, null)
+            drawImage(image, 0, 0, null)
             dispose()
         }
-        if (!ImageIO.write(rgbImage, "jpg", outFile)) {
-            throw IllegalStateException("No JPEG writer available")
-        }
+        return rgbImage
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/TallImageSplitter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/TallImageSplitter.kt
@@ -1,0 +1,119 @@
+package suwayomi.tachidesk.manga.impl.util.storage
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * Splits overly tall "long strip" page images into several smaller images, similar to Mihon's
+ * "split tall images" reader/downloader feature (see eu.kanade.tachiyomi's ImageUtil.splitTallImage).
+ */
+object TallImageSplitter {
+    private val logger = KotlinLogging.logger {}
+
+    /** Target height (px) for each split part. There's no device screen to size against on the server, so this is fixed. */
+    private const val OPTIMAL_HEIGHT = 5000
+
+    /** -1 so that a height exactly equal to a multiple of [OPTIMAL_HEIGHT] doesn't produce an extra empty part */
+    internal fun calculatePartCount(imageHeight: Int): Int {
+        require(imageHeight > 0) { "imageHeight must be positive" }
+        return (imageHeight - 1) / OPTIMAL_HEIGHT + 1
+    }
+
+    internal fun shouldSplit(
+        imageWidth: Int,
+        imageHeight: Int,
+    ): Boolean {
+        require(imageWidth > 0) { "imageWidth must be positive" }
+        return imageHeight > imageWidth * 3 && calculatePartCount(imageHeight) > 1
+    }
+
+    /**
+     * Looks for a page file named `fileName.*` inside [directory] and, if it's a tall enough
+     * still image, replaces it with several `fileName.NNN.jpg` files stacked in reading order.
+     *
+     * No-ops (and logs a warning) if anything goes wrong, leaving the original file untouched -
+     * a failed split must never cause a page to go missing.
+     */
+    fun splitIfNeeded(
+        directory: File,
+        fileName: String,
+    ) {
+        val originalPath = ImageResponse.findFileNameStartingWith(directory.path, fileName) ?: return
+        val originalFile = File(originalPath)
+
+        try {
+            ImageIO.createImageInputStream(originalFile).use { imageInputStream ->
+                val readers = ImageIO.getImageReaders(imageInputStream)
+                if (!readers.hasNext()) return
+                val reader = readers.next()
+                try {
+                    reader.setInput(imageInputStream)
+
+                    // animated images (e.g. GIF) must not be split
+                    if (reader.getNumImages(true) > 1) return
+
+                    val width = reader.getWidth(0)
+                    val height = reader.getHeight(0)
+                    if (!shouldSplit(width, height)) return
+
+                    val partCount = calculatePartCount(height)
+                    val partHeight = height / partCount
+                    val image = reader.read(0)
+
+                    val splitFiles = mutableListOf<File>()
+                    try {
+                        for (index in 0 until partCount) {
+                            val topOffset = index * partHeight
+                            var thisPartHeight = minOf(partHeight, height - topOffset)
+                            if (index == partCount - 1) {
+                                // last part absorbs the remainder so all parts sum up to the full height
+                                thisPartHeight += height - (topOffset + thisPartHeight)
+                            }
+
+                            val splitFile = File(directory, "$fileName.${"%03d".format(index + 1)}.jpg")
+                            writeAsJpeg(image, topOffset, thisPartHeight, width, splitFile)
+                            splitFiles.add(splitFile)
+                        }
+                    } catch (e: Exception) {
+                        splitFiles.forEach { it.delete() }
+                        throw e
+                    }
+
+                    originalFile.delete()
+                } finally {
+                    reader.dispose()
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to split tall image: $originalPath" }
+        }
+    }
+
+    private fun writeAsJpeg(
+        source: BufferedImage,
+        topOffset: Int,
+        partHeight: Int,
+        width: Int,
+        outFile: File,
+    ) {
+        val subImage = source.getSubimage(0, topOffset, width, partHeight)
+        // JPEG doesn't support an alpha channel, so flatten onto an opaque RGB image regardless of source format
+        val rgbImage = BufferedImage(width, partHeight, BufferedImage.TYPE_INT_RGB)
+        rgbImage.createGraphics().apply {
+            drawImage(subImage, 0, 0, null)
+            dispose()
+        }
+        if (!ImageIO.write(rgbImage, "jpg", outFile)) {
+            throw IllegalStateException("No JPEG writer available")
+        }
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/TallImageSplitterTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/TallImageSplitterTest.kt
@@ -1,0 +1,81 @@
+package suwayomi.tachidesk
+
+import suwayomi.tachidesk.manga.impl.util.storage.TallImageSplitter
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TallImageSplitterTest {
+    @Test
+    fun calculatePartCountBoundaries() {
+        assertEquals(1, TallImageSplitter.calculatePartCount(1))
+        assertEquals(1, TallImageSplitter.calculatePartCount(5000))
+        assertEquals(2, TallImageSplitter.calculatePartCount(5001))
+        assertEquals(2, TallImageSplitter.calculatePartCount(10000))
+        assertEquals(3, TallImageSplitter.calculatePartCount(10001))
+    }
+
+    @Test
+    fun shouldSplitRequiresBothAspectRatioAndHeight() {
+        // tall enough aspect ratio, but under the height threshold -> no split
+        assertFalse(TallImageSplitter.shouldSplit(imageWidth = 100, imageHeight = 4999))
+        // over the height threshold, but not a tall aspect ratio -> no split
+        assertFalse(TallImageSplitter.shouldSplit(imageWidth = 2000, imageHeight = 5001))
+        // both conditions met -> split
+        assertTrue(TallImageSplitter.shouldSplit(imageWidth = 100, imageHeight = 5001))
+    }
+
+    @Test
+    fun splitIfNeededProducesMultipleFilesInOrder() {
+        val tmpDir = createTempDirectory("split-test").toFile()
+        try {
+            val width = 100
+            val height = 12000
+            val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+            val graphics = image.createGraphics()
+            graphics.color = Color(255, 0, 0)
+            graphics.fillRect(0, 0, width, height / 2)
+            graphics.color = Color(0, 0, 255)
+            graphics.fillRect(0, height / 2, width, height - height / 2)
+            graphics.dispose()
+
+            val originalFile = File(tmpDir, "001.jpg")
+            ImageIO.write(image, "jpg", originalFile)
+
+            TallImageSplitter.splitIfNeeded(tmpDir, "001")
+
+            assertFalse(originalFile.exists(), "original file should be deleted after a successful split")
+
+            val splitFiles = tmpDir.listFiles()!!.sortedBy { it.name }
+            assertEquals(listOf("001.001.jpg", "001.002.jpg", "001.003.jpg"), splitFiles.map { it.name })
+
+            val totalHeight = splitFiles.sumOf { ImageIO.read(it).height }
+            assertEquals(height, totalHeight)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun splitIfNeededLeavesSmallImageUntouched() {
+        val tmpDir = createTempDirectory("split-test-small").toFile()
+        try {
+            val image = BufferedImage(800, 1200, BufferedImage.TYPE_INT_RGB)
+            val originalFile = File(tmpDir, "001.jpg")
+            ImageIO.write(image, "jpg", originalFile)
+
+            TallImageSplitter.splitIfNeeded(tmpDir, "001")
+
+            assertTrue(originalFile.exists())
+            assertEquals(1, tmpDir.listFiles()!!.size)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/TallImageSplitterTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/TallImageSplitterTest.kt
@@ -13,30 +13,42 @@ import kotlin.test.assertTrue
 
 class TallImageSplitterTest {
     @Test
+    fun computeOptimalHeightScalesWithWidth() {
+        // height of 2 "screens" of that width at a 21:9 (portrait) aspect ratio: 2 * (width * 21 / 9)
+        assertEquals(4200, TallImageSplitter.computeOptimalHeight(900))
+        assertEquals(840, TallImageSplitter.computeOptimalHeight(180))
+    }
+
+    @Test
     fun calculatePartCountBoundaries() {
-        assertEquals(1, TallImageSplitter.calculatePartCount(1))
-        assertEquals(1, TallImageSplitter.calculatePartCount(5000))
-        assertEquals(2, TallImageSplitter.calculatePartCount(5001))
-        assertEquals(2, TallImageSplitter.calculatePartCount(10000))
-        assertEquals(3, TallImageSplitter.calculatePartCount(10001))
+        assertEquals(1, TallImageSplitter.calculatePartCount(imageHeight = 1, optimalImageHeight = 1))
+        assertEquals(1, TallImageSplitter.calculatePartCount(imageHeight = 4384, optimalImageHeight = 4384))
+        assertEquals(2, TallImageSplitter.calculatePartCount(imageHeight = 4385, optimalImageHeight = 4384))
     }
 
     @Test
     fun shouldSplitRequiresBothAspectRatioAndHeight() {
-        // tall enough aspect ratio, but under the height threshold -> no split
-        assertFalse(TallImageSplitter.shouldSplit(imageWidth = 100, imageHeight = 4999))
+        // tall enough aspect ratio, but computed part count is only 1 -> no split
+        assertFalse(
+            TallImageSplitter.shouldSplit(imageWidth = 1024, imageHeight = 4385, optimalImageHeight = 4386),
+        )
+        // tall enough aspect ratio, and computed part count is greater than 1 -> split
+        assertTrue(
+            TallImageSplitter.shouldSplit(imageWidth = 1024, imageHeight = 4385, optimalImageHeight = 4384),
+        )
         // over the height threshold, but not a tall aspect ratio -> no split
-        assertFalse(TallImageSplitter.shouldSplit(imageWidth = 2000, imageHeight = 5001))
-        // both conditions met -> split
-        assertTrue(TallImageSplitter.shouldSplit(imageWidth = 100, imageHeight = 5001))
+        assertFalse(
+            TallImageSplitter.shouldSplit(imageWidth = 2000, imageHeight = 5001, optimalImageHeight = 100),
+        )
     }
 
     @Test
-    fun splitIfNeededProducesMultipleFilesInOrder() {
+    fun splitIfNeededProducesMultipleJpegFilesInOrder() {
         val tmpDir = createTempDirectory("split-test").toFile()
         try {
-            val width = 100
-            val height = 12000
+            // optimalHeight(90) == 420, so a height of 1260 (3 * 420) splits cleanly into 3 parts
+            val width = 90
+            val height = 1260
             val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
             val graphics = image.createGraphics()
             graphics.color = Color(255, 0, 0)
@@ -53,10 +65,69 @@ class TallImageSplitterTest {
             assertFalse(originalFile.exists(), "original file should be deleted after a successful split")
 
             val splitFiles = tmpDir.listFiles()!!.sortedBy { it.name }
-            assertEquals(listOf("001.001.jpg", "001.002.jpg", "001.003.jpg"), splitFiles.map { it.name })
+            assertEquals(
+                listOf("001.001.jpg", "001.002.jpg", "001.003.jpg"),
+                splitFiles.map { it.name },
+            )
 
             val totalHeight = splitFiles.sumOf { ImageIO.read(it).height }
             assertEquals(height, totalHeight)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun splitIfNeededKeepsPngPartsLosslessWithAlpha() {
+        val tmpDir = createTempDirectory("split-test-png").toFile()
+        try {
+            val width = 90
+            val height = 1260
+            val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+            val graphics = image.createGraphics()
+            // semi-transparent fill: if a part were flattened to an opaque image, this would become fully opaque
+            graphics.color = Color(255, 0, 0, 128)
+            graphics.fillRect(0, 0, width, height)
+            graphics.dispose()
+
+            val originalFile = File(tmpDir, "001.png")
+            ImageIO.write(image, "png", originalFile)
+
+            TallImageSplitter.splitIfNeeded(tmpDir, "001")
+
+            val splitFiles = tmpDir.listFiles()!!.sortedBy { it.name }
+            assertEquals(
+                listOf("001.001.png", "001.002.png", "001.003.png"),
+                splitFiles.map { it.name },
+            )
+
+            val firstPart = ImageIO.read(splitFiles.first())
+            val alpha = (firstPart.getRGB(0, 0) ushr 24) and 0xFF
+            assertTrue(alpha in 1..254, "expected the alpha channel to survive the split, was $alpha")
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun splitIfNeededKeepsOtherWritableFormatsNative() {
+        val tmpDir = createTempDirectory("split-test-bmp").toFile()
+        try {
+            val width = 90
+            val height = 1260
+            val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+
+            val originalFile = File(tmpDir, "001.bmp")
+            ImageIO.write(image, "bmp", originalFile)
+
+            TallImageSplitter.splitIfNeeded(tmpDir, "001")
+
+            val splitFiles = tmpDir.listFiles()!!.sortedBy { it.name }
+            assertEquals(
+                listOf("001.001.bmp", "001.002.bmp", "001.003.bmp"),
+                splitFiles.map { it.name },
+                "a BMP source should be split back into BMP parts, not forced into JPEG",
+            )
         } finally {
             tmpDir.deleteRecursively()
         }


### PR DESCRIPTION
## Summary
- Adds a server-side setting, `splitTallImages` (opt-in, defaults to `false`), that splits overly tall "long strip" webtoon pages into several smaller JPEG images right after a page is downloaded.
- Splitting logic (`TallImageSplitter`) is a JVM port of the heuristic used by Mihon's "split tall images" feature: an image is split when its height is more than 3x its width **and** exceeds 5000px, dividing it into equal-height bands (the last band absorbs any remainder).
- Hooked into `Page.getPageImageDownload()`, right after a downloaded page (converted or not) is saved to the chapter's download cache folder.
- No changes were needed to page-count bookkeeping: `ChapterForDownload.getChapterDownloadReady()` already resyncs `Chapter.pageCount` to the number of files actually on disk, so chapters with split pages report the correct page count to clients automatically.

Towards #1547 and #645.

## Scope note
This PR only covers the server side (Kotlin). The Suwayomi-WebUI project (separate repository) will need its own follow-up to expose a toggle for this setting in the Downloads settings screen — the new setting is already exposed automatically through the GraphQL `settings`/`setSettings` API in the meantime.

## Test plan
- [x] Added `TallImageSplitterTest` covering the split-threshold boundary conditions and an end-to-end split of a synthetic 12000px-tall image, verifying output file count, naming, and total height.
- [ ] Could not run a full Gradle build/test suite in the development environment used for this change (unrelated local JDK/Windows networking issue); please run CI/`./gradlew :server:test` to confirm.