### PR TITLE
Fix extensions incorrectly marked as updatable

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
@@ -143,7 +143,8 @@ object ExtensionsList {
 
                                         this[ExtensionTable.hasUpdate] = false
                                     }
-                            }
+                            }.toExecutable()
+                            .execute(this@transaction)
 
                         BatchUpdateStatement(ExtensionTable)
                             .apply {

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/ExtensionsList.kt
@@ -105,12 +105,14 @@ object ExtensionsList {
                         .selectAll()
                         .toList()
                         .associateBy { it[ExtensionTable.pkgName] }
+
                 val extensionsToUpdate = mutableListOf<Pair<ExtensionInfo, ResultRow>>()
                 val extensionsToInsert = mutableListOf<ExtensionInfo>()
                 val extensionsToDelete =
                     installedExtensions.filter { it.value[ExtensionTable.storeIndexUrl] != null }.mapNotNull { (pkgName, extension) ->
                         extension.takeUnless { uniqueExtensions.any { it.pkgName == pkgName } }
                     }
+
                 uniqueExtensions.forEach {
                     val extension = installedExtensions[it.pkgName]
                     if (extension != null) {
@@ -119,12 +121,30 @@ object ExtensionsList {
                         extensionsToInsert.add(it)
                     }
                 }
+
                 if (extensionsToUpdate.isNotEmpty()) {
                     val extensionsInstalled =
                         extensionsToUpdate
                             .groupBy { it.second[ExtensionTable.isInstalled] }
+
                     val installedExtensionsToUpdate = extensionsInstalled[true].orEmpty()
                     if (installedExtensionsToUpdate.isNotEmpty()) {
+                        // Reset the "hasUpdate" flag to ensure that we have no extensions that are incorrectly marked as updatable
+                        // This can happen if an extension store has some versionCode mismatch that gets fixed without bumping the actual versionCode.
+                        // I.e.
+                        // 1. Extension list update -> causes issue => extensions get incorrectly marked as updatable
+                        // 2. Extension list update -> fixes issue => incorrectly marked extensions get reset
+                        BatchUpdateStatement(ExtensionTable)
+                            .apply {
+                                installedExtensionsToUpdate
+                                    .filter { it.second[ExtensionTable.hasUpdate] }
+                                    .forEach { (_, extension) ->
+                                        addBatch(EntityID(extension[ExtensionTable.id].value, ExtensionTable))
+
+                                        this[ExtensionTable.hasUpdate] = false
+                                    }
+                            }
+
                         BatchUpdateStatement(ExtensionTable)
                             .apply {
                                 installedExtensionsToUpdate.forEach { (foundExtension, extensionRecord) ->
@@ -162,6 +182,7 @@ object ExtensionsList {
                             }.toExecutable()
                             .execute(this@transaction)
                     }
+
                     val extensionsToFullyUpdate = extensionsInstalled[false].orEmpty()
                     if (extensionsToFullyUpdate.isNotEmpty()) {
                         BatchUpdateStatement(ExtensionTable)
@@ -184,6 +205,7 @@ object ExtensionsList {
                             .execute(this@transaction)
                     }
                 }
+
                 if (extensionsToInsert.isNotEmpty()) {
                     ExtensionTable.batchInsert(extensionsToInsert) { foundExtension ->
                         this[ExtensionTable.storeIndexUrl] = foundExtension.storeIndexUrl
@@ -205,6 +227,7 @@ object ExtensionsList {
                     extensionsToDelete
                         .groupBy { it[ExtensionTable.isInstalled] }
                         .mapValues { (_, extensions) -> extensions.map { it[ExtensionTable.pkgName] } }
+
                 // not in the repo, so these extensions are obsolete
                 val obsoleteExtensions = extensionsToRemove[true].orEmpty()
                 if (obsoleteExtensions.isNotEmpty()) {
@@ -212,6 +235,7 @@ object ExtensionsList {
                         it[isObsolete] = true
                     }
                 }
+
                 // is not installed, so we can remove the record without a care
                 val removeExtensions = extensionsToRemove[false].orEmpty()
                 if (removeExtensions.isNotEmpty()) {


### PR DESCRIPTION
Due to an extension store fixing a version code mismatch, some extensions are now incorrectly marked as updatable. However, these are still pointing to the same version already installed. This makes updating them impossible. The only solution to fix this manually is reinstalling the extension.

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
