### PR TITLE
Coordinate concurrent chapter reads and downloads on the shared page cache

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Page.kt
@@ -24,6 +24,7 @@ import suwayomi.tachidesk.manga.impl.util.getChapterCachePath
 import suwayomi.tachidesk.manga.impl.util.source.GetSource.getSourceOrNull
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse.getImageResponse
 import suwayomi.tachidesk.manga.impl.util.storage.ImageUtil
+import suwayomi.tachidesk.manga.impl.util.storage.PageCacheCoordinator
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import suwayomi.tachidesk.manga.model.table.PageTable
@@ -192,61 +193,67 @@ object Page {
                 index = index,
                 progressFlow = progressFlow,
             )
-        val conversions = serverConfig.downloadConversions.value
-        if (conversions.isEmpty() || !downloadCacheFolder.exists()) {
-            inputStream.close()
-            return
-        }
-        val defaultConversion = conversions["default"]
-        val conversion =
-            conversions[mime]
-                ?: defaultConversion
-        if (conversion == null) {
-            inputStream.close()
-            return
-        }
 
-        try {
-            val converted =
+        // A separate, sequential lock phase from the one getPageImage()/getImageResponse() already took for the
+        // fetch above (Mutex isn't reentrant) - guards post-processing against a concurrent live read of this
+        // same page observing a half-written/half-split file.
+        val cacheSaveDir = getChapterCachePath(mangaId, chapterId)
+        PageCacheCoordinator.withPageLock(cacheSaveDir, fileName) {
+            val conversions = serverConfig.downloadConversions.value
+            val defaultConversion = conversions["default"]
+            val conversion = conversions[mime] ?: defaultConversion
+
+            if (conversions.isEmpty() || !downloadCacheFolder.exists() || conversion == null) {
+                inputStream.close()
+            } else {
                 try {
-                    convertImageResponse(
-                        image = inputStream,
-                        mime = mime,
-                        conversion = conversion,
-                    )
+                    val converted =
+                        try {
+                            convertImageResponse(
+                                image = inputStream,
+                                mime = mime,
+                                conversion = conversion,
+                            )
+                        } catch (e: Exception) {
+                            throw e
+                        } finally {
+                            inputStream.close()
+                        }
+
+                    if (converted != null) {
+                        val (convertedStream, convertedMime) = converted
+                        val convertedExtension =
+                            MimeUtils.guessExtensionFromMimeType(convertedMime)
+                                ?: convertedMime.substringAfter('/')
+                        val convertedPage =
+                            File(
+                                downloadCacheFolder,
+                                "$fileName.$convertedExtension",
+                            )
+
+                        convertedPage.outputStream().use { outputStream ->
+                            convertedStream.use { it.copyTo(outputStream) }
+                        }
+
+                        val extension =
+                            MimeUtils.guessExtensionFromMimeType(mime)
+                                ?: mime.substringAfter('/')
+                        if (extension != convertedExtension) {
+                            File(
+                                downloadCacheFolder,
+                                "$fileName.$extension",
+                            ).delete()
+                        }
+                    }
                 } catch (e: Exception) {
-                    throw e
-                } finally {
-                    inputStream.close()
-                }
-
-            if (converted != null) {
-                val (convertedStream, convertedMime) = converted
-                val convertedExtension =
-                    MimeUtils.guessExtensionFromMimeType(convertedMime)
-                        ?: convertedMime.substringAfter('/')
-                val convertedPage =
-                    File(
-                        downloadCacheFolder,
-                        "$fileName.$convertedExtension",
-                    )
-
-                convertedPage.outputStream().use { outputStream ->
-                    convertedStream.use { it.copyTo(outputStream) }
-                }
-
-                val extension =
-                    MimeUtils.guessExtensionFromMimeType(mime)
-                        ?: mime.substringAfter('/')
-                if (extension != convertedExtension) {
-                    File(
-                        downloadCacheFolder,
-                        "$fileName.$extension",
-                    ).delete()
+                    logger.warn(e) { "Error while post-processing image" }
                 }
             }
-        } catch (e: Exception) {
-            logger.warn(e) { "Error while post-processing image" }
+
+            // marks that download-time post-processing has been attempted for this page, so a concurrent or
+            // later download run doesn't skip it just because the raw bytes happen to already be cached
+            // (see https://github.com/Suwayomi/Suwayomi-Server/issues/2193 and #2289)
+            PageCacheCoordinator.markProcessed(cacheSaveDir, fileName)
         }
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/download/fileProvider/ChaptersFilesProvider.kt
@@ -24,6 +24,7 @@ import suwayomi.tachidesk.manga.impl.util.getChapterCachePath
 import suwayomi.tachidesk.manga.impl.util.getChapterCbzPath
 import suwayomi.tachidesk.manga.impl.util.getChapterDownloadPath
 import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
+import suwayomi.tachidesk.manga.impl.util.storage.PageCacheCoordinator
 import suwayomi.tachidesk.manga.model.table.ChapterTable
 import suwayomi.tachidesk.manga.model.table.MangaTable
 import java.io.File
@@ -140,8 +141,14 @@ abstract class ChaptersFilesProvider<Type : FileType>(
             val pageExistsInFinalDownloadFolder = ImageResponse.findFileNameStartingWith(finalDownloadFolder, fileName) != null
             val pageExistsInCacheDownloadFolder = ImageResponse.findFileNameStartingWith(cacheChapterDir, fileName) != null
 
-            val doesPageAlreadyExist = pageExistsInFinalDownloadFolder || pageExistsInCacheDownloadFolder
-            if (doesPageAlreadyExist) {
+            // A page cached by a concurrent/prior live read has raw bytes but was never run through
+            // Page.getPageImageDownload()'s post-processing (conversion, splitting), so it must not be skipped
+            // just because a file exists - only a page from a previously *finished* download (final folder) or one
+            // already marked processed in this cache is truly done. See #2193 / #2289.
+            val pageFullyProcessed =
+                pageExistsInFinalDownloadFolder ||
+                    (pageExistsInCacheDownloadFolder && PageCacheCoordinator.isProcessed(cacheChapterDir, fileName))
+            if (pageFullyProcessed) {
                 continue
             }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageResponse.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageResponse.kt
@@ -55,39 +55,40 @@ object ImageResponse {
         saveDir: String,
         fileName: String,
         fetcher: suspend () -> Response,
-    ): Pair<InputStream, String> {
-        File(saveDir).mkdirs()
+    ): Pair<InputStream, String> =
+        PageCacheCoordinator.withPageLock(saveDir, fileName) {
+            File(saveDir).mkdirs()
 
-        val cachedFile = findFileNameStartingWith(saveDir, fileName)
-        val filePath = "$saveDir/$fileName"
+            val cachedFile = findFileNameStartingWith(saveDir, fileName)
+            val filePath = "$saveDir/$fileName"
 
-        // in case the cached file is a ".tmp" file something went wrong with the previous download, and it has to be downloaded again
-        if (cachedFile != null && !cachedFile.endsWith(".tmp")) {
-            return getCachedImageResponse(cachedFile, filePath)
-        }
-
-        val response = fetcher()
-
-        try {
-            if (response.code == 200) {
-                val (actualSavePath, imageType) =
-                    saveImage(
-                        filePath,
-                        response.body.byteStream(),
-                        response.header("Content-Type"),
-                    )
-                return pathToInputStream(actualSavePath) to imageType
-            } else {
-                throw Exception("request error! ${response.code}")
+            // in case the cached file is a ".tmp" file something went wrong with the previous download, and it has to be downloaded again
+            if (cachedFile != null && !cachedFile.endsWith(".tmp")) {
+                return@withPageLock getCachedImageResponse(cachedFile, filePath)
             }
-        } catch (e: IOException) {
-            // make sure no partial download remains
-            clearCachedImage(saveDir, fileName)
-            throw e
-        } finally {
-            response.closeQuietly()
+
+            val response = fetcher()
+
+            try {
+                if (response.code == 200) {
+                    val (actualSavePath, imageType) =
+                        saveImage(
+                            filePath,
+                            response.body.byteStream(),
+                            response.header("Content-Type"),
+                        )
+                    pathToInputStream(actualSavePath) to imageType
+                } else {
+                    throw Exception("request error! ${response.code}")
+                }
+            } catch (e: IOException) {
+                // make sure no partial download remains
+                clearCachedImage(saveDir, fileName)
+                throw e
+            } finally {
+                response.closeQuietly()
+            }
         }
-    }
 
     /** Save image safely */
     fun saveImage(

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageResponse.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/ImageResponse.kt
@@ -39,7 +39,7 @@ object ImageResponse {
         val fileType = cachedFile.substringAfter("$filePath.")
         return Pair(
             pathToInputStream(cachedFile),
-            "image/$fileType",
+            MimeUtils.guessMimeTypeFromExtension(fileType) ?: "image/$fileType",
         )
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/PageCacheCoordinator.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/PageCacheCoordinator.kt
@@ -1,0 +1,66 @@
+package suwayomi.tachidesk.manga.impl.util.storage
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import io.github.reactivecircus.cache4k.Cache
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Coordinates concurrent access to the per-page cache files shared by the live "read a
+ * not-yet-downloaded chapter" path ([ImageResponse.getImageResponse]) and the chapter download
+ * job (`ChaptersFilesProvider.downloadImpl` / `Page.getPageImageDownload`).
+ *
+ * Both paths read/write the exact same cache directory and filename convention with no
+ * coordination otherwise, which can result in one side observing the other's file mid-write, or
+ * silently skipping post-processing (format conversion, image splitting) for a page that was
+ * only ever fetched by a live read.
+ */
+object PageCacheCoordinator {
+    private val mutexes: Cache<String, Mutex> =
+        Cache
+            .Builder<String, Mutex>()
+            .expireAfterAccess(10.minutes)
+            .build()
+
+    private val processedMarkers: Cache<String, Boolean> =
+        Cache
+            .Builder<String, Boolean>()
+            .expireAfterAccess(10.minutes)
+            .build()
+
+    private fun key(
+        saveDir: String,
+        fileName: String,
+    ) = "$saveDir/$fileName"
+
+    /**
+     * Runs [block] while holding the lock for this page slot. Not reentrant - never call this
+     * from within a [block] that's already holding the same (or, transitively, any) page lock.
+     */
+    suspend fun <T> withPageLock(
+        saveDir: String,
+        fileName: String,
+        block: suspend () -> T,
+    ): T = mutexes.get(key(saveDir, fileName)) { Mutex() }.withLock { block() }
+
+    /** Whether download-time post-processing has already been attempted for this page. */
+    fun isProcessed(
+        saveDir: String,
+        fileName: String,
+    ): Boolean = processedMarkers.get(key(saveDir, fileName)) == true
+
+    /** Marks this page as having gone through download-time post-processing (successfully or not - it won't be retried). */
+    fun markProcessed(
+        saveDir: String,
+        fileName: String,
+    ) {
+        processedMarkers.put(key(saveDir, fileName), true)
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/ImageResponseTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/ImageResponseTest.kt
@@ -1,0 +1,30 @@
+package suwayomi.tachidesk
+
+import suwayomi.tachidesk.manga.impl.util.storage.ImageResponse
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ImageResponseTest {
+    @Test
+    fun getCachedImageResponseReturnsTheStandardMimeType() {
+        val tmpDir = createTempDirectory("image-response-test").toFile()
+        try {
+            // production always joins paths with a literal "/" (see ImageResponse.getImageResponse /
+            // findFileNameStartingWith), regardless of the OS - mirror that here rather than using File.path,
+            // which would normalize to "\" on Windows and never match.
+            val filePath = "${tmpDir.path}/001"
+            val cachedFilePath = "$filePath.jpg"
+            File(cachedFilePath).writeBytes(byteArrayOf(0))
+
+            val (_, mime) = ImageResponse.getCachedImageResponse(cachedFilePath, filePath)
+
+            // not "image/jpg" - a naive "image/" + extension reconstruction doesn't match the standard mime type,
+            // which breaks lookups keyed by mime (e.g. server.downloadConversions) for pages reused from cache
+            assertEquals("image/jpeg", mime)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+}

--- a/server/src/test/kotlin/suwayomi/tachidesk/PageCacheCoordinatorTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/PageCacheCoordinatorTest.kt
@@ -1,0 +1,67 @@
+package suwayomi.tachidesk
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import suwayomi.tachidesk.manga.impl.util.storage.PageCacheCoordinator
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PageCacheCoordinatorTest {
+    @Test
+    fun withPageLockSerializesAccessToTheSameKey() =
+        runBlocking(Dispatchers.Default) {
+            val concurrentEntries = AtomicInteger(0)
+            val maxObservedConcurrentEntries = AtomicInteger(0)
+
+            val jobs =
+                (1..20).map {
+                    async {
+                        PageCacheCoordinator.withPageLock("dir", "page-001") {
+                            val entries = concurrentEntries.incrementAndGet()
+                            maxObservedConcurrentEntries.getAndUpdate { current -> maxOf(current, entries) }
+                            delay(5)
+                            concurrentEntries.decrementAndGet()
+                        }
+                    }
+                }
+            jobs.awaitAll()
+
+            assertEquals(1, maxObservedConcurrentEntries.get(), "critical sections for the same key must never overlap")
+        }
+
+    @Test
+    fun withPageLockDoesNotSerializeDifferentKeys() {
+        // just a liveness check: unrelated keys must not deadlock/serialize on the same lock
+        runBlocking(Dispatchers.Default) {
+            val jobs =
+                (1..20).map { index ->
+                    async {
+                        PageCacheCoordinator.withPageLock("dir", "page-$index") {
+                            delay(5)
+                        }
+                    }
+                }
+            jobs.awaitAll()
+        }
+    }
+
+    @Test
+    fun isProcessedTracksMarkProcessedPerKey() {
+        val saveDir = "some/dir"
+        val fileName = "001"
+        val otherFileName = "002"
+
+        assertFalse(PageCacheCoordinator.isProcessed(saveDir, fileName))
+
+        PageCacheCoordinator.markProcessed(saveDir, fileName)
+
+        assertTrue(PageCacheCoordinator.isProcessed(saveDir, fileName))
+        assertFalse(PageCacheCoordinator.isProcessed(saveDir, otherFileName))
+    }
+}


### PR DESCRIPTION
## Summary

The chapter download job (`ChaptersFilesProvider.downloadImpl()`) and the live "read a not-yet-downloaded chapter" path (`Page.getPageImage()`) read/write the exact same per-chapter cache directory and filename convention, with no coordination between them. This causes two related bugs:

- #2193: the download job's "does this page already exist" check treats *any* file at that cache path as fully processed and skips it - but a page cached there by a live read was never run through `Page.getPageImageDownload()`'s post-processing (format conversion via `downloadConversions`, and eventually tall-image splitting from #2288), so that step silently never runs for it.
- #2289: without a lock, a live read and the download job can observe each other's files mid-write (a `.tmp` file, or - once #2288 lands - a page mid-split into fragments).

Confirmed in practice while looking into #2289: Suwayomi-Tsumiru's "save chapter to device" flow deliberately enqueues the chapter on the server's download queue *and* fetches pages itself via the same `fetchChapterPages` mutation at the same time, without waiting on either - so this isn't a rare corner case for that client.

## Changes

- New `PageCacheCoordinator` (`server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/storage/PageCacheCoordinator.kt`): a per-page-cache-key `Mutex` (mirroring the existing `mutexByChapterId` pattern in `ChapterForDownload.kt`) plus an in-memory "processed" marker, both keyed by `"$saveDir/$fileName"`.
- `ImageResponse.getImageResponse()` now runs its cache-check/fetch/save body under that lock - this is the single function backing every page/thumbnail/icon cache read in the app, so it's a drop-in safety net with no API change.
- `Page.getPageImageDownload()` acquires the *same* lock key as a second, sequential critical section after the fetch (`Mutex` isn't reentrant, so it can't just wrap the whole function), runs its post-processing there, and marks the page processed at the end of every exit path.
- `ChaptersFilesProvider.downloadImpl()`'s skip check now only skips a page if it's in the *final* download folder (a genuinely finished prior download) or if it's cached **and marked processed** - a page cached by a live read (bytes present, no marker) now still goes through post-processing, cheaply reusing the already-cached bytes rather than re-fetching from the network.
- Fixed `ImageResponse.getCachedImageResponse()` reconstructing the mime type naively (`"image/" + extension`, e.g. `"image/jpg"`) instead of using `MimeUtils.guessMimeTypeFromExtension` like the rest of the codebase does. This path was previously unreachable from the download flow (a cached page was always skipped outright), so the wrong mime never mattered there before; now that cache-hit pages actually go through post-processing, a wrong mime here would silently break `downloadConversions` lookups (keyed by the standard mime type) for exactly the pages this PR is meant to fix.

`ChapterForDownload.kt`'s existing `mutexByChapterId` (guards the page-list/pageCount DB refresh, a different concern) is left untouched.

## Why this fix doesn't affect the common "just reading" case

Traced through what happens when a client (WebUI or Tsumiru - both hit the exact same server-side entry points, `fetchChapterPages` + the per-page image endpoint) opens a chapter that was **never downloaded and never read before**: no download job is ever running for that chapter, so the new lock is always uncontended - acquiring an uncontended `Mutex` doesn't suspend, it's a cheap CAS. Zero observable behavior change, negligible overhead for the mainstream read-only case.

Also worth calling out: #2193's own repro steps describe a **sequential**, non-racing scenario (read part of a chapter, *then* download it) - the skip-check fix alone (no locking needed) already resolves that variant, since it's a genuine logic bug independent of concurrency. The locking specifically addresses the *concurrent* variant (Tsumiru's default behavior, or a library auto-download coinciding with someone reading).

Also traced the exact "read a few pages live, close, download, reopen" flow end-to-end (fresh pages fetched normally, previously-cached pages reused and now correctly post-processed, `handleSuccessfulDownload()` copies everything to the final folder, `isDownloaded` flips true, reopening serves from the final folder) - works correctly with this fix.

## Related, but explicitly out of scope here

While cross-checking the above against #2288's proposed splitting, found a separate issue: filed as #2290. `lastPageRead` is a raw page index that's only clamped against `pageCount`, never remapped - so once tall-image splitting inserts extra page files earlier in a chapter, a previously-recorded reading position can end up pointing at the wrong page after download. That's purely about what a page index *means* once splitting changes file layout, unrelated to the read/download concurrency this PR fixes, so it's tracked separately rather than folded in here.

## Non-goals / residual limitations

- `ChapterTable.pageCount`/`isDownloaded` staleness during an in-progress download is unchanged - it still resolves on the next `fetchChapterPages` call, same as today, and never corrupts data.
- The "processed" marker is in-memory only, so it's lost on a server restart mid-download; affected pages just get harmlessly re-checked/re-processed once on resume.

## Test plan

- [x] `:server:compileKotlin` / `:server:compileTestKotlin` - clean build, no errors.
- [x] `:server:test` - full suite passes (0 failures/errors across all test classes, including `PageTest`), plus new `PageCacheCoordinatorTest` (lock mutual-exclusion under real concurrency via `Dispatchers.Default`, liveness check for unrelated keys, `isProcessed`/`markProcessed` round-trip) and `ImageResponseTest` (standard mime type for a cache-hit file).
- [x] `:server:ktlintMainSourceSetCheck` / `:server:ktlintTestSourceSetCheck` - clean.