### PR TITLE
Add missing impl for `android.text.Spanned android.text.Html.fromHtml(java.lang.String, int)`

### DIFF
--- a/AndroidCompat/src/main/java/android/text/Html.java
+++ b/AndroidCompat/src/main/java/android/text/Html.java
@@ -17,7 +17,13 @@ import org.xml.sax.XMLReader;
 
 public class Html {
 
+    public static final int FROM_HTML_MODE_LEGACY = 0x00000000;
+
     public static Spanned fromHtml(String source) {
+        return fromHtml(source, FROM_HTML_MODE_LEGACY);
+    }
+
+    public static Spanned fromHtml(String source, int flags) {
         return new FakeSpanned(Jsoup.clean(source, Safelist.none()));
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**WebView**) Fix `kcef` causing the server startup to fail
 - (**Category**) Fix library/category counts not matching the actual number of manga due to duplicate category-manga rows
 - (**Migration/Extension**) Fix `extensionRepos` setting not being migrated to `extensionStores`
+- (**Extension**) Fixes author's notes not working in sources that offer them
 
 ## [v2.3.2243] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**WebView**) Fix `kcef` causing the server startup to fail
 - (**Category**) Fix library/category counts not matching the actual number of manga due to duplicate category-manga rows
 - (**Migration/Extension**) Fix `extensionRepos` setting not being migrated to `extensionStores`
-- (**Extension**) Fixes author's notes not working in sources that offer them
+- (**Extension/Android**) Implement fromHtml with flags for author's note support
 
 ## [v2.3.2243] - 2026-07-13
 


### PR DESCRIPTION
<!--
Pull Request Checklist:
- [✓] Mention what the pull request does and the reasons behind the changes
- [✓] Mention all issues the pull request is closing
- [x] Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->
Fixes author's notes not working in sources that offer them.

Tested working:
<img width="1243" height="1220" alt="image" src="https://github.com/user-attachments/assets/16681552-a98b-49bb-a456-8087fc91301c" />

Fixes #2263 

(Would you like me to add this to the changelog, or nah?)