### PR TITLE
Add `isDefaultCategory` in preparation of User Accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - (**Logs**) Add IP location logging
 - (**Cache/API**) Add a way to clear cache & cookies
 - (**API**) Add platform information to `aboutServer` query
+- (**Category/API**) Add `isDefaultCategory` in preparation of incompatible changes of future versions
 
 ### Changed
 - (**SystemTray**) Disable DorkBox update requests

--- a/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/graphql/types/CategoryType.kt
@@ -27,6 +27,7 @@ class CategoryType(
     val default: Boolean,
     val includeInUpdate: IncludeOrExclude,
     val includeInDownload: IncludeOrExclude,
+    val isDefaultCategory: Boolean = id == 0,
 ) : Node {
     constructor(row: ResultRow) : this(
         row[CategoryTable.id].value,


### PR DESCRIPTION
<!--
Pull Request Checklist:
- Mention what the pull request does and the reasons behind the changes
- Mention all issues the pull request is closing
- Make sure to update the CHANGELOG accordingly if necessary based on the LAST stable release
-->

This is needed for clients that need to be updated to properly get the default category, but don't want to break compatibility with Stable versions