### PR TITLE
fix(backup): default scalar fields omitted by proto3 peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Webview**) Don't throw an exception when disabling CEF
 
 ### Fixed
+- (**Backup/SyncYomi**) Fix restoring a library that originated from another client or was re-encoded by the sync server ("Field 'libraryId' is required ... but it was missing")
 - (**Cloudflare/flaresolverr**) Treat a bypass as successful when a `cf_clearance` cookie is returned, so non-CloudFlare source errors are correctly passed through to the extensions.
 - (**Manga/Extension**) Fix resolving manga URLs for extensions that use memo data
 - (**Tracker**) Fix Shikimori

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/Backup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/Backup.kt
@@ -8,14 +8,14 @@ import java.util.Date
 
 @Serializable
 data class Backup(
-    @ProtoNumber(1) val backupManga: List<BackupManga>,
+    @ProtoNumber(1) val backupManga: List<BackupManga> = emptyList(),
     @ProtoNumber(2) var backupCategories: List<BackupCategory> = emptyList(),
     // Bump by 100 to specify this is a 0.x value
     // @ProtoNumber(100) var brokenBackupSources: List<BrokenBackupSource> = emptyList(),
     @ProtoNumber(101) var backupSources: List<BackupSource> = emptyList(),
     // suwayomi
     @ProtoNumber(9000) var meta: Map<String, String> = emptyMap(),
-    @ProtoNumber(9001) var serverSettings: BackupServerSettings?,
+    @ProtoNumber(9001) var serverSettings: BackupServerSettings? = null,
 ) {
     fun getSourceMap(): Map<Long, String> =
         backupSources

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupCategory.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupCategory.kt
@@ -1,11 +1,14 @@
 package suwayomi.tachidesk.manga.impl.backup.proto.models
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
+// Scalars need defaults (proto3 peers omit zero values); see BackupManga.
+// A data class so that SyncManager's category list comparison is structural.
 @Serializable
-class BackupCategory(
-    @ProtoNumber(1) var name: String,
+data class BackupCategory(
+    @ProtoNumber(1) @EncodeDefault var name: String = "",
     @ProtoNumber(2) var order: Int = 0,
     // @ProtoNumber(3) val updateInterval: Int = 0, 1.x value not used in 0.x
     // Bump by 100 to specify this is a 0.x value

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupChapter.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupChapter.kt
@@ -1,15 +1,17 @@
 package suwayomi.tachidesk.manga.impl.backup.proto.models
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 import suwayomi.tachidesk.manga.impl.util.lang.JsonObjectEmptyBytes
 
+// Scalars need defaults (proto3 peers omit zero values); see BackupManga.
 @Serializable
 data class BackupChapter(
     // in 1.x some of these values have different names
     // url is called key in 1.x
-    @ProtoNumber(1) var url: String,
-    @ProtoNumber(2) var name: String,
+    @ProtoNumber(1) @EncodeDefault var url: String = "",
+    @ProtoNumber(2) @EncodeDefault var name: String = "",
     @ProtoNumber(3) var scanlator: String? = null,
     @ProtoNumber(4) var read: Boolean = false,
     @ProtoNumber(5) var bookmark: Boolean = false,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupHistory.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupHistory.kt
@@ -1,10 +1,12 @@
 package suwayomi.tachidesk.manga.impl.backup.proto.models
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
+// Scalars need defaults (proto3 peers omit zero values); see BackupManga.
 @Serializable
 data class BackupHistory(
-    @ProtoNumber(1) var url: String,
-    @ProtoNumber(2) var lastRead: Long,
+    @ProtoNumber(1) @EncodeDefault var url: String = "",
+    @ProtoNumber(2) @EncodeDefault var lastRead: Long = 0,
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupManga.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupManga.kt
@@ -1,16 +1,26 @@
 package suwayomi.tachidesk.manga.impl.backup.proto.models
 
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 import suwayomi.tachidesk.manga.impl.util.lang.JsonObjectEmptyBytes
 
+/**
+ * Every scalar field of the backup models needs a default: proto3 peers (the SyncYomi server
+ * re-encodes backups with proto3 semantics) and other clients (Mihon, TachiyomiSY) omit
+ * zero-valued scalars on the wire, so a required field fails to decode a library that
+ * originated elsewhere with "Field 'x' is required ... but it was missing".
+ *
+ * [EncodeDefault] on the historically required fields keeps emitting their zero values so
+ * that Mihon/TachiyomiSY, whose models still require them, can import Suwayomi backups.
+ */
 @Serializable
 data class BackupManga(
     // in 1.x some of these values have different names
-    @ProtoNumber(1) var source: Long,
+    @ProtoNumber(1) @EncodeDefault var source: Long = 0,
     // url is called key in 1.x
-    @ProtoNumber(2) var url: String,
+    @ProtoNumber(2) @EncodeDefault var url: String = "",
     @ProtoNumber(3) var title: String = "",
     @ProtoNumber(4) var artist: String? = null,
     @ProtoNumber(5) var author: String? = null,

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupSource.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupSource.kt
@@ -1,12 +1,14 @@
 package suwayomi.tachidesk.manga.impl.backup.proto.models
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
+// Scalars need defaults (proto3 peers omit zero values); see BackupManga.
 @Serializable
 data class BackupSource(
     @ProtoNumber(1) var name: String = "",
-    @ProtoNumber(2) var sourceId: Long,
+    @ProtoNumber(2) @EncodeDefault var sourceId: Long = 0,
     // suwayomi
     @ProtoNumber(9000) var meta: Map<String, String> = emptyMap(),
 )

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupTracking.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/backup/proto/models/BackupTracking.kt
@@ -1,14 +1,16 @@
 package suwayomi.tachidesk.manga.impl.backup.proto.models
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
+// Scalars need defaults (proto3 peers omit zero values); see BackupManga.
 @Serializable
 data class BackupTracking(
     // in 1.x some of these values have different types or names
-    @ProtoNumber(1) var syncId: Int,
+    @ProtoNumber(1) @EncodeDefault var syncId: Int = 0,
     // LibraryId is not null in 1.x
-    @ProtoNumber(2) var libraryId: Long,
+    @ProtoNumber(2) @EncodeDefault var libraryId: Long = 0,
     @Deprecated("Use mediaId instead", level = DeprecationLevel.WARNING)
     @ProtoNumber(3)
     var mediaIdInt: Int = 0,

--- a/server/src/test/kotlin/suwayomi/tachidesk/global/impl/sync/BackupProtoCompatTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/global/impl/sync/BackupProtoCompatTest.kt
@@ -1,0 +1,213 @@
+package suwayomi.tachidesk.global.impl.sync
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.protobuf.ProtoNumber
+import suwayomi.tachidesk.manga.impl.backup.proto.models.Backup
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupCategory
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupChapter
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupHistory
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupManga
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupSource
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupTracking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+
+/**
+ * The SyncYomi server re-encodes backups with proto3 semantics and other clients never send
+ * zero-valued scalars, so every backup model field must decode when it is missing on the wire.
+ * Conversely Mihon/TachiyomiSY still require some of those fields, so Suwayomi must keep
+ * emitting them even when they are zero.
+ */
+class BackupProtoCompatTest {
+    // Mirrors of the backup models with the historically required fields left out entirely,
+    // which is what a proto3 encoder produces for zero values.
+    @Serializable
+    private class P3Tracking(
+        @ProtoNumber(5) val title: String,
+    )
+
+    @Serializable
+    private class P3History(
+        @ProtoNumber(3) val readDuration: Long,
+    )
+
+    @Serializable
+    private class P3Chapter(
+        @ProtoNumber(9) val chapterNumber: Float,
+    )
+
+    @Serializable
+    private class P3Manga(
+        @ProtoNumber(3) val title: String,
+        @ProtoNumber(16) val chapters: List<P3Chapter>,
+        @ProtoNumber(18) val tracking: List<P3Tracking>,
+        @ProtoNumber(104) val history: List<P3History>,
+    )
+
+    @Serializable
+    private class P3Category(
+        @ProtoNumber(2) val order: Int,
+    )
+
+    @Serializable
+    private class P3Source(
+        @ProtoNumber(1) val name: String,
+    )
+
+    @Serializable
+    private class P3Backup(
+        @ProtoNumber(1) val backupManga: List<P3Manga>,
+        @ProtoNumber(2) val backupCategories: List<P3Category>,
+        @ProtoNumber(101) val backupSources: List<P3Source>,
+    )
+
+    // Mirrors of the Mihon models, where these fields are still required.
+    @Serializable
+    private class StrictTracking(
+        @ProtoNumber(1) val syncId: Int,
+        @ProtoNumber(2) val libraryId: Long,
+    )
+
+    @Serializable
+    private class StrictHistory(
+        @ProtoNumber(1) val url: String,
+        @ProtoNumber(2) val lastRead: Long,
+    )
+
+    @Serializable
+    private class StrictChapter(
+        @ProtoNumber(1) val url: String,
+        @ProtoNumber(2) val name: String,
+    )
+
+    @Serializable
+    private class StrictManga(
+        @ProtoNumber(1) val source: Long,
+        @ProtoNumber(2) val url: String,
+        @ProtoNumber(16) val chapters: List<StrictChapter>,
+        @ProtoNumber(18) val tracking: List<StrictTracking>,
+        @ProtoNumber(104) val history: List<StrictHistory>,
+    )
+
+    @Serializable
+    private class StrictCategory(
+        @ProtoNumber(1) val name: String,
+    )
+
+    @Serializable
+    private class StrictSource(
+        @ProtoNumber(2) val sourceId: Long,
+    )
+
+    @Serializable
+    private class StrictBackup(
+        @ProtoNumber(1) val backupManga: List<StrictManga>,
+        @ProtoNumber(2) val backupCategories: List<StrictCategory>,
+        @ProtoNumber(101) val backupSources: List<StrictSource>,
+    )
+
+    @Test
+    fun decodesBackupWithZeroScalarsOmitted() {
+        val bytes =
+            ProtoBuf.encodeToByteArray(
+                P3Backup.serializer(),
+                P3Backup(
+                    backupManga =
+                        listOf(
+                            P3Manga(
+                                title = "Local",
+                                chapters = listOf(P3Chapter(chapterNumber = 1.5F)),
+                                tracking = listOf(P3Tracking(title = "tracked")),
+                                history = listOf(P3History(readDuration = 42)),
+                            ),
+                        ),
+                    backupCategories = listOf(P3Category(order = 3)),
+                    backupSources = listOf(P3Source(name = "Local source")),
+                ),
+            )
+
+        val backup = ProtoBuf.decodeFromByteArray(Backup.serializer(), bytes)
+
+        val manga = backup.backupManga.single()
+        assertEquals(0L, manga.source)
+        assertEquals("", manga.url)
+        assertEquals("Local", manga.title)
+
+        val chapter = manga.chapters.single()
+        assertEquals("", chapter.url)
+        assertEquals("", chapter.name)
+        assertEquals(1.5F, chapter.chapterNumber)
+
+        val tracking = manga.tracking.single()
+        assertEquals(0, tracking.syncId)
+        assertEquals(0L, tracking.libraryId)
+        assertEquals("tracked", tracking.title)
+
+        val history = manga.history.single()
+        assertEquals("", history.url)
+        assertEquals(0L, history.lastRead)
+
+        val category = backup.backupCategories.single()
+        assertEquals("", category.name)
+        assertEquals(3, category.order)
+
+        assertEquals(0L, backup.backupSources.single().sourceId)
+    }
+
+    @Test
+    fun decodesEmptyNestedMessages() {
+        // A Backup whose single BackupManga carries no fields at all.
+        val backup = ProtoBuf.decodeFromByteArray(Backup.serializer(), byteArrayOf(0x0a, 0x00))
+        val manga = backup.backupManga.single()
+        assertEquals(0L, manga.source)
+        assertEquals("", manga.url)
+    }
+
+    // Mihon still requires these fields, so their zero values must stay on the wire.
+    @Test
+    fun keepsEmittingZeroValuedRequiredFields() {
+        val bytes =
+            ProtoBuf.encodeToByteArray(
+                Backup.serializer(),
+                Backup(
+                    backupManga =
+                        listOf(
+                            BackupManga(
+                                source = 0,
+                                url = "",
+                                chapters = listOf(BackupChapter(url = "", name = "")),
+                                tracking = listOf(BackupTracking(syncId = 0, libraryId = 0)),
+                                history = listOf(BackupHistory(url = "", lastRead = 0)),
+                            ),
+                        ),
+                    backupCategories = listOf(BackupCategory(name = "")),
+                    backupSources = listOf(BackupSource(sourceId = 0)),
+                ),
+            )
+
+        val strict = ProtoBuf.decodeFromByteArray(StrictBackup.serializer(), bytes)
+
+        val manga = strict.backupManga.single()
+        assertEquals(0L, manga.source)
+        assertEquals("", manga.url)
+        assertEquals("", manga.chapters.single().url)
+        assertEquals(0L, manga.tracking.single().libraryId)
+        assertEquals(0L, manga.history.single().lastRead)
+        assertEquals("", strict.backupCategories.single().name)
+        assertEquals(0L, strict.backupSources.single().sourceId)
+    }
+
+    // SyncManager decides whether to restore by comparing the category lists with ==.
+    @Test
+    fun categoriesCompareStructurally() {
+        val local = BackupCategory(name = "Reading", order = 1, uid = 7, version = 2)
+        assertEquals(local, BackupCategory(name = "Reading", order = 1, uid = 7, version = 2))
+
+        val bytes = ProtoBuf.encodeToByteArray(Backup.serializer(), Backup(backupCategories = listOf(local)))
+        val remote = ProtoBuf.decodeFromByteArray(Backup.serializer(), bytes).backupCategories
+        assertNotSame(local, remote.single())
+        assertEquals(listOf(local), remote)
+    }
+}


### PR DESCRIPTION
The SyncYomi server re-encodes backups with proto3 semantics and Mihon/TachiyomiSY encode with `encodeDefaults=false`, so zero-valued scalars never reach the wire. Ten backup model fields had no default, which made decoding a library that originated elsewhere fail with `Field 'libraryId' is required for type 'BackupTracking' but it was missing` — LocalSource (source id 0) and tracks with a null libraryId are real cases.

This gives those fields defaults and marks the historically required ones `@EncodeDefault`, so Suwayomi keeps emitting the zero values for Mihon/TachiyomiSY, whose models still require them. `BackupCategory` becomes a data class so category-list comparisons are structural. A round-trip test covers both directions (decoding proto3-style bytes with zeros omitted, and still emitting zeros for strict decoders).

Split out of #2308.
