### PR TITLE
feat(sync): SyncYomi protocol v2 (server-side merge with deltas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased] (Preview)
 
 ### Added
+- (**SyncYomi**) Support sync protocol v2: the server merges, only changes since the last upload are sent and category deletions are reported explicitly
 - (**Downloads**) Try to preserve downloaded files during a chapter list update for chapters with title and/or scanlator change
 - (**Downloads/API**) Add batch GQL mutation for reordering chapter downloads (`reorderChapterDownloads`)
 - (**Logs**) Add IP location logging

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncDelta.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncDelta.kt
@@ -1,0 +1,16 @@
+package suwayomi.tachidesk.global.impl.sync
+
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupManga
+
+/**
+ * Keeps only manga (and their chapters) modified at or after the last successful upload, which
+ * is all a protocol v2 server needs. `last_modified_at` is in epoch seconds, set by the database
+ * triggers.
+ */
+internal fun changedSince(
+    mangas: List<BackupManga>,
+    since: Long,
+): List<BackupManga> =
+    mangas
+        .filter { it.lastModifiedAt >= since || it.chapters.any { c -> c.lastModifiedAt >= since } }
+        .onEach { manga -> manga.chapters = manga.chapters.filter { it.lastModifiedAt >= since } }

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncManager.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncManager.kt
@@ -57,6 +57,8 @@ data class SyncData(
 )
 
 object SyncManager {
+    private const val PREF_LAST_PUSHED_AT = "last_pushed_at"
+
     // bump to force one full converging sync after a change to how versions are maintained
     private const val PREF_SYNC_SCHEMA = "sync_schema"
     private const val SYNC_SCHEMA = 1
@@ -205,10 +207,11 @@ object SyncManager {
             _lastSyncState.value = SyncState.CreatingBackup(startInstant)
             val converge = syncPreferences.getInt(PREF_SYNC_SCHEMA, 0) < SYNC_SCHEMA
             val syncMode = if (converge) SyncRestoreMode.CONVERGE else SyncRestoreMode.ADOPT
+            val full = converge || SyncYomiSyncService.needsFullSync()
             if (converge) {
                 logger.info { "Full converging sync: adopting server versions" }
             }
-            val backupMangas = BackupMangaHandler.backup(backupFlags)
+            val backupMangas = BackupMangaHandler.backup(backupFlags).let { if (full) it else changedSince(it, lastPushedAt()) }
             val backupCategories =
                 BackupCategoryHandler.backup(backupFlags).filter { it.name != Category.DEFAULT_CATEGORY_NAME }
             toWireCategoryOrders(backupCategories, backupMangas)
@@ -226,10 +229,11 @@ object SyncManager {
                     backup = backup,
                 )
 
-            val remoteBackup =
-                SyncYomiSyncService.doSync(syncData, startInstant) {
+            val result =
+                SyncYomiSyncService.doSync(syncData, full, startInstant) {
                     _lastSyncState.value = it
                 }
+            val remoteBackup = result.backup
 
             if (remoteBackup == null) {
                 logger.debug { "Skip restore due to network issues" }
@@ -237,34 +241,35 @@ object SyncManager {
                 return
             }
 
-            if (remoteBackup === syncData.backup) {
-                // nothing changed
-                logger.debug { "Skip restore due to remote was overwrite from local" }
+            if (!result.changed) {
+                logger.debug { "Skip restore, nothing new on the server" }
                 markSyncSchema(converge)
-                finishWithSuccess(startInstant, periodic)
+                finishWithSuccess(startInstant, periodic, pushedAt = startInstant)
                 return
             }
 
-            // Stop the sync early if the remote backup is null or empty
-            if (remoteBackup.backupManga.isEmpty() && remoteBackup.backupCategories.isEmpty() && remoteBackup.backupSources.isEmpty()) {
-                logger.error { "No data found on remote server." }
-                finishWithError(startInstant, "No data found on remote server.", periodic)
-                return
-            }
-
-            val isLibraryEmpty =
-                transaction {
-                    MangaTable
-                        .selectAll()
-                        .where { MangaTable.inLibrary eq true }
-                        .empty()
+            if (!result.protocolV2) {
+                // Stop the sync early if the remote backup is null or empty
+                if (remoteBackup.backupManga.isEmpty() && remoteBackup.backupCategories.isEmpty() && remoteBackup.backupSources.isEmpty()) {
+                    logger.error { "No data found on remote server." }
+                    finishWithError(startInstant, "No data found on remote server.", periodic)
+                    return
                 }
 
-            // Check if it's first sync based on lastSyncTimestamp
-            if (syncPreferences.getLong("last_sync_timestamp", 0) == 0L && !isLibraryEmpty) {
-                // It's first sync no need to restore data. (just update remote data)
-                finishWithSuccess(startInstant, periodic)
-                return
+                val isLibraryEmpty =
+                    transaction {
+                        MangaTable
+                            .selectAll()
+                            .where { MangaTable.inLibrary eq true }
+                            .empty()
+                    }
+
+                // Check if it's first sync based on lastSyncTimestamp
+                if (syncPreferences.getLong("last_sync_timestamp", 0) == 0L && !isLibraryEmpty) {
+                    // It's first sync no need to restore data. (just update remote data)
+                    finishWithSuccess(startInstant, periodic, pushedAt = startInstant)
+                    return
+                }
             }
 
             val (filteredFavorites, nonFavorites) = filterFavoritesAndNonFavorites(remoteBackup, restoreAll = converge)
@@ -274,7 +279,8 @@ object SyncManager {
                 backup.copy(
                     backupManga = filteredFavorites,
                     backupCategories = remoteBackup.backupCategories,
-                    backupSources = remoteBackup.backupSources,
+                    // a v2 delta only carries changed sources
+                    backupSources = remoteBackup.backupSources.ifEmpty { backup.backupSources },
                 )
 
             val hasMangaChanges = filteredFavorites.isNotEmpty()
@@ -284,7 +290,7 @@ object SyncManager {
             if (!hasMangaChanges && !hasCategoryChanges && !hasSourceChanges) {
                 // update the sync timestamp
                 markSyncSchema(converge)
-                finishWithSuccess(startInstant, periodic)
+                finishWithSuccess(startInstant, periodic, pushedAt = startInstant)
                 return
             }
 
@@ -298,8 +304,7 @@ object SyncManager {
                     }
                 if (categoriesToDelete.isNotEmpty()) {
                     transaction {
-                        // the cascade delete of the category links and the sort_order renumbering
-                        // must not bump versions
+                        // the cascade delete of the category links must not bump the manga versions
                         val categoryIds = categoriesToDelete.map { it.id }
                         val mangaIds =
                             CategoryMangaTable
@@ -309,6 +314,7 @@ object SyncManager {
                         MangaTable.update({ MangaTable.id inList mangaIds }) {
                             it[isSyncing] = true
                         }
+                        // normalizeCategories rewrites sort_order; the survivors must not out-version the server
                         CategoryTable.update {
                             it[isSyncing] = true
                         }
@@ -340,7 +346,7 @@ object SyncManager {
             }
 
             // update the sync timestamp
-            finishWithSuccess(startInstant, periodic)
+            finishWithSuccess(startInstant, periodic, pushedAt = startInstant)
         } catch (e: Throwable) {
             logger.error { "Error syncing: ${e.message}" }
             finishWithError(startInstant, "${e::class.qualifiedName}: ${e.message}", periodic)
@@ -364,20 +370,18 @@ object SyncManager {
         }
     }
 
-    private fun markSyncSchema(converge: Boolean) {
-        if (converge) {
-            syncPreferences.edit().putInt(PREF_SYNC_SCHEMA, SYNC_SCHEMA).apply()
-        }
-    }
-
     private fun finishWithSuccess(
         startInstant: Instant,
         periodic: Boolean,
+        pushedAt: Instant? = null,
     ) {
         syncPreferences
             .edit()
             .putLong("last_sync_timestamp", Clock.System.now().toEpochMilliseconds())
-            .apply()
+            .apply {
+                // everything modified before this instant reached the server; the next delta starts here
+                if (pushedAt != null) putLong(PREF_LAST_PUSHED_AT, pushedAt.epochSeconds)
+            }.apply()
         _lastSyncState.value = SyncState.Success(startInstant)
 
         logger.info {
@@ -402,6 +406,14 @@ object SyncManager {
             } else {
                 "Manual sync failed: $message"
             }
+        }
+    }
+
+    private fun lastPushedAt(): Long = syncPreferences.getLong(PREF_LAST_PUSHED_AT, 0L)
+
+    private fun markSyncSchema(converge: Boolean) {
+        if (converge) {
+            syncPreferences.edit().putInt(PREF_SYNC_SCHEMA, SYNC_SCHEMA).apply()
         }
     }
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncYomiSyncService.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/global/impl/sync/SyncYomiSyncService.kt
@@ -26,6 +26,9 @@ import suwayomi.tachidesk.server.serverConfig
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import java.util.UUID
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
@@ -43,9 +46,26 @@ object SyncYomiSyncService {
     @Serializable
     private data class SyncEvent(
         val event: SyncEventStatus,
+        val device_id: String? = null,
         val device_Name: String? = null,
         val message: String? = null,
     )
+
+    data class SyncResult(
+        val backup: Backup?,
+        val changed: Boolean,
+        val protocolV2: Boolean,
+    )
+
+    private const val DEVICE_NAME = "Suwayomi Server"
+    private const val PREF_DEVICE_ID = "device_id"
+    private const val PREF_CURSOR = "sync_cursor"
+    private const val PREF_FULL_REQUESTED = "full_sync_requested"
+    private const val PREF_LAST_FULL_SYNC = "last_full_sync"
+    private const val PREF_PENDING_DELETED_CATEGORIES = "pending_deleted_category_uids"
+    private const val PREF_V2_PROBED_HOST = "v2_probed_host"
+    private const val PREF_V2_SUPPORTED = "server_supports_v2"
+    private val fullSyncInterval = 24.hours
 
     @Serializable
     private enum class SyncEventStatus {
@@ -58,39 +78,18 @@ object SyncYomiSyncService {
 
     suspend fun doSync(
         syncData: SyncData,
+        full: Boolean,
         startDate: Instant,
         setSyncState: (SyncManager.SyncState) -> Unit,
-    ): Backup? {
+    ): SyncResult {
         reportSyncEvent(SyncEventStatus.SYNC_STARTED)
-        setSyncState(SyncManager.SyncState.Downloading(startDate))
 
         return try {
-            val (remoteData, etag) = pullSyncData()
-
-            val finalSyncData =
-                if (remoteData != null) {
-                    require(etag.isNotEmpty()) { "ETag should never be empty if remote data is not null" }
-                    logger.debug { "Try update remote data with ETag($etag)" }
-                    setSyncState(SyncManager.SyncState.Merging(startDate))
-                    mergeSyncData(syncData, remoteData)
-                } else {
-                    // init or overwrite remote data
-                    logger.debug { "Try overwrite remote data with ETag($etag)" }
-                    syncData
-                }
-
-            if (finalSyncData.backup != null) {
-                setSyncState(SyncManager.SyncState.Uploading(startDate))
-            }
-
-            val success = pushSyncData(finalSyncData, etag)
-            if (success) {
-                reportSyncEvent(SyncEventStatus.SYNC_SUCCESS)
+            if (supportsV2()) {
+                doSyncV2(syncData, full, startDate, setSyncState)
             } else {
-                reportSyncEvent(SyncEventStatus.SYNC_FAILED, "Failed to push sync data")
+                doSyncV1(syncData, startDate, setSyncState)
             }
-
-            finalSyncData.backup
         } catch (e: Exception) {
             if (e is CancellationException) {
                 reportSyncEvent(SyncEventStatus.SYNC_CANCELLED, e.message)
@@ -102,12 +101,181 @@ object SyncYomiSyncService {
         }
     }
 
+    private suspend fun doSyncV1(
+        syncData: SyncData,
+        startDate: Instant,
+        setSyncState: (SyncManager.SyncState) -> Unit,
+    ): SyncResult {
+        setSyncState(SyncManager.SyncState.Downloading(startDate))
+        val (remoteData, etag) = pullSyncData()
+
+        val finalSyncData =
+            if (remoteData != null) {
+                require(etag.isNotEmpty()) { "ETag should never be empty if remote data is not null" }
+                logger.debug { "Try update remote data with ETag($etag)" }
+                setSyncState(SyncManager.SyncState.Merging(startDate))
+                mergeSyncData(syncData, remoteData)
+            } else {
+                // init or overwrite remote data
+                logger.debug { "Try overwrite remote data with ETag($etag)" }
+                syncData
+            }
+
+        if (finalSyncData.backup != null) {
+            setSyncState(SyncManager.SyncState.Uploading(startDate))
+        }
+
+        val success = pushSyncData(finalSyncData, etag)
+        if (success) {
+            reportSyncEvent(SyncEventStatus.SYNC_SUCCESS)
+        } else {
+            reportSyncEvent(SyncEventStatus.SYNC_FAILED, "Failed to push sync data")
+        }
+
+        return SyncResult(finalSyncData.backup, changed = remoteData != null, protocolV2 = false)
+    }
+
+    // Protocol v2: the server merges; we upload what changed and restore what comes back.
+    private suspend fun doSyncV2(
+        syncData: SyncData,
+        full: Boolean,
+        startDate: Instant,
+        setSyncState: (SyncManager.SyncState) -> Unit,
+    ): SyncResult {
+        val backup = syncData.backup ?: return SyncResult(null, changed = false, protocolV2 = true)
+        val host = serverConfig.syncYomiHost.value
+        val apiKey = serverConfig.syncYomiApiKey.value
+
+        val pendingDeleted = pendingDeletedCategories()
+        val headers =
+            baseHeaders(apiKey)
+                .add("X-Sync-Cursor", syncCursor().toString())
+                .add("X-Sync-Full", full.toString())
+        if (pendingDeleted.isNotEmpty()) {
+            headers.add("X-Sync-Deleted-Categories", pendingDeleted.joinToString(","))
+        }
+
+        setSyncState(SyncManager.SyncState.Uploading(startDate))
+        val body =
+            ProtoBuf
+                .encodeToByteArray(Backup.serializer(), backup)
+                .toRequestBody("application/octet-stream".toMediaType())
+        val response =
+            syncClient()
+                .newCall(POST(url = "$host/api/sync/v2/merge", headers = headers.build(), body = body))
+                .await()
+
+        if (!response.isSuccessful) {
+            val responseBody = response.body.string()
+            logger.error { "SyncError (${response.code}): $responseBody" }
+            reportSyncEvent(SyncEventStatus.SYNC_FAILED, "Server answered ${response.code}")
+            throw SyncYomiException("Failed to sync: ${response.code} $responseBody")
+        }
+
+        setSyncState(SyncManager.SyncState.Downloading(startDate))
+        val bytes = response.body.byteStream().use { it.readBytes() }
+        val remote =
+            try {
+                ProtoBuf.decodeFromByteArray(Backup.serializer(), bytes)
+            } catch (e: SerializationException) {
+                logger.error(e) { "Bad content responded from server" }
+                reportSyncEvent(SyncEventStatus.SYNC_FAILED, "Bad content responded from server")
+                throw SyncYomiException("Bad content responded from server: ${e.message}")
+            }
+        val cursor =
+            response.headers["X-Sync-Cursor"]?.toLongOrNull()
+                ?: throw SyncYomiException("Missing X-Sync-Cursor")
+        val changed = response.headers["X-Sync-Changed"]?.toBoolean() ?: true
+        val fullRequested = response.headers["X-Sync-Full-Requested"]?.toBoolean() ?: false
+
+        syncPreferences
+            .edit()
+            .putLong(PREF_CURSOR, cursor)
+            .putBoolean(PREF_FULL_REQUESTED, fullRequested)
+            .putStringSet(PREF_PENDING_DELETED_CATEGORIES, pendingDeletedCategories() - pendingDeleted)
+            .apply()
+        if (full) {
+            syncPreferences.edit().putLong(PREF_LAST_FULL_SYNC, startDate.toEpochMilliseconds()).apply()
+        }
+        logger.debug { "SyncYomi v2 merge done: cursor=$cursor changed=$changed fullRequested=$fullRequested" }
+
+        reportSyncEvent(SyncEventStatus.SYNC_SUCCESS)
+        return SyncResult(remote, changed = changed, protocolV2 = true)
+    }
+
+    // A full library is needed on the first sync, when the server asks for it, and once a day as a safety net.
+    suspend fun needsFullSync(): Boolean {
+        if (!supportsV2()) return true
+        if (syncCursor() == 0L || syncPreferences.getBoolean(PREF_FULL_REQUESTED, false)) return true
+        val lastFull = syncPreferences.getLong(PREF_LAST_FULL_SYNC, 0L)
+        return lastFull == 0L || Clock.System.now() - Instant.fromEpochMilliseconds(lastFull) > fullSyncInterval
+    }
+
+    suspend fun supportsV2(): Boolean {
+        val host = serverConfig.syncYomiHost.value
+        if (syncPreferences.getString(PREF_V2_PROBED_HOST, null) == host) {
+            return syncPreferences.getBoolean(PREF_V2_SUPPORTED, false)
+        }
+
+        val request = GET(url = "$host/api/sync/v2/capabilities", headers = baseHeaders(serverConfig.syncYomiApiKey.value).build())
+        val response = network.client.newCall(request).await()
+        response.close()
+        val supported =
+            when (response.code) {
+                HttpStatus.OK.code -> true
+                HttpStatus.NOT_FOUND.code -> false
+                else -> throw SyncYomiException("Failed to probe server capabilities: ${response.code}")
+            }
+        syncPreferences
+            .edit()
+            .putString(PREF_V2_PROBED_HOST, host)
+            .putBoolean(PREF_V2_SUPPORTED, supported)
+            .apply()
+        logger.info { "SyncYomi server supports protocol v2: $supported" }
+        return supported
+    }
+
+    fun syncCursor(): Long = syncPreferences.getLong(PREF_CURSOR, 0L)
+
+    fun deviceId(): String {
+        syncPreferences.getString(PREF_DEVICE_ID, null)?.let { return it }
+        val id = UUID.randomUUID().toString()
+        syncPreferences.edit().putString(PREF_DEVICE_ID, id).apply()
+        return id
+    }
+
+    fun rememberDeletedCategory(uid: Long) {
+        if (uid == 0L || !serverConfig.syncYomiEnabled.value) return
+        syncPreferences
+            .edit()
+            .putStringSet(PREF_PENDING_DELETED_CATEGORIES, pendingDeletedCategories() + uid.toString())
+            .apply()
+    }
+
+    private fun pendingDeletedCategories(): Set<String> =
+        syncPreferences.getStringSet(PREF_PENDING_DELETED_CATEGORIES, emptySet()).orEmpty().toSet()
+
+    private fun baseHeaders(apiKey: String): Headers.Builder =
+        Headers
+            .Builder()
+            .add("X-API-Token", apiKey)
+            .add("X-Device-ID", deviceId())
+            .add("X-Device-Name", DEVICE_NAME)
+
+    private fun syncClient() =
+        network.client
+            .newBuilder()
+            .connectTimeout(30.seconds)
+            .readTimeout(30.seconds)
+            .writeTimeout(30.seconds)
+            .build()
+
     private suspend fun pullSyncData(): Pair<SyncData?, String> {
         val host = serverConfig.syncYomiHost.value
         val apiKey = serverConfig.syncYomiApiKey.value
         val downloadUrl = "$host/api/sync/content"
 
-        val headersBuilder = Headers.Builder().add("X-API-Token", apiKey)
+        val headersBuilder = baseHeaders(apiKey)
         val lastETag = syncPreferences.getString("last_sync_etag", "") ?: ""
         if (lastETag != "") {
             headersBuilder.add("If-None-Match", lastETag)
@@ -168,21 +336,13 @@ object SyncYomiSyncService {
         val apiKey = serverConfig.syncYomiApiKey.value
         val uploadUrl = "$host/api/sync/content"
 
-        val headersBuilder = Headers.Builder().add("X-API-Token", apiKey)
+        val headersBuilder = baseHeaders(apiKey)
         if (eTag.isNotEmpty()) {
             headersBuilder.add("If-Match", eTag)
         }
         val headers = headersBuilder.build()
 
-        // Set timeout to 30 seconds
-        val timeout = 30.seconds
-        val client =
-            network.client
-                .newBuilder()
-                .connectTimeout(timeout)
-                .readTimeout(timeout)
-                .writeTimeout(timeout)
-                .build()
+        val client = syncClient()
 
         val byteArray = ProtoBuf.encodeToByteArray(Backup.serializer(), backup)
         if (byteArray.isEmpty()) {
@@ -229,13 +389,13 @@ object SyncYomiSyncService {
             val apiKey = serverConfig.syncYomiApiKey.value
             val url = "$host/api/sync/event"
 
-            val headers = Headers.Builder().add("X-API-Token", apiKey).build()
+            val headers = baseHeaders(apiKey).build()
 
-            // Use a fixed server name.
             val bodyObj =
                 SyncEvent(
                     event = event,
-                    device_Name = "Suwayomi Server",
+                    device_id = deviceId(),
+                    device_Name = DEVICE_NAME,
                     message = message,
                 )
 

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/mutations/CategoryMutation.kt
@@ -17,6 +17,7 @@ import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import suwayomi.tachidesk.global.impl.sync.SyncYomiSyncService
 import suwayomi.tachidesk.graphql.directives.RequireAuth
 import suwayomi.tachidesk.graphql.types.CategoryMetaType
 import suwayomi.tachidesk.graphql.types.CategoryType
@@ -457,6 +458,7 @@ class CategoryMutation {
                 CategoryTable.deleteWhere { CategoryTable.id eq categoryId }
 
                 Category.normalizeCategories()
+                category?.let { SyncYomiSyncService.rememberDeletedCategory(it[CategoryTable.uid]) }
 
                 if (category != null) {
                     CategoryType(category)

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/Category.kt
@@ -22,6 +22,7 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.statements.toExecutable
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import suwayomi.tachidesk.global.impl.sync.SyncYomiSyncService
 import suwayomi.tachidesk.manga.model.dataclass.CategoryDataClass
 import suwayomi.tachidesk.manga.model.table.CategoryMangaTable
 import suwayomi.tachidesk.manga.model.table.CategoryMetaTable
@@ -144,8 +145,17 @@ object Category {
     fun removeCategory(categoryId: Int) {
         if (categoryId == DEFAULT_CATEGORY_ID) return
         transaction {
+            val uid =
+                CategoryTable
+                    .selectAll()
+                    .where { CategoryTable.id eq categoryId }
+                    .firstOrNull()
+                    ?.get(CategoryTable.uid)
             CategoryTable.deleteWhere { CategoryTable.id eq categoryId }
             normalizeCategories()
+            if (uid != null) {
+                SyncYomiSyncService.rememberDeletedCategory(uid)
+            }
         }
     }
 

--- a/server/src/test/kotlin/suwayomi/tachidesk/global/impl/sync/SyncDeltaTest.kt
+++ b/server/src/test/kotlin/suwayomi/tachidesk/global/impl/sync/SyncDeltaTest.kt
@@ -1,0 +1,64 @@
+package suwayomi.tachidesk.global.impl.sync
+
+import kotlinx.serialization.protobuf.ProtoBuf
+import suwayomi.tachidesk.manga.impl.backup.proto.models.Backup
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupCategory
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupChapter
+import suwayomi.tachidesk.manga.impl.backup.proto.models.BackupManga
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncDeltaTest {
+    private fun manga(
+        url: String,
+        modifiedAt: Long,
+        vararg chapters: BackupChapter,
+    ) = BackupManga(source = 1, url = url, title = url, lastModifiedAt = modifiedAt, chapters = chapters.toList())
+
+    private fun chapter(
+        url: String,
+        modifiedAt: Long,
+    ) = BackupChapter(url = url, name = url, lastModifiedAt = modifiedAt)
+
+    @Test
+    fun keepsOnlyWhatChangedSinceTheLastUpload() {
+        val mangas =
+            listOf(
+                manga("/old", 10, chapter("/old/1", 10)),
+                manga("/touched", 50, chapter("/touched/1", 10), chapter("/touched/2", 50)),
+                manga("/chapter-only", 10, chapter("/chapter-only/1", 60)),
+                manga("/boundary", 40),
+            )
+
+        val delta = changedSince(mangas, since = 40)
+
+        assertEquals(listOf("/touched", "/chapter-only", "/boundary"), delta.map { it.url })
+        assertEquals(listOf("/touched/2"), delta[0].chapters.map { it.url })
+        assertEquals(listOf("/chapter-only/1"), delta[1].chapters.map { it.url })
+        assertTrue(delta[2].chapters.isEmpty())
+    }
+
+    @Test
+    fun everythingIsChangedSinceZero() {
+        val mangas = listOf(manga("/a", 0, chapter("/a/1", 0)), manga("/b", 5))
+        assertEquals(2, changedSince(mangas, since = 0).size)
+        assertEquals(1, changedSince(mangas, since = 0)[0].chapters.size)
+    }
+
+    // A v2 delta response can carry categories but no manga; that must decode as an empty list.
+    @Test
+    fun decodesResponseWithoutManga() {
+        val bytes =
+            ProtoBuf.encodeToByteArray(
+                Backup.serializer(),
+                Backup(backupCategories = listOf(BackupCategory(name = "Reading", uid = 7))),
+            )
+        val decoded = ProtoBuf.decodeFromByteArray(Backup.serializer(), bytes)
+        assertTrue(decoded.backupManga.isEmpty())
+        assertEquals("Reading", decoded.backupCategories.single().name)
+
+        val empty = ProtoBuf.decodeFromByteArray(Backup.serializer(), ByteArray(0))
+        assertTrue(empty.backupManga.isEmpty())
+    }
+}


### PR DESCRIPTION
Adds SyncYomi protocol v2. When the server offers `/api/sync/v2`, it does the merging: the client uploads only manga/chapters modified since the last successful upload and restores the delta that comes back, instead of downloading and re-merging the whole library on every sync. v1 is kept unchanged for servers that answer 404 on the capabilities probe.

- Probe `/api/sync/v2/capabilities` once per host and pick the flow from that.
- Send the full library on the first sync, when the server asks, and once a day as a safety net.
- Stable device id on every request and sync event so the server can hand out per-device deltas.
- v2 never infers a delete from absence, so deleted category uids are remembered and sent in `X-Sync-Deleted-Categories`.
- A malformed v2 response is reported as a sync error instead of being treated as data.

Builds on #2310, #2311 and #2312. Server side: https://github.com/SyncYomi/SyncYomi
