### PR TITLE
Ignore extension file deletion issues during installation/update

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/extension/Extension.kt
@@ -7,6 +7,8 @@ package suwayomi.tachidesk.manga.impl.extension
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import android.app.Application
+import android.content.Context
 import android.content.pm.PackageInfo
 import android.net.Uri
 import eu.kanade.tachiyomi.network.GET
@@ -44,7 +46,6 @@ import suwayomi.tachidesk.manga.impl.util.PackageTools.METADATA_NSFW
 import suwayomi.tachidesk.manga.impl.util.PackageTools.METADATA_SOURCE_CLASS
 import suwayomi.tachidesk.manga.impl.util.PackageTools.dex2jar
 import suwayomi.tachidesk.manga.impl.util.PackageTools.getPackageInfo
-import suwayomi.tachidesk.manga.impl.util.PackageTools.loadExtensionSources
 import suwayomi.tachidesk.manga.impl.util.ResourceArscIconParser
 import suwayomi.tachidesk.manga.impl.util.network.await
 import suwayomi.tachidesk.manga.impl.util.source.GetSource
@@ -56,9 +57,12 @@ import suwayomi.tachidesk.manga.model.table.SourceTable
 import suwayomi.tachidesk.server.ApplicationDirs
 import suwayomi.tachidesk.server.database.dbSuspendTransaction
 import suwayomi.tachidesk.server.database.dbTransaction
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.io.InputStream
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -237,7 +241,14 @@ object Extension {
             override suspend fun prepareJarAndIcons(extensionsRoot: Path): Path {
                 val jarFile = extensionsRoot / (getApkName().substringBeforeLast(".") + ".jar")
 
-                jarFile.deleteIfExists()
+                try {
+                    jarFile.deleteIfExists()
+                } catch (_: Exception) {
+                    // This most likely means that the file could not get deleted during uninstallation on windows due
+                    // to its strict file locking for loaded jars.
+                    // We can just ignore it and reuse the existing jar since it's for the requested version anyway.
+                    return jarFile
+                }
 
                 ZipFile.builder().setPath(file).get().use { jarZip ->
                     try {
@@ -471,8 +482,10 @@ object Extension {
 
                     val removeOldJarFile = oldJarFile != null && !jarFile.isSameFileAs(oldJarFile)
                     if (removeOldJarFile) {
-                        oldJarFile.deleteExisting()
+                        tryToDeleteFile(oldJarFile)
                     }
+
+                    removeDeletionOnStartupRequest(jarFile)
                 } catch (e: Throwable) {
                     unload(apkName = apkName)
 
@@ -687,6 +700,36 @@ object Extension {
         }
     }
 
+    private val filesToDeleteOnStartup = ConcurrentHashMap.newKeySet<String>()
+    private val preferences = Injekt.get<Application>().getSharedPreferences(Extension.javaClass.name, Context.MODE_PRIVATE)
+    private const val FILES_TO_DELETE = "files_to_delete"
+
+    fun cleanupExtensionFiles() {
+        logger.debug { "Cleanup extension files that could not be deleted during extension update/deinstallation" }
+        val failedFileDeletions =
+            preferences
+                .getStringSet(FILES_TO_DELETE, emptySet())
+                ?.filterNot {
+                    runCatching { Path(it).deleteIfExists() }.getOrDefault(false)
+                }.orEmpty()
+        preferences.edit().putStringSet(FILES_TO_DELETE, failedFileDeletions.toSet()).apply()
+    }
+
+    private fun tryToDeleteFile(file: Path) {
+        try {
+            file.deleteIfExists()
+        } catch (e: Exception) {
+            logger.warn(e) { "Could not delete file $file, requesting deletion on startup" }
+            filesToDeleteOnStartup.add(file.toRealPath().absolutePathString())
+            preferences.edit().putStringSet(FILES_TO_DELETE, filesToDeleteOnStartup).apply()
+        }
+    }
+
+    private fun removeDeletionOnStartupRequest(file: Path) {
+        filesToDeleteOnStartup.remove(file.toRealPath().absolutePathString())
+        preferences.edit().putStringSet(FILES_TO_DELETE, filesToDeleteOnStartup).apply()
+    }
+
     fun uninstallExtension(pkgName: String) {
         logger.debug { "Uninstalling $pkgName" }
 
@@ -710,7 +753,7 @@ object Extension {
 
             unload(extensionRecord, sources)
 
-            getJarPath(extensionRecord).deleteIfExists()
+            tryToDeleteFile(getJarPath(extensionRecord))
         }
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/server/ServerSetup.kt
@@ -9,17 +9,12 @@ package suwayomi.tachidesk.server
 
 import android.os.Looper
 import ch.qos.logback.classic.Level
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigRenderOptions
-import com.typesafe.config.ConfigValue
-import com.typesafe.config.parser.ConfigDocument
 import dorkbox.updates.Updates
 import eu.kanade.tachiyomi.App
 import eu.kanade.tachiyomi.createAppModule
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.source.local.LocalSource
-import io.github.config4k.toConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.javalin.json.JavalinJackson3
 import io.javalin.json.JsonMapper
@@ -43,6 +38,7 @@ import suwayomi.tachidesk.graphql.types.DatabaseType
 import suwayomi.tachidesk.i18n.LocalizationHelper
 import suwayomi.tachidesk.manga.impl.backup.proto.ProtoBackupExport
 import suwayomi.tachidesk.manga.impl.download.DownloadManager
+import suwayomi.tachidesk.manga.impl.extension.Extension
 import suwayomi.tachidesk.manga.impl.extension.ExtensionStoreService
 import suwayomi.tachidesk.manga.impl.update.IUpdater
 import suwayomi.tachidesk.manga.impl.update.Updater
@@ -273,6 +269,9 @@ fun applicationSetup() {
     AndroidCompatInitializer().init()
     // start app
     androidCompat.startApp(app)
+
+    // Delete files before any extension-related logic can be executed that causes the jars to get loaded
+    Extension.cleanupExtensionFiles()
 
     // Initialize NetworkHelper early
     Injekt


### PR DESCRIPTION
When uninstalling/updating an extension, we unload the jar. However, there is no guarantee that the loaded jar gets fully unloaded. A jar that was not fully unloaded won't be able to be deleted on windows due to its strict file locking. On linux this is not an issue because it allows one to delete jars that are still loaded.

<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
