### PR TITLE
Fix extensions incorrectly marked as updatable

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0063_FixExtensionsIncorrectMarkedUpdatable.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/database/migration/M0063_FixExtensionsIncorrectMarkedUpdatable.kt
@@ -1,0 +1,23 @@
+package suwayomi.tachidesk.server.database.migration
+
+/*
+ * Copyright (C) Contributors to the Suwayomi project
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import de.neonew.exposed.migrations.helpers.SQLMigration
+import suwayomi.tachidesk.server.database.migration.helpers.toSqlName
+
+@Suppress("ClassName", "unused")
+class M0063_FixExtensionsIncorrectMarkedUpdatable : SQLMigration() {
+    override val sql: String by lazy {
+        val extension = "extension".toSqlName()
+        val hasUpdate = "has_update".toSqlName()
+
+        """
+        UPDATE $extension SET $hasUpdate = TRUE WHERE has_update = FALSE
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Due to an extension store fixing a version code mismatch, some extensions are now incorrectly marked as updatable. However, these are still pointing to the same version already installed. This makes updating them impossible. The only solution to fix this manually is reinstalling the extension.
